### PR TITLE
Stage 2b — shared GPU optimizations (consolidated dedup)

### DIFF
--- a/benchmark/PERF_LOG.md
+++ b/benchmark/PERF_LOG.md
@@ -49,3 +49,35 @@ Eliashberg gaps were previously validated CPU-vs-GPU to 1e-5 meV. The in-repo lo
 (`check_eph_batched`, identical fixed eigenvectors on both backends) matches to 1e-9. The
 bench's element-wise `g2` comparison is simply not a valid check across two eigensolvers for a
 degenerate system.
+
+---
+
+## 2026-07-11 — `71f90e0` (gpu-2b-shared-opts, Stage 2b: 3 consolidated GPU opts)
+
+**Hardware:** NVIDIA RTX A6000 (48 GB), host `ccqlin059`.
+**Software:** Julia 1.11.7, CUDA.jl functional. GPU tests: 81/81 green.
+
+Stage 2b adds three GPU optimizations on top of Stage 2a: fused e-ph rotation kernel
+parallelized over (band, band, q); k-side window projection of the batched interpolation
+(the k side carries only `nbk_max` in-window bands, not all `nw`); and `@inbounds` on the
+per-batch device iq gathers.
+
+**End-to-end e-ph loop** (`bench_eliashberg_loop_gpu.jl`, EliashbergCalculator, window E_F±0.3 eV):
+
+| grid | n_i | CPU | GPU | speedup |
+|-|-|-|-|-|
+| 16³ | 432  | 0.58 s | 0.55 s | 1.05× |
+| 24³ | 1716 | 7.12 s | 2.94 s | 2.42× |
+| 32³ | 4052 | 41.1 s | 8.83 s | 4.66× |
+
+**No GPU regression — the reliable 32³ GPU signal improved 11.2 s → 8.83 s (1.27×) vs the Stage 1
+baseline row above.** The 24³ GPU also improved (3.55 → 2.94 s). The window-projection win is
+modest here because Pb has `nw = 4` (little to project away); the large speedups it targets
+(2.9–4.9× measured in EP `15d2570` on TaAs `nw = 32`, ±0.1 eV) need a wide-band, narrow-window
+system. The **CPU** times dropped vs the baseline row too (e.g. 78.8 → 41.1 s at 32³), which
+reflects the current MigdalEliashberg working-tree state rather than a GPU change — so the
+cross-row *speedup ratio* is not directly comparable; trend the GPU wall-time column instead.
+
+`relerr(g2)=0.76` / `ωq=false`: same degenerate-gauge artifact documented in the Stage 1 entry
+above (two eigensolvers pick different gauges for Pb's degenerate bands), not a correctness
+regression — the 81/81 GPU tests use gauge-invariant / fixed-eigenvector checks.

--- a/ext/ElectronPhononCUDAExt.jl
+++ b/ext/ElectronPhononCUDAExt.jl
@@ -125,11 +125,20 @@ const _FUSED_ROT_MAX_NWNM = 24
 
 # g : (nw, nbandk, nmodes, nq) ; ukq : (nw, nbandkq, nq) ; uph : (nmodes, nmodes, nq)
 # ep : (nbandkq, nbandk, nmodes, nq) ; g2 / ωq optional (g2 : same as ep ; ωq : (nmodes, nq)).
+# One thread per (ibkq, ibk, q) — NOT per q: a per-q thread leaves the GPU idle at production
+# chunk sizes (nq ~ 2·10³–2·10⁴ threads is a handful of blocks on ~100 SMs; the (band², q) grid
+# is nbandkq·nbandk× larger). The scalar accumulation below is the previous per-q kernel body
+# verbatim (with the ibk/ibkq loops hoisted into the thread index), so results are bit-identical;
+# the redundant per-im re-read of g/ukq is L1-served (the kernel is occupancy-, not flop-bound).
 function _fused_eph_rot_kernel!(ep, g2, g, ukq, uph, ωq, nw, nbkq, nbk, nm, nq)
-    q = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    q <= nq || return
-    @inbounds for ibk in 1:nbk, im in 1:nm
-        for ibkq in 1:nbkq
+    t = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    t <= nbkq * nbk * nq || return
+    @inbounds begin
+        ibkq = (t - 1) % nbkq + 1
+        r = (t - 1) ÷ nbkq
+        ibk = r % nbk + 1
+        q = r ÷ nbk + 1
+        for im in 1:nm
             acc = zero(eltype(ep))
             for jm in 1:nm
                 tval = zero(eltype(ep))
@@ -157,8 +166,8 @@ function ElectronPhonon.eph_apply_rotations!(ep_kq_all::DenseCuArray{Complex{T},
     nw = size(ukqs, 1)
     if nw * nmodes <= _FUSED_ROT_MAX_NWNM
         g4 = reshape(g, nw, nbandk, nmodes, nq)
-        threads = 128
-        blocks = cld(nq, threads)
+        threads = 256
+        blocks = cld(nbandkq * nbandk * nq, threads)
         @cuda threads=threads blocks=blocks _fused_eph_rot_kernel!(
             ep_kq_all, g2_out, g4, ukqs, u_phs, ωq, nw, nbandkq, nbandk, nmodes, nq)
     else

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -78,9 +78,10 @@ Keyword arguments:
 - `g2`   :: same shape as `ep_kq` — the loop passes `g2 = |ep|²/(2ω)` already formed (the GPU path
   folds it into the rotation kernel for free), so a calculator that needs `g2` should use this
   rather than recomputing it from `ep_kq`.
-- `ibandk_offset` :: k-side window-projection band offset — `ep_kq`'s band-of-k axis `n` corresponds to
-  PHYSICAL band `ibandk_offset + n` (the loop rotates only an `nbandk`-wide contiguous eigenvector window
-  around the in-window bands; 0 for full-band runs).
+- `ibandk_offset` :: k-side window-projection band offset, **0-based** — `ep_kq`'s band-of-k axis `n`
+  (1-based, `1:nbandk`) corresponds to PHYSICAL band `ibandk_offset + n` (so `n = 1` is physical band
+  `ibandk_offset + 1`). The loop rotates only an `nbandk`-wide contiguous eigenvector window around the
+  in-window bands; `ibandk_offset = 0` for full-band runs (then physical band `= n`).
 
 Runs on the backend of `ep_kq` (CPU or GPU); implementations should stay backend-generic
 (`similar`, `copyto!`, broadcasting, scatter assignment) so no CUDA dependency leaks into the

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -62,7 +62,7 @@ opts out, so calculators keep using the host `run_calculator!` path.
 allow_eph_batched(::AbstractCalculator) = false
 
 """
-    run_calculator_batched!(calc, ep_kq, ωq, ik, ikqs; kwargs...)
+    run_calculator_batched!(calc, ep_kq, ωq, ik, ikqs; g2=nothing, nbk0=0, kwargs...)
 
 Batched hook invoked by `run_eph_over_k_and_kq` when `use_gpu = true`. That loop is an outer-k
 loop with the inner k+q points batched, so this is called once per outer k-point `ik` with all
@@ -74,10 +74,13 @@ the e-ph matrix for the list of k+q points:
 - `ikqs`  :: the `nq` k+q point indices of this batch (so the calculator can address its inner
   states).
 
-Keyword argument:
-- `g2` :: same shape as `ep_kq` — the loop passes `g2 = |ep|²/(2ω)` already formed (the GPU path
+Keyword arguments:
+- `g2`   :: same shape as `ep_kq` — the loop passes `g2 = |ep|²/(2ω)` already formed (the GPU path
   folds it into the rotation kernel for free), so a calculator that needs `g2` should use this
   rather than recomputing it from `ep_kq`.
+- `nbk0` :: k-side window-projection band offset — `ep_kq`'s band-of-k axis `n` corresponds to
+  PHYSICAL band `nbk0 + n` (the loop rotates only an `nbandk`-wide contiguous eigenvector window
+  around the in-window bands; 0 for full-band runs).
 
 Runs on the backend of `ep_kq` (CPU or GPU); implementations should stay backend-generic
 (`similar`, `copyto!`, broadcasting, scatter assignment) so no CUDA dependency leaks into the

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -62,7 +62,7 @@ opts out, so calculators keep using the host `run_calculator!` path.
 allow_eph_batched(::AbstractCalculator) = false
 
 """
-    run_calculator_batched!(calc, ep_kq, ωq, ik, ikqs; g2=nothing, nbk0=0, kwargs...)
+    run_calculator_batched!(calc, ep_kq, ωq, ik, ikqs; g2=nothing, ibandk_offset=0, kwargs...)
 
 Batched hook invoked by `run_eph_over_k_and_kq` when `use_gpu = true`. That loop is an outer-k
 loop with the inner k+q points batched, so this is called once per outer k-point `ik` with all
@@ -78,8 +78,8 @@ Keyword arguments:
 - `g2`   :: same shape as `ep_kq` — the loop passes `g2 = |ep|²/(2ω)` already formed (the GPU path
   folds it into the rotation kernel for free), so a calculator that needs `g2` should use this
   rather than recomputing it from `ep_kq`.
-- `nbk0` :: k-side window-projection band offset — `ep_kq`'s band-of-k axis `n` corresponds to
-  PHYSICAL band `nbk0 + n` (the loop rotates only an `nbandk`-wide contiguous eigenvector window
+- `ibandk_offset` :: k-side window-projection band offset — `ep_kq`'s band-of-k axis `n` corresponds to
+  PHYSICAL band `ibandk_offset + n` (the loop rotates only an `nbandk`-wide contiguous eigenvector window
   around the in-window bands; 0 for full-band runs).
 
 Runs on the backend of `ep_kq` (CPU or GPU); implementations should stay backend-generic

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -719,9 +719,12 @@ function _loop_eph_over_k_and_kq_gpu(
             # H2D copy of just the first nq_batch indices (5-arg contiguous copy — copying a host↔
             # device SubArray view instead would fall back to scalar indexing); the device gather
             # then reads only `view(iqs_batch_dev, rng_q)`, so the untouched tail is never used.
+            # `@inbounds`: bounds-checking a device INDEX ARRAY costs a Bool map+reduce kernel and
+            # a D2H round trip of the result per (k, batch); `iq` is already validated on the host
+            # (the guard above), so the device-side re-check is pure overhead.
             copyto!(iqs_batch_dev, 1, iqs_batch, 1, nq_batch)
-            @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, view(iqs_batch_dev, rng_q)]
-            @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, view(iqs_batch_dev, rng_q)]
+            @inbounds @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, view(iqs_batch_dev, rng_q)]
+            @inbounds @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, view(iqs_batch_dev, rng_q)]
             # k+q rotations: a contiguous slice of the prebuilt device stack (no copy).
             ukqs_used = view(ukqs_all_dev, :, :, qstart:qend)
 

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -545,6 +545,10 @@ function _loop_eph_over_k_and_kq_gpu(
     # window scatter to imap == 0 and are skipped exactly as before; the calculators only need the
     # per-k physical-band offset `ibandk_offset` to address their imaps. Full-band runs have
     # nbandk_max = nw, ibandk_offset = 0 — the path (shapes, GEMMs, results) is unchanged.
+    # ibandk_offsets[ik]: 0-based window start = (first in-window band − 1), clamped so the
+    # nbandk_max-wide window [offset+1, offset+nbandk_max] stays within [1, nw]. The clamp only
+    # bites when a k's bands sit near the top edge: e.g. nw=4, nbandk_max=3, rng=3:4 → first−1=2
+    # exceeds nw−nbandk_max=1, so offset=1 (window 2:4 ⊇ 3:4); offset=2 would give 3:5, off the top.
     nbandk_max = fullband ? nw : max(maximum(el -> el.nband, el_k_save; init = 1), 1)
     ibandk_offsets = fullband ? zeros(Int, nk) :
         [clamp(first(el.rng) - 1, 0, nw - nbandk_max) for el in el_k_save]

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -537,25 +537,25 @@ function _loop_eph_over_k_and_kq_gpu(
 
     # ----- k-side window projection -----
     # The OUTER-k side does NOT need all nw bands: the calculator scatter keeps only in-window
-    # (band, k) pairs, so rotate the k side by only an `nbk_max`-wide CONTIGUOUS window of
-    # eigenvector columns per k (`u_full[:, nb0+1 : nb0+nbk_max]`, positioned to contain that k's
+    # (band, k) pairs, so rotate the k side by only an `nbandk_max`-wide CONTIGUOUS window of
+    # eigenvector columns per k (`u_full[:, nb0+1 : nb0+nbandk_max]`, positioned to contain that k's
     # in-window range `rng`). Every downstream per-(k,q) object — the kR→kq GEMM, both gauge
-    # rotations, g2, and the scatter — shrinks by nw/nbk_max, the dominant ∝ nk·nq cost at narrow
-    # windows (e.g. TaAs ±0.1 eV: nbk_max ≈ 4 of nw = 32). Out-of-window bands inside the projected
+    # rotations, g2, and the scatter — shrinks by nw/nbandk_max, the dominant ∝ nk·nq cost at narrow
+    # windows (e.g. TaAs ±0.1 eV: nbandk_max ≈ 4 of nw = 32). Out-of-window bands inside the projected
     # window scatter to imap == 0 and are skipped exactly as before; the calculators only need the
-    # per-k physical-band offset `nbk0` to address their imaps. Full-band runs have
-    # nbk_max = nw, nbk0 = 0 — the path (shapes, GEMMs, results) is unchanged.
-    nbk_max = fullband ? nw : max(maximum(el -> el.nband, el_k_save; init = 1), 1)
-    kband0 = fullband ? zeros(Int, nk) :
-        [clamp(first(el.rng) - 1, 0, nw - nbk_max) for el in el_k_save]
+    # per-k physical-band offset `ibandk_offset` to address their imaps. Full-band runs have
+    # nbandk_max = nw, ibandk_offset = 0 — the path (shapes, GEMMs, results) is unchanged.
+    nbandk_max = fullband ? nw : max(maximum(el -> el.nband, el_k_save; init = 1), 1)
+    ibandk_offsets = fullband ? zeros(Int, nk) :
+        [clamp(first(el.rng) - 1, 0, nw - nbandk_max) for el in el_k_save]
 
     # ----- device interpolators (allocated once) -----
     epmat_dev = to_device(model.epmat)
     epmat_itp = BatchedWannierInterpolator(epmat_dev; batch_size = nk_batch_max)
     ep_ekpR_dev = to_device(get_next_wannier_object(model.epmat))
-    ndata_ekpR = nw * nbk_max * nmodes
+    ndata_ekpR = nw * nbandk_max * nmodes
     # Set ndata BEFORE building the interpolator (its Fourier cache is sized to parent.ndata):
-    # under the k-side projection only the first nw·nbk_max·nmodes rows of op_r are filled/read.
+    # under the k-side projection only the first nw·nbandk_max·nmodes rows of op_r are filled/read.
     ep_ekpR_dev.ndata = ndata_ekpR
     ep_ekpR_itp = BatchedWannierInterpolator(ep_ekpR_dev; batch_size = nq_batch_max)
     nr_ep = ep_ekpR_dev.nr
@@ -567,18 +567,18 @@ function _loop_eph_over_k_and_kq_gpu(
     # RR->kR over a batch of `nk_batch_max` outer-k at once: one batched kernel per batch instead of one
     # launch-bound single-k call per k. `ep_ekpR_all` holds g(k, R_ep) for the whole batch; each
     # k's slice is then copied into `ep_ekpR_dev` (device→device) for the inner kR->kq driver.
-    uks_dev     = similar(epmat_dev.op_r, Complex{FT}, nw, nbk_max, nk_batch_max)
-    uks_host    = Array{Complex{FT}}(undef, nw, nbk_max, nk_batch_max)
+    uks_dev     = similar(epmat_dev.op_r, Complex{FT}, nw, nbandk_max, nk_batch_max)
+    uks_host    = Array{Complex{FT}}(undef, nw, nbandk_max, nk_batch_max)
     ep_ekpR_all = similar(epmat_dev.op_r, Complex{FT}, ndata_ekpR, nr_ep, nk_batch_max)
     ks_batch     = Vector{Vec3{FT}}(undef, nk_batch_max)
 
     uphs_dev = similar(epmat_dev.op_r, Complex{FT}, nmodes, nmodes, nq_batch_max)
-    epkq_dev = similar(epmat_dev.op_r, Complex{FT}, nw, nbk_max, nmodes, nq_batch_max)
+    epkq_dev = similar(epmat_dev.op_r, Complex{FT}, nw, nbandk_max, nmodes, nq_batch_max)
 
     # In-place scratch for the per-k kR->kq driver (g / tmp), reused across all (k, q) so the
     # driver allocates nothing per call. Sized for the max batch width `nq_batch_max`; the driver
     # uses the first `nq_batch` columns for a partial final batch.
-    kRkq_ws = KRtoKQWorkspace(ep_ekpR_dev.op_r, ndata_ekpR, nw, nbk_max, nmodes, nq_batch_max)
+    kRkq_ws = KRtoKQWorkspace(ep_ekpR_dev.op_r, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max)
 
     # Collect the k+q electron eigenvectors on the host and copy to the device once (they do not
     # depend on the outer k), reused across all k. Each q-batch reads a contiguous slice directly.
@@ -634,7 +634,7 @@ function _loop_eph_over_k_and_kq_gpu(
     ikqs_host = Vector{Int}(undef, nq_batch_max)
     ωq_dev    = similar(epmat_dev.op_r, FT, nmodes, nq_batch_max)
     ikqs_dev  = similar(epmat_dev.op_r, Int, nq_batch_max)
-    g2_dev    = similar(epmat_dev.op_r, FT, nw, nbk_max, nmodes, nq_batch_max)
+    g2_dev    = similar(epmat_dev.op_r, FT, nw, nbandk_max, nmodes, nq_batch_max)
 
     epdata = take!(epdatas)
 
@@ -646,11 +646,11 @@ function _loop_eph_over_k_and_kq_gpu(
         # Stack U(k) and the k list for this outer-k batch (pad the partial tail with valid
         # duplicated data so the batched RR->kR runs on dense `nk_batch_max`-sized arrays).
         for (ik_ind, ik) in enumerate(iks_batch)
-            # k-side window projection: the `nbk_max` contiguous eigenvector columns around this
+            # k-side window projection: the `nbandk_max` contiguous eigenvector columns around this
             # k's in-window range (all nw columns when full-band). The window selection itself
-            # still happens in the calculator scatter (imap == 0 outside), offset by kband0[ik].
-            nb0 = kband0[ik]
-            @views uks_host[:, :, ik_ind] .= el_k_save[ik].u_full[:, nb0+1:nb0+nbk_max]
+            # still happens in the calculator scatter (imap == 0 outside), offset by ibandk_offsets[ik].
+            nb0 = ibandk_offsets[ik]
+            @views uks_host[:, :, ik_ind] .= el_k_save[ik].u_full[:, nb0+1:nb0+nbandk_max]
             ks_batch[ik_ind] = kpts.vectors[ik]
         end
         for ik_ind in (nk_batch+1):nk_batch_max
@@ -742,7 +742,7 @@ function _loop_eph_over_k_and_kq_gpu(
                 run_calculator_batched!(calc,
                     view(epkq_dev, :, :, :, rng_q), view(ωq_dev, :, rng_q),
                     ik, view(ikqs_dev, rng_q); g2 = view(g2_dev, :, :, :, rng_q),
-                    nbk0 = kband0[ik])
+                    ibandk_offset = ibandk_offsets[ik])
             end
 
             qstart = qend + 1

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -530,16 +530,34 @@ function _loop_eph_over_k_and_kq_gpu(
         "use_gpu requires every calculator to implement the batched device hook " *
         "(allow_eph_batched = true); the GPU path does not fall back to the host run_calculator! loop."))
 
-    # The interpolation always runs full-band (uniform nw×nw, using the full eigenvectors
+    # The k+q side of the interpolation runs full-band (uniform nw×nw, using the full eigenvectors
     # `el.u_full`); the energy window is applied in the calculator scatter, where out-of-window
-    # states have imap == 0 and are skipped, so a windowed run needs no special handling here.
+    # states have imap == 0 and are skipped, so a windowed run needs no special handling there.
+    fullband = all(el.nband == nw for el in el_k_save) && all(el.nband == nw for el in el_kq_save)
+
+    # ----- k-side window projection -----
+    # The OUTER-k side does NOT need all nw bands: the calculator scatter keeps only in-window
+    # (band, k) pairs, so rotate the k side by only an `nbk_max`-wide CONTIGUOUS window of
+    # eigenvector columns per k (`u_full[:, nb0+1 : nb0+nbk_max]`, positioned to contain that k's
+    # in-window range `rng`). Every downstream per-(k,q) object — the kR→kq GEMM, both gauge
+    # rotations, g2, and the scatter — shrinks by nw/nbk_max, the dominant ∝ nk·nq cost at narrow
+    # windows (e.g. TaAs ±0.1 eV: nbk_max ≈ 4 of nw = 32). Out-of-window bands inside the projected
+    # window scatter to imap == 0 and are skipped exactly as before; the calculators only need the
+    # per-k physical-band offset `nbk0` to address their imaps. Full-band runs have
+    # nbk_max = nw, nbk0 = 0 — the path (shapes, GEMMs, results) is unchanged.
+    nbk_max = fullband ? nw : max(maximum(el -> el.nband, el_k_save; init = 1), 1)
+    kband0 = fullband ? zeros(Int, nk) :
+        [clamp(first(el.rng) - 1, 0, nw - nbk_max) for el in el_k_save]
 
     # ----- device interpolators (allocated once) -----
     epmat_dev = to_device(model.epmat)
     epmat_itp = BatchedWannierInterpolator(epmat_dev; batch_size = nk_batch_max)
     ep_ekpR_dev = to_device(get_next_wannier_object(model.epmat))
+    ndata_ekpR = nw * nbk_max * nmodes
+    # Set ndata BEFORE building the interpolator (its Fourier cache is sized to parent.ndata):
+    # under the k-side projection only the first nw·nbk_max·nmodes rows of op_r are filled/read.
+    ep_ekpR_dev.ndata = ndata_ekpR
     ep_ekpR_itp = BatchedWannierInterpolator(ep_ekpR_dev; batch_size = nq_batch_max)
-    ndata_ekpR = nw * nw * nmodes
     nr_ep = ep_ekpR_dev.nr
 
     # ----- persistent workspace (allocated once, reused across all (k, q)) -----
@@ -549,18 +567,18 @@ function _loop_eph_over_k_and_kq_gpu(
     # RR->kR over a batch of `nk_batch_max` outer-k at once: one batched kernel per batch instead of one
     # launch-bound single-k call per k. `ep_ekpR_all` holds g(k, R_ep) for the whole batch; each
     # k's slice is then copied into `ep_ekpR_dev` (device→device) for the inner kR->kq driver.
-    uks_dev     = similar(epmat_dev.op_r, Complex{FT}, nw, nw, nk_batch_max)
-    uks_host    = Array{Complex{FT}}(undef, nw, nw, nk_batch_max)
+    uks_dev     = similar(epmat_dev.op_r, Complex{FT}, nw, nbk_max, nk_batch_max)
+    uks_host    = Array{Complex{FT}}(undef, nw, nbk_max, nk_batch_max)
     ep_ekpR_all = similar(epmat_dev.op_r, Complex{FT}, ndata_ekpR, nr_ep, nk_batch_max)
     ks_batch     = Vector{Vec3{FT}}(undef, nk_batch_max)
 
     uphs_dev = similar(epmat_dev.op_r, Complex{FT}, nmodes, nmodes, nq_batch_max)
-    epkq_dev = similar(epmat_dev.op_r, Complex{FT}, nw, nw, nmodes, nq_batch_max)
+    epkq_dev = similar(epmat_dev.op_r, Complex{FT}, nw, nbk_max, nmodes, nq_batch_max)
 
     # In-place scratch for the per-k kR->kq driver (g / tmp), reused across all (k, q) so the
     # driver allocates nothing per call. Sized for the max batch width `nq_batch_max`; the driver
     # uses the first `nq_batch` columns for a partial final batch.
-    kRkq_ws = KRtoKQWorkspace(ep_ekpR_dev.op_r, ndata_ekpR, nw, nw, nmodes, nq_batch_max)
+    kRkq_ws = KRtoKQWorkspace(ep_ekpR_dev.op_r, ndata_ekpR, nw, nbk_max, nmodes, nq_batch_max)
 
     # Collect the k+q electron eigenvectors on the host and copy to the device once (they do not
     # depend on the outer k), reused across all k. Each q-batch reads a contiguous slice directly.
@@ -616,7 +634,7 @@ function _loop_eph_over_k_and_kq_gpu(
     ikqs_host = Vector{Int}(undef, nq_batch_max)
     ωq_dev    = similar(epmat_dev.op_r, FT, nmodes, nq_batch_max)
     ikqs_dev  = similar(epmat_dev.op_r, Int, nq_batch_max)
-    g2_dev    = similar(epmat_dev.op_r, FT, nw, nw, nmodes, nq_batch_max)
+    g2_dev    = similar(epmat_dev.op_r, FT, nw, nbk_max, nmodes, nq_batch_max)
 
     epdata = take!(epdatas)
 
@@ -628,9 +646,11 @@ function _loop_eph_over_k_and_kq_gpu(
         # Stack U(k) and the k list for this outer-k batch (pad the partial tail with valid
         # duplicated data so the batched RR->kR runs on dense `nk_batch_max`-sized arrays).
         for (ik_ind, ik) in enumerate(iks_batch)
-            # Full eigenvectors (nw×nw) so the batched RR->kR stays uniform; the window is
-            # applied later in the calculator scatter, not here.
-            @views uks_host[:, :, ik_ind] .= el_k_save[ik].u_full
+            # k-side window projection: the `nbk_max` contiguous eigenvector columns around this
+            # k's in-window range (all nw columns when full-band). The window selection itself
+            # still happens in the calculator scatter (imap == 0 outside), offset by kband0[ik].
+            nb0 = kband0[ik]
+            @views uks_host[:, :, ik_ind] .= el_k_save[ik].u_full[:, nb0+1:nb0+nbk_max]
             ks_batch[ik_ind] = kpts.vectors[ik]
         end
         for ik_ind in (nk_batch+1):nk_batch_max
@@ -657,8 +677,9 @@ function _loop_eph_over_k_and_kq_gpu(
         epdata.el_k = el_k
 
         # Load this k's g(k, R_ep) into the interpolator's parent (cheap device→device copy);
-        # the inner kR->kq driver reads `ep_ekpR_dev.op_r` fresh.
-        copyto!(ep_ekpR_dev.op_r, view(ep_ekpR_all, :, :, ik_ind))
+        # the inner kR->kq driver reads `ep_ekpR_dev.op_r` fresh. Under the k-side projection
+        # only the first ndata_ekpR rows are used (op_r itself is full-band-sized).
+        @views ep_ekpR_dev.op_r[1:ndata_ekpR, :] .= ep_ekpR_all[:, :, ik_ind]
         ep_ekpR_dev._id += 1
 
         for calc in calculators
@@ -717,7 +738,8 @@ function _loop_eph_over_k_and_kq_gpu(
             for calc in calculators
                 run_calculator_batched!(calc,
                     view(epkq_dev, :, :, :, rng_q), view(ωq_dev, :, rng_q),
-                    ik, view(ikqs_dev, rng_q); g2 = view(g2_dev, :, :, :, rng_q))
+                    ik, view(ikqs_dev, rng_q); g2 = view(g2_dev, :, :, :, rng_q),
+                    nbk0 = kband0[ik])
             end
 
             qstart = qend + 1

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -543,7 +543,8 @@ function _loop_eph_over_k_and_kq_gpu(
     # rotations, g2, and the scatter — shrinks by nw/nbandk_max, the dominant ∝ nk·nq cost at narrow
     # windows (e.g. TaAs ±0.1 eV: nbandk_max ≈ 4 of nw = 32). Out-of-window bands inside the projected
     # window scatter to imap == 0 and are skipped exactly as before; the calculators only need the
-    # per-k physical-band offset `ibandk_offset` to address their imaps. Full-band runs have
+    # per-k physical-band offset `ibandk_offset` (0-based: ep_kq band n ↔ physical band
+    # ibandk_offset + n) to address their imaps. Full-band runs have
     # nbandk_max = nw, ibandk_offset = 0 — the path (shapes, GEMMs, results) is unchanged.
     # ibandk_offsets[ik]: 0-based window start = (first in-window band − 1), clamped so the
     # nbandk_max-wide window [offset+1, offset+nbandk_max] stays within [1, nw]. The clamp only

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -165,7 +165,7 @@ per-k rotation by `uk` (recast as `transpose(uk(k)) * permute(g(k))`).
 Requires a UNIFORM `nband` across the batch: `ep_ekpR_all` is sized exactly
 `(nw*nband*nmodes, …)`, so all `nk` k-points must share the same `nband` (unlike the per-k
 `get_eph_RR_to_kR!`, which handles a per-k window). A windowed run satisfies this by projecting
-every k onto the same `nbk_max`-wide eigenvector window (`nband = nbk_max`); full-band is the
+every k onto the same `nbandk_max`-wide eigenvector window (`nband = nbandk_max`); full-band is the
 `nband = nw` special case.
 """
 function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -162,9 +162,11 @@ electron-Bloch / phonon-Wannier object at `ks[k]`.
 One batched Fourier (`get_fourier_batched!`) over `R_el`, then one `batched_gemm!` for the
 per-k rotation by `uk` (recast as `transpose(uk(k)) * permute(g(k))`).
 
-Full-band only: `ep_ekpR_all` is sized exactly `(nw*nband*nmodes, …)`. Unlike the per-k
-`get_eph_RR_to_kR!`, this list-batched path does not support an energy window
-(`nband < nband_bound`) — all `nk` k-points must share the same `nband`.
+Requires a UNIFORM `nband` across the batch: `ep_ekpR_all` is sized exactly
+`(nw*nband*nmodes, …)`, so all `nk` k-points must share the same `nband` (unlike the per-k
+`get_eph_RR_to_kR!`, which handles a per-k window). A windowed run satisfies this by projecting
+every k onto the same `nbk_max`-wide eigenvector window (`nband = nbk_max`); full-band is the
+`nband = nw` special case.
 """
 function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
                                    epmat_itp::BatchedWannierInterpolator{T}, ks, uks) where {T}

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -264,16 +264,18 @@ ElectronPhonon.postprocess_calculator!(c::_RecordCalcBatched; kwargs...) = c
 # Computes g2 from `ep_kq` itself (independent check of the fused-kernel ep_kq output). The GPU
 # loop now also folds g2 into the kRkq kernel and passes it as `g2=`; when present, assert it
 # matches the abs2/(2ω) recomputation — this guards the production g2 output in-package.
-function ElectronPhonon.run_calculator_batched!(c::_RecordCalcBatched, ep_kq, ωq, ik, ikqs; g2=nothing)
+function ElectronPhonon.run_calculator_batched!(c::_RecordCalcBatched, ep_kq, ωq, ik, ikqs;
+        g2=nothing, nbk0=0)
     nbandkq, nbandk, nm, nqc = size(ep_kq)
     g2dev = abs2.(ep_kq) ./ (2 .* reshape(ωq, 1, 1, nm, nqc))
     g2 === nothing || @assert maximum(abs, Array(g2 .- g2dev)) <= 1e-10 * maximum(abs, Array(g2dev))
     g2h = Array(g2dev)   # device → host (m,n,ν,j)
     ωh = Array(ωq)
     ikqsh = Array(ikqs)
-    for j in 1:nqc, ν in 1:nm, n in 1:nbandk, m in 1:nbandkq
-        c.g2[m, n, ν, ik, ikqsh[j]] = g2h[m, n, ν, j]
-        c.ωq[m, n, ν, ik, ikqsh[j]] = ωh[ν, j]
+    @inbounds for j in 1:nqc, ν in 1:nm, n in 1:nbandk, m in 1:nbandkq
+        # nbk0: the loop's k-side window projection offset (ep_kq band n ↔ physical band nbk0+n).
+        c.g2[m, nbk0 + n, ν, ik, ikqsh[j]] = g2h[m, n, ν, j]
+        c.ωq[m, nbk0 + n, ν, ik, ikqsh[j]] = ωh[ν, j]
     end
     c
 end

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -265,17 +265,17 @@ ElectronPhonon.postprocess_calculator!(c::_RecordCalcBatched; kwargs...) = c
 # loop now also folds g2 into the kRkq kernel and passes it as `g2=`; when present, assert it
 # matches the abs2/(2ω) recomputation — this guards the production g2 output in-package.
 function ElectronPhonon.run_calculator_batched!(c::_RecordCalcBatched, ep_kq, ωq, ik, ikqs;
-        g2=nothing, nbk0=0)
+        g2=nothing, ibandk_offset=0)
     nbandkq, nbandk, nm, nqc = size(ep_kq)
     g2dev = abs2.(ep_kq) ./ (2 .* reshape(ωq, 1, 1, nm, nqc))
     g2 === nothing || @assert maximum(abs, Array(g2 .- g2dev)) <= 1e-10 * maximum(abs, Array(g2dev))
     g2h = Array(g2dev)   # device → host (m,n,ν,j)
     ωh = Array(ωq)
     ikqsh = Array(ikqs)
-    @inbounds for j in 1:nqc, ν in 1:nm, n in 1:nbandk, m in 1:nbandkq
-        # nbk0: the loop's k-side window projection offset (ep_kq band n ↔ physical band nbk0+n).
-        c.g2[m, nbk0 + n, ν, ik, ikqsh[j]] = g2h[m, n, ν, j]
-        c.ωq[m, nbk0 + n, ν, ik, ikqsh[j]] = ωh[ν, j]
+    for j in 1:nqc, ν in 1:nm, n in 1:nbandk, m in 1:nbandkq
+        # ibandk_offset: the loop's k-side window projection offset (ep_kq band n ↔ physical band ibandk_offset+n).
+        c.g2[m, ibandk_offset + n, ν, ik, ikqsh[j]] = g2h[m, n, ν, j]
+        c.ωq[m, ibandk_offset + n, ν, ik, ikqsh[j]] = ωh[ν, j]
     end
     c
 end


### PR DESCRIPTION
## Stage 2b — Shared GPU optimizations (consolidated dedup)

Fourth stage of the GPU-port merge (see `MERGE_PLAN.md`). Consolidates the three GPU
optimizations that were each implemented **twice** (identically) on `gpu-fmp-speedup` and
`bte-gpu`, so they are reviewed and merged exactly once. Cherry-picked from the `gpu-fmp-speedup`
copies onto the post-Stage-2a `main`.

### Commits
1. `perf(gpu): parallelize the fused e-ph rotation kernel over (band, band, q)` — applied clean.
2. `perf(gpu): k-side window projection of the batched e-ph interpolation` — **reconciled** (see below).
3. `perf(gpu): skip device-side bounds checks of the per-chunk iq gathers` — **reconciled**.
4. `docs: clarify get_eph_RR_to_kR_batched! uniform-nband requirement` — review follow-up.
5. `docs(bench): record Stage 2b GPU perf`.

### Reconciliation (the part to scrutinize)
Stage 2a had already (a) renamed the batch vars on `main` (`k_batch_size`→`nk_batch_max`,
`ks_tile`→`ks_batch`, `a`→`ik_ind`, `nqc`→`nq_batch`/`rng_q`, …) and (b) **removed the old
`batched`/host-fallback path** (the GPU loop now requires every calculator to implement the
batched device hook). The fmp commits predate both, so cherry-picks #2/#3 conflicted heavily.
Every conflict was resolved by keeping **main's structure and names** and layering in **only**
the window-projection + `@inbounds` semantics — no stale `kb`/`qb`/`ks_tile`/`nqc`/host-fallback
leaked back.

The k-side window projection lets the outer-k side carry only an `nbk_max`-wide contiguous
eigenvector window (not all `nw` bands), shrinking the kR→kq GEMM, both gauge rotations, `g2`,
and the scatter by `nw/nbk_max`. It adds a new `nbk0` band-offset kwarg to the
`run_calculator_batched!` contract; `nbk0 = 0` full-band runs are bit-identical to before.

### Verification
- **Critical review** (reviewer persona over the full diff): clean — verified the window-projection
  replay is byte-identical to fmp `15d2570` re-expressed in main's names, fullband path unchanged,
  `@inbounds` layered on main's `rng_q` gathers, `ndata` set-before-build ordering load-bearing.
- **GPU tests:** `test/test_gpu.jl` **81/81 green** on RTX A6000 (ccqlin059).
- **Perf** (`bench_eliashberg_loop_gpu.jl`, Pb, ±0.3 eV): reliable 32³ GPU wall **11.2 → 8.83 s**
  (no regression); details in `benchmark/PERF_LOG.md`.

### Downstream note
The new `nbk0` kwarg is a contract change for `run_calculator_batched!` implementers.
`MigdalEliashberg`'s `EliashbergCalculator` must accept/apply it in lockstep (mirrors ME
`89f2708`); handled in the local ME repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
