### PR TITLE
Stage 3 — MPI outer-k decomposition for run_eph_over_k_and_kq (FMP)

### DIFF
--- a/benchmark/PERF_LOG.md
+++ b/benchmark/PERF_LOG.md
@@ -81,3 +81,33 @@ cross-row *speedup ratio* is not directly comparable; trend the GPU wall-time co
 `relerr(g2)=0.76` / `ωq=false`: same degenerate-gauge artifact documented in the Stage 1 entry
 above (two eigensolvers pick different gauges for Pb's degenerate bands), not a correctness
 regression — the 81/81 GPU tests use gauge-invariant / fixed-eigenvector checks.
+
+---
+
+## 2026-07-11 — `8597488` (gpu-3-mpi-outerk, Stage 3: MPI outer-k decomposition)
+
+**Hardware:** NVIDIA RTX A6000 (48 GB), host `ccqlin059`.
+**Software:** Julia 1.11.7, CUDA.jl functional. GPU tests: 81/81 green.
+
+Stage 3 enables `mpi_comm_k` to split the OUTER k-points across MPI ranks (each rank computes
+its k-slice's e-ph coupling; k+q / q-grid / phonons stay full per rank) and fixes the
+`kpoints_grid_range` BZ-fraction weight so a per-rank sub-range's Σ_k w_k is correct. The
+**serial single-rank path is unchanged** (the new guards are no-ops when `mpi_comm_k = nothing`,
+and the full-range weight is identical), so this benchmark is a single-GPU no-regression check —
+the MPI win is not measurable on one rank.
+
+**End-to-end e-ph loop** (`bench_eliashberg_loop_gpu.jl`, EliashbergCalculator, window E_F±0.3 eV):
+
+| grid | n_i | CPU | GPU | speedup |
+|-|-|-|-|-|
+| 16³ | 432  | 0.59 s | 0.54 s | 1.10× |
+| 24³ | 1716 | 6.85 s | 3.00 s | 2.28× |
+| 32³ | 4052 | 38.7 s | 8.96 s | 4.32× |
+
+**No regression vs Stage 2b** (`71f90e0`): the reliable 32³ GPU signal is 8.96 s vs 8.83 s
+(Δ≈1.5%, run-to-run noise); 24³ GPU 3.00 vs 2.94 s; 16³ 0.54 vs 0.55 s. As expected — Stage 3
+does not touch the single-rank inner loop.
+
+`relerr(g2)=0.76` / `ωq=false`: same degenerate-gauge artifact documented in the Stage 1/2b
+entries (two eigensolvers pick different gauges for Pb's degenerate bands), not a correctness
+regression — the 81/81 GPU tests use gauge-invariant / fixed-eigenvector checks.

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -481,14 +481,18 @@ end
 #  batched over k-batches and q-batches with device staging — differs from the per-(k,q) CPU loop,
 #  not because it holds any device-specific code.
 #
-#  Minimal first step — the rest is asserted off (not implemented on the GPU path):
-#    * no polar / long-range terms (so ϵs = 1, no dipole correction)
-#    * full bands, no energy window  ->  nband == nw at every k / k+q (uniform batch shapes)
-#    * commensurate k / k+q grids (precompute_ph) so phonon states are precomputed
-#    * no covariant derivative of g, no screening, no el_kq_from_unfolding,
-#      and energy_conservation = (:None, 0.0)
-#  (IBZ outer-k symmetry and outer-k MPI decomposition ARE supported — both are handled upstream
-#   in the shared `_setup`, so this loop stays symmetry- and MPI-agnostic.)
+#  Supported (all handled upstream in the shared `_setup`, so this loop itself is agnostic to them):
+#    * energy windows (window_k / window_kq): the k side carries only its in-window bands, the
+#      window is applied in the calculator scatter
+#    * IBZ outer-k symmetry
+#    * outer-k MPI decomposition (mpi_comm_k)
+#  Not supported — asserted off on the GPU path (see the scope-assert block below):
+#    * polar / long-range terms
+#    * incommensurate k / k+q grids: requires precompute_ph (phonon states precomputed)
+#    * covariant derivative of g
+#    * screening
+#    * el_kq_from_unfolding (directly-computed k+q only)
+#    * energy_conservation other than (:None, 0.0)
 #
 #  Buffer reuse: device buffers are allocated once before the k loop and reused for every
 #  (k, q), so the loop itself allocates almost nothing.

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -32,13 +32,11 @@ function run_eph_over_k_and_kq(
     end
 
     # Outer-k MPI decomposition (multi-CPU/GPU): `mpi_comm_k` splits the OUTER k-points across ranks
-    # — each rank computes the e-ph coupling only for its k-slice, yielding a rank-local
-    # `calc.g2[:, i_local, :]` / `el_i`. k+q, the q-grid, and the phonon states stay FULL on every
-    # rank (so any k can scatter to any k+q). `filter_kpoints` does the split + load-balance in the
-    # shared `_setup`; the EliashbergCalculator is already rank-local; and the CPU and GPU inner
-    # loops are UNCHANGED (they iterate whatever `kpts` they are handed). The solver then decomposes
-    # over the matching outer states i (see MigdalEliashberg). q-decomposition (mpi_comm_q) is a
-    # separate, not-yet-implemented scheme. See GPU_PROGRESS.md "Multi-GPU / MPI".
+    # — each rank computes the e-ph coupling for its k-slice only (rank-local `calc.g2` / `el_i`),
+    # while k+q, the q-grid, and the phonon states stay FULL per rank (so any k can scatter to any
+    # k+q). `filter_kpoints` does the split + load-balance in `_setup`; the CPU and GPU inner loops
+    # are unchanged (they iterate whatever `kpts` they receive). `mpi_comm_q` is a separate scheme,
+    # not yet implemented.
     mpi_comm_q === nothing || error("mpi_comm_q not implemented (use mpi_comm_k for outer-k decomposition)")
     (mpi_comm_k === nothing || !el_kq_from_unfolding) || throw(ArgumentError(
         "mpi_comm_k requires el_kq_from_unfolding = false (k+q stays full per rank; the unfolding " *
@@ -487,8 +485,10 @@ end
 #    * no polar / long-range terms (so ϵs = 1, no dipole correction)
 #    * full bands, no energy window  ->  nband == nw at every k / k+q (uniform batch shapes)
 #    * commensurate k / k+q grids (precompute_ph) so phonon states are precomputed
-#    * no covariant derivative of g, no screening, no symmetry/unfolding, single node (no MPI),
+#    * no covariant derivative of g, no screening, no el_kq_from_unfolding,
 #      and energy_conservation = (:None, 0.0)
+#  (IBZ outer-k symmetry and outer-k MPI decomposition ARE supported — both are handled upstream
+#   in the shared `_setup`, so this loop stays symmetry- and MPI-agnostic.)
 #
 #  Buffer reuse: device buffers are allocated once before the k loop and reused for every
 #  (k, q), so the loop itself allocates almost nothing.

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -31,8 +31,18 @@ function run_eph_over_k_and_kq(
         end
     end
 
-    mpi_comm_k === nothing || error("mpi_comm_k not implemented")
-    mpi_comm_q === nothing || error("mpi_comm_q not implemented")
+    # Outer-k MPI decomposition (multi-CPU/GPU): `mpi_comm_k` splits the OUTER k-points across ranks
+    # — each rank computes the e-ph coupling only for its k-slice, yielding a rank-local
+    # `calc.g2[:, i_local, :]` / `el_i`. k+q, the q-grid, and the phonon states stay FULL on every
+    # rank (so any k can scatter to any k+q). `filter_kpoints` does the split + load-balance in the
+    # shared `_setup`; the EliashbergCalculator is already rank-local; and the CPU and GPU inner
+    # loops are UNCHANGED (they iterate whatever `kpts` they are handed). The solver then decomposes
+    # over the matching outer states i (see MigdalEliashberg). q-decomposition (mpi_comm_q) is a
+    # separate, not-yet-implemented scheme. See GPU_PROGRESS.md "Multi-GPU / MPI".
+    mpi_comm_q === nothing || error("mpi_comm_q not implemented (use mpi_comm_k for outer-k decomposition)")
+    (mpi_comm_k === nothing || !el_kq_from_unfolding) || throw(ArgumentError(
+        "mpi_comm_k requires el_kq_from_unfolding = false (k+q stays full per rank; the unfolding " *
+        "path is not split-aware)."))
 
     # Symmetry (IBZ outer k) is supported on the GPU path, but only with directly-computed k+q
     # (el_kq_from_unfolding = false): the IBZ reduction happens in the shared setup and the GPU loop

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -407,7 +407,10 @@ function mpi_gather(k::GridKpoints{FT}, comm::MPI.Comm) where {FT}
     end
 end
 
-"Collect and uniformly redistribute GridKpoints among processers (each even chunk stays grid-aligned)."
+# Gather every rank's k-points to the root and redistribute them evenly. Needed after
+# `filter_kpoints`, which drops out-of-window points and so leaves an unbalanced count per rank —
+# this restores an even split. Every point is a node of the original regular grid, so any split of
+# them is still made of grid nodes ("grid-aligned") and each rank's chunk is again a `GridKpoints`.
 mpi_gather_and_scatter(k::GridKpoints, comm::MPI.Comm) = mpi_scatter(mpi_gather(k, comm), comm)
 mpi_gather_and_scatter(k::GridKpoints, comm::Nothing) = k
 

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -106,9 +106,12 @@ function kpoints_grid(ngrid, mpi_comm::Union{MPI.Comm, Nothing}=nothing; shift=(
             error("kpoints_grid with symmetry incompatible with shift")
         end
         if mpi_comm isa MPI.Comm
-            # Create the irreducible k points in the root. Then redistribute.
+            # Create the irreducible k points in the root. Then redistribute. Reduce the root's
+            # `GridKpoints` to a plain `Kpoints` first so every rank holds the same type for the
+            # collective `mpi_scatter` (which has a `Kpoints` method) and returns `Kpoints` — the
+            # same type the non-symmetry MPI branch (`kpoints_grid_range`) returns.
             kpoints = if mpi_isroot(mpi_comm)
-                kpoints_grid_symmetry(ngrid, symmetry; ignore_time_reversal)
+                Kpoints(kpoints_grid_symmetry(ngrid, symmetry; ignore_time_reversal))
             else
                 Kpoints{Float64}()
             end

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -106,15 +106,10 @@ function kpoints_grid(ngrid, mpi_comm::Union{MPI.Comm, Nothing}=nothing; shift=(
             error("kpoints_grid with symmetry incompatible with shift")
         end
         if mpi_comm isa MPI.Comm
-            # Create the irreducible k points in the root. Then redistribute. Reduce the root's
-            # `GridKpoints` to a plain `Kpoints` first so every rank holds the same type for the
-            # collective `mpi_scatter` (which has a `Kpoints` method) and returns `Kpoints` — the
-            # same type the non-symmetry MPI branch (`kpoints_grid_range`) returns.
-            kpoints = if mpi_isroot(mpi_comm)
-                Kpoints(kpoints_grid_symmetry(ngrid, symmetry; ignore_time_reversal))
-            else
-                Kpoints{Float64}()
-            end
+            # Create the irreducible k points on the root, then scatter them across ranks. The
+            # scatter keeps the `GridKpoints` type (each rank's subset is grid-aligned and rebuilds
+            # its own xk->ik hash), so both the serial and MPI symmetry branches return `GridKpoints`.
+            kpoints = mpi_isroot(mpi_comm) ? kpoints_grid_symmetry(ngrid, symmetry; ignore_time_reversal) : GridKpoints{Float64}()
             return mpi_scatter(kpoints, mpi_comm)
         else
             return kpoints_grid_symmetry(ngrid, symmetry; ignore_time_reversal)
@@ -122,6 +117,8 @@ function kpoints_grid(ngrid, mpi_comm::Union{MPI.Comm, Nothing}=nothing; shift=(
     elseif symmetry === nothing
         nk = prod(ngrid)
         range = mpi_comm isa MPI.Comm ? mpi_split_iterator(1:nk, mpi_comm) : 1:nk
+        # TODO: return GridKpoints here too (see kpoints_grid_range) so the non-symmetry branch
+        # matches the symmetry branch's GridKpoints return type in both the serial and MPI cases.
         return kpoints_grid_range(ngrid, range; shift)
     else
         error("Wrong input symmetry: must be a Symmetry object or nothing")
@@ -149,12 +146,8 @@ function kpoints_grid_range(ngrid::NTuple{3, Int}, rng::UnitRange{Int}, ::Type{F
         i = mod(div(ik-1 - k - j*nk3, nk2*nk3), nk1)
         push!(kvecs, Vec3{FT}(i/nk1, j/nk2, k/nk3) .+ shift)
     end
-    # BZ weight is the grid fraction 1/prod(ngrid) per point — NOT 1/length(rng). They coincide for
-    # the full range (rng = 1:prod(ngrid)), but for an MPI sub-range each rank must still carry the
-    # global BZ fraction so the distributed Σ_k w_k = 1 (a per-range 1/length would over-count by the
-    # number of ranks). Only the sub-range (MPI) case changes; the full-grid/serial result is identical.
-    nrange = length(kvecs)
-    Kpoints(nrange, kvecs, fill(one(FT) / (nk1 * nk2 * nk3), nrange), (nk1, nk2, nk3))
+    nk = length(kvecs)
+    Kpoints(nk, kvecs, fill(one(FT) / (nk1 * nk2 * nk3), nk), (nk1, nk2, nk3))
 end
 
 "Filter kpoints using a Boolean vector ik_keep. Retern Kpoints object where
@@ -383,9 +376,40 @@ end
 
 GridKpoints(xk::Vec3{T}) where {T <: Real} = GridKpoints(Kpoints(xk))
 
+# Empty GridKpoints (e.g. the receive-side placeholder on non-root ranks before mpi_scatter).
+GridKpoints{T}() where {T} = GridKpoints{T}(0, Vector{Vec3{T}}(), Vector{T}(), (0, 0, 0), zero(Vec3{T}), Dict{Int,Int}())
+
 # Reduce GridKpoints to Kpoints
 Kpoints(k::GridKpoints{T}) where {T} = Kpoints{T}(k.n, k.vectors, k.weights, k.ngrid)
 GridKpoints(k::GridKpoints) = k
+
+"""
+    mpi_scatter(k::GridKpoints{FT}, comm::MPI.Comm) where {FT}
+Scatter the grid-aligned points across `comm`, returning a `GridKpoints` on each rank (the
+per-rank xk->ik hash is rebuilt from that rank's subset). Each subset is itself on the grid, so
+the result stays a `GridKpoints` — matching the serial symmetry return type.
+"""
+function mpi_scatter(k::GridKpoints{FT}, comm::MPI.Comm) where {FT}
+    ngrid = mpi_bcast(k.ngrid, comm)
+    vectors = mpi_scatter(k.vectors, comm)
+    weights = mpi_scatter(k.weights, comm)
+    GridKpoints(Kpoints{FT}(length(vectors), vectors, weights, ngrid), ngrid)
+end
+
+function mpi_gather(k::GridKpoints{FT}, comm::MPI.Comm) where {FT}
+    kvectors = mpi_gather(k.vectors, comm)
+    weights = mpi_gather(k.weights, comm)
+    new_ngrid = _gather_ngrid(k.ngrid, comm)
+    if mpi_isroot(comm)
+        GridKpoints(Kpoints{FT}(length(kvectors), kvectors, weights, new_ngrid), new_ngrid)
+    else
+        GridKpoints{FT}()
+    end
+end
+
+"Collect and uniformly redistribute GridKpoints among processers (each even chunk stays grid-aligned)."
+mpi_gather_and_scatter(k::GridKpoints, comm::MPI.Comm) = mpi_scatter(mpi_gather(k, comm), comm)
+mpi_gather_and_scatter(k::GridKpoints, comm::Nothing) = k
 
 function _hash_xk(xk, ngrid, shift)
     # xk_int = mod.(round.(Int, (xk - shift) .* ngrid), ngrid)

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -149,8 +149,12 @@ function kpoints_grid_range(ngrid::NTuple{3, Int}, rng::UnitRange{Int}, ::Type{F
         i = mod(div(ik-1 - k - j*nk3, nk2*nk3), nk1)
         push!(kvecs, Vec3{FT}(i/nk1, j/nk2, k/nk3) .+ shift)
     end
-    nk = length(kvecs)
-    Kpoints(nk, kvecs, fill(1/nk, (nk,)), (nk1, nk2, nk3))
+    # BZ weight is the grid fraction 1/prod(ngrid) per point — NOT 1/length(rng). They coincide for
+    # the full range (rng = 1:prod(ngrid)), but for an MPI sub-range each rank must still carry the
+    # global BZ fraction so the distributed Σ_k w_k = 1 (a per-range 1/length would over-count by the
+    # number of ranks). Only the sub-range (MPI) case changes; the full-grid/serial result is identical.
+    nrange = length(kvecs)
+    Kpoints(nrange, kvecs, fill(one(FT) / (nk1 * nk2 * nk3), nrange), (nk1, nk2, nk3))
 end
 
 "Filter kpoints using a Boolean vector ik_keep. Retern Kpoints object where

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -64,7 +64,7 @@ Obtained k points are distributed over the MPI communicator mpi_comm.
 - `band_min`, `band_max`: Minimum and maximum index of bands inside the window.
 - `nelec_below_window`: Number of bands below the window, weighted by the k-point weights.
 """
-function filter_kpoints(nks::NTuple{3,Integer}, nw, el_ham, window, mpi_comm::MPI.Comm; fourier_mode="gridopt", symmetry=nothing, shift=[0, 0, 0])
+function filter_kpoints(nks::NTuple{3,Integer}, nw, el_ham, window, mpi_comm::MPI.Comm; fourier_mode="gridopt", symmetry=nothing, shift=(0, 0, 0), use_gpu=false)
     if symmetry !== nothing && (! all(shift .== 0))
         error("nonzero shift and symmetry incompatible (not implemented)")
     end
@@ -74,7 +74,7 @@ function filter_kpoints(nks::NTuple{3,Integer}, nw, el_ham, window, mpi_comm::MP
     # If the window is trivial, return the whole grid
     window == (-Inf, Inf) && return kpoints, 1, nw, zero(eltype(window))
 
-    ik_keep, band_min, band_max, nelec_below_window = _filter_kpoints(nw, kpoints, el_ham, window; fourier_mode)
+    ik_keep, band_min, band_max, nelec_below_window = _filter_kpoints(nw, kpoints, el_ham, window; fourier_mode, use_gpu)
 
     k_filtered = get_filtered_kpoints(kpoints, ik_keep)
 

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -3,7 +3,7 @@ using Random
 using ElectronPhonon
 
 @testset "kpoints: grid" begin
-    using ElectronPhonon: get_filtered_kpoints, kpoints_grid, kpoints_create_subgrid
+    using ElectronPhonon: get_filtered_kpoints, kpoints_grid, kpoints_create_subgrid, kpoints_grid_range
 
     nk1 = 2
     nk2 = 3
@@ -16,6 +16,18 @@ using ElectronPhonon
     kpts_split = split_kpoints(kpts, 5)
     @test sum([k.n for k in kpts_split]) == kpts.n
     @test all([k isa Kpoints for k in kpts_split])
+
+    # kpoints_grid_range weights each point by the global BZ fraction 1/prod(ngrid), NOT
+    # 1/length(rng): a sub-range (as used per MPI rank) must carry the global fraction so the
+    # union of sub-ranges still sums to 1.
+    ngrid = (nk1, nk2, nk3)
+    nk = prod(ngrid)
+    kpts_full = kpoints_grid_range(ngrid, 1:nk)
+    @test all(kpts_full.weights .≈ 1 / nk)
+    kpts_sub = kpoints_grid_range(ngrid, 3:9)  # a strict sub-range
+    @test all(kpts_sub.weights .≈ 1 / nk)      # global BZ fraction, not 1/7
+    subranges = [1:5, 6:12, 13:nk]
+    @test sum(sum(kpoints_grid_range(ngrid, r).weights) for r in subranges) ≈ 1
 
     # Test get_filtered_kpoints
     ik_keep = zeros(Bool, nk1 * nk2 * nk3)
@@ -173,4 +185,35 @@ end
     # combine_kpoint_grids routes through that constructor, so the guard applies to ngrid_kq.
     single = GridKpoints(kpoints_grid((1, 1, 1)))
     @test_throws ArgumentError combine_kpoint_grids(single, single, +, (10^7, 10^7, 10^7))
+end
+
+@testset "kpoints: mpi_scatter return type" begin
+    using ElectronPhonon: kpoints_grid, mpi_scatter, mpi_gather_and_scatter
+    MPI = ElectronPhonon.MPI
+    MPI.Initialized() || MPI.Init()
+    comm = MPI.COMM_SELF  # single rank: scatter keeps all points on this rank
+
+    # Empty GridKpoints placeholder (the non-root receive side before mpi_scatter).
+    empty_grid = GridKpoints{Float64}()
+    @test empty_grid isa GridKpoints
+    @test empty_grid.n == 0
+
+    # mpi_scatter of a GridKpoints preserves the GridKpoints type (rebuilds the per-rank hash).
+    gridk = GridKpoints(kpoints_grid((2, 2, 3)))
+    scattered = mpi_scatter(gridk, comm)
+    @test scattered isa GridKpoints
+    @test scattered.n == gridk.n
+    @test scattered.vectors ≈ gridk.vectors
+    @test all(xk_to_ik.(scattered.vectors, Ref(scattered)) .== 1:scattered.n)
+
+    # The load-balancing gather+scatter (used by filter_kpoints under MPI) also stays GridKpoints.
+    balanced = mpi_gather_and_scatter(gridk, comm)
+    @test balanced isa GridKpoints
+    @test balanced.n == gridk.n
+
+    # Contrast: a plain Kpoints scatters back to a plain Kpoints.
+    plaink = kpoints_grid((2, 2, 3))
+    @test plaink isa Kpoints
+    @test mpi_scatter(plaink, comm) isa Kpoints
+    @test mpi_gather_and_scatter(plaink, comm) isa Kpoints
 end

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -191,7 +191,10 @@ end
     using ElectronPhonon: kpoints_grid, mpi_scatter, mpi_gather_and_scatter
     MPI = ElectronPhonon.MPI
     MPI.Initialized() || MPI.Init()
-    comm = MPI.COMM_SELF  # single rank: scatter keeps all points on this rank
+    # COMM_SELF exercises only the single-rank path (scatter keeps all points on this rank).
+    # TODO: actually test with a real multi-rank MPI communicator (np > 1), where scatter/gather
+    # split points across ranks — e.g. under mpiexec, or a spawned child comm.
+    comm = MPI.COMM_SELF
 
     # Empty GridKpoints placeholder (the non-root receive side before mpi_scatter).
     empty_grid = GridKpoints{Float64}()


### PR DESCRIPTION
## Stage 3 of the GPU-port merge plan (FMP-specific)

Cherry-picks the two genuinely FMP-unique commits from \`gpu-fmp-speedup\` onto the post-Stage-2b \`main\`, after subtracting the Stage-2b duplicates.

| commit | change |
|---|---|
| \`72fb148\` (was \`f1e42ed\`) | feat: MPI outer-k decomposition for \`run_eph_over_k_and_kq\` (multi-CPU/GPU) |
| \`3304d2d\` (was \`0024017\`) | fix: \`kpoints_grid_range\` uses BZ-fraction weight (correct under MPI k-split) |

### What it does
- \`mpi_comm_k\` now splits the **outer** k-points across ranks; each rank computes its k-slice's coupling (rank-local \`calc.g2[:, i_local, :]\`). k+q / q-grid / phonons stay full per rank. CPU and GPU inner loops unchanged.
- Guards \`mpi_comm_k\` to \`el_kq_from_unfolding = false\` (unfolding path is not split-aware); \`mpi_comm_q\` still errors (not implemented).
- Fixes latent bugs in the symmetry+MPI(+GPU) path (never exercised before, no driver passed \`mpi_comm_k\`): \`filter_kpoints(::MPI.Comm)\` missing \`use_gpu\`; \`shift\` \`Vector\` default spuriously tripping the symmetry guard; \`kpoints_grid(::MPI.Comm; symmetry)\` scattering a \`GridKpoints\`.
- Weight fix: \`kpoints_grid_range\` weights each point by the BZ fraction \`1/prod(ngrid)\` (not \`1/length(rng)\`), so a per-rank sub-range's Σ w_k is correct. Serial/full-grid result is identical.

### Reconciliation vs the plan
Both commits cherry-picked **clean** onto \`main\` (no conflicts). Verified the merged \`main..HEAD\` diff is content-identical to the original \`f1e42ed~1..0024017\` range (only blob-hash header lines differ, from unrelated Stage-2b edits elsewhere in the same files).

### Serial path unchanged
Default \`mpi_comm_k = nothing\`: the new guards are no-ops and \`kpoints_grid_range\`'s full-range weight is unchanged, so the standard (serial, single-GPU) test suite is the no-regression guardrail.

Draft until the pre-commit gate (critical review + GPU tests + benchmark→PERF_LOG) passes.