### PR TITLE
GPU outer-q e-ph loop for phonon self-energy / susceptibility

### DIFF
--- a/README_GPU.md
+++ b/README_GPU.md
@@ -34,9 +34,10 @@ Deliberately **not** on the GPU (stays on the CPU per-k path):
 - **`op_r` fits in GPU memory.** No streaming/chunking of the Wannier operator itself.
 - **Full-band on the GPU.** No per-k energy window; see the design note.
 - **The GPU path is fully GPU — no silent fallback.** The GPU calculator loop requires every
-  calculator to implement the batched device hook (`allow_eph_batched`). It must not silently
-  fall back to the per-`(k,q)` host `run_calculator!` path, which would be a hard-to-spot
-  performance cliff — a calculator that forgets to opt in should fail loudly instead.
+  calculator to implement the batched device hook (`allow_eph_outer_k_batched` for the outer-k
+  loop, `allow_eph_outer_q_batched` for the outer-q loop). It must not silently fall back to the
+  per-`(k,q)` host `run_calculator!` path, which would be a hard-to-spot performance cliff — a
+  calculator that forgets to opt in should fail loudly instead.
 
 ## Strategy
 
@@ -125,15 +126,25 @@ functions are unchanged. The GPU loop: `to_device(model.epmat)` once; processes 
 outer-k with one list-batched `get_eph_RR_to_kR_batched!`; batches the inner `ikq` loop (in
 batches of `nq_batch_max`) through one `get_eph_kR_to_kq_batched!`.
 
-A calculator can opt into a **device-native hook** so the e-ph matrix for a whole `(k, {k+q})`
-batch stays on the device and the reduction/scatter happens there:
+A calculator can opt into a **device-native hook** so the e-ph matrix for a whole batch stays on
+the device and the reduction/scatter happens there. The two loops each have their own hook, named
+for which momentum is the outer loop and which is batched on the inner axis:
 
-- **To run on the GPU, a calculator must (1) define `allow_eph_batched(calc) = true` and (2)
-  implement `run_calculator_batched!(calc, ep_kq, ωq, ik, ikqs)`.** The GPU path is batched-only:
-  the loop keeps `ep_kq` on the device and calls the batched hook once per batch. A calculator that
-  does not opt in is rejected with an error — there is no silent fallback to the per-`(k,q)` host
-  path.
-- A calculator can implement this backend-generically (only `similar`/`copyto!`/broadcast/
+- **Outer-k loop (`run_eph_over_k_and_kq`, outer k / inner k+q batched).** To run on the GPU, a
+  calculator MUST (1) define `allow_eph_outer_k_batched(calc) = true` and (2) implement
+  `run_calculator_outer_k_batched!(calc, ep_kq, ωq, ik, ikqs)`. The loop keeps `ep_kq` for a whole
+  `(k, {k+q})` batch on the device and calls the hook once per batch.
+- **Outer-q loop (`run_eph_outer_q`, outer q / inner k batched).** To run on the GPU, a calculator
+  MUST (1) define `allow_eph_outer_q_batched(calc) = true` and (2) implement
+  `run_calculator_outer_q_batched!(calc, ep_kq, e_k, e_kq, uk, ukq, wtk, xks, iq)`. For a fixed q
+  the loop keeps the e-ph matrix for a batch of outer-k on the device and calls the hook once per
+  batch; the per-q device accumulator is bracketed by the generic `setup_calculator_inner!` /
+  `postprocess_calculator_inner!` hooks (which on this path receive `gpu_array` / `nk_batch_max`),
+  and the per-k device scratch is declared via `eph_outer_q_batched_bytes_per_k` for the loop's
+  memory-adaptive batch sizing.
+- Either path is rejected with an error if a calculator does not opt in — there is no silent
+  fallback to the per-`(k,q)` host path.
+- A calculator can implement these backend-generically (only `similar`/`copyto!`/broadcast/
   scatter-assignment) and add no CUDA dependency of its own.
 
 ### Full bands on the GPU (design note)
@@ -155,6 +166,11 @@ is needed.
 
 ## Deferred (may do later)
 
+- **Outer-q k-side streaming.** The outer-q GPU loop keeps the whole-grid k-side eigenvector /
+  energy / weight stacks device-resident for the entire run (16·nw²·nk bytes), which is not covered
+  by the per-batch memory-adaptive sizing — for large `nw` on a dense grid it, not the per-batch
+  scratch, is the memory limit. Streaming the k side per batch (like the outer-k loop's per-batch
+  `uks_host`) is deferred.
 - **In-place workspace drivers** (workspace-backed scratch instead of per-call `similar()`) were
   benchmarked and validated bit-identical, but the gain is small on the GPU (CUDA's pool already
   recycles device buffers), so it is deferred. Best done together with the calculator loop, where

--- a/ext/ElectronPhononCUDAExt.jl
+++ b/ext/ElectronPhononCUDAExt.jl
@@ -193,8 +193,8 @@ end
 # with the ν loop inside and the small iw/jw contractions in registers, replacing both GEMMs.
 # The per-jw partial Σ_iw is re-read per n (L1-served), mirroring that kernel's redundancy note.
 # Per-thread work grows as nmodes·nw², so gate on nw²·nmodes; above the threshold the matmuls are
-# large enough that cuBLAS is efficient and the generic two-GEMM method is used.
-# THRESHOLD IS A100-TUNED (covers nw=3, nmodes=21 → 189; excludes e.g. nw=8, nmodes=12 → 768).
+# large enough that cuBLAS is efficient and the generic two-GEMM method is used. The threshold
+# covers small-nw metals (e.g. nw=3, nmodes=21 → 189) and excludes e.g. nw=8, nmodes=12 → 768.
 const _FUSED_RQKQ_MAX_NW2NM = 512
 
 # g : (nw, nw, nmodes, nk) with legend g[iw, jw, ν, k] (iw = k+q leg, jw = k leg);

--- a/ext/ElectronPhononCUDAExt.jl
+++ b/ext/ElectronPhononCUDAExt.jl
@@ -184,6 +184,63 @@ function ElectronPhonon.eph_apply_rotations!(ep_kq_all::DenseCuArray{Complex{T},
     ep_kq_all
 end
 
+# ---- fused Rq→kq gauge rotation (outer-q loop) -------------------------------------------------
+#
+# Same tiny-GEMM pathology as the outer-k rotation above, but along the k batch: the right
+# rotation of `eph_apply_rotations_rqkq!` is an nw×nw matmul strided-batched over nmodes·nk
+# (≈ 2·10⁶ batches at nw=3, nmodes=21, nk ≈ 10⁵), where cuBLAS' flat per-batch overhead
+# dominates. Following the outer-k `_fused_eph_rot_kernel!` precedent: one thread per (m, n, k)
+# with the ν loop inside and the small iw/jw contractions in registers, replacing both GEMMs.
+# The per-jw partial Σ_iw is re-read per n (L1-served), mirroring that kernel's redundancy note.
+# Per-thread work grows as nmodes·nw², so gate on nw²·nmodes; above the threshold the matmuls are
+# large enough that cuBLAS is efficient and the generic two-GEMM method is used.
+# THRESHOLD IS A100-TUNED (covers nw=3, nmodes=21 → 189; excludes e.g. nw=8, nmodes=12 → 768).
+const _FUSED_RQKQ_MAX_NW2NM = 512
+
+# g : (nw, nw, nmodes, nk) with legend g[iw, jw, ν, k] (iw = k+q leg, jw = k leg);
+# uks : (nw, nbandk, nk); ukqs : (nw, nbandkq, nk); ep : (nbandkq, nbandk, nmodes, nk).
+function _fused_rqkq_rot_kernel!(ep, g, uks, ukqs, nw, nbkq, nbk, nm, nk)
+    t = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    t <= nbkq * nbk * nk || return
+    @inbounds begin
+        m = (t - 1) % nbkq + 1
+        r = (t - 1) ÷ nbkq
+        n = r % nbk + 1
+        k = r ÷ nbk + 1
+        for ν in 1:nm
+            acc = zero(eltype(ep))
+            for jw in 1:nw
+                tval = zero(eltype(ep))
+                for iw in 1:nw
+                    tval += conj(ukqs[iw, m, k]) * g[iw, jw, ν, k]
+                end
+                acc += tval * uks[jw, n, k]
+            end
+            ep[m, n, ν, k] = acc
+        end
+    end
+    return
+end
+
+function ElectronPhonon.eph_apply_rotations_rqkq!(ep_kq_all::CuArray{Complex{T},4}, g,
+        uks::CuArray, ukqs::CuArray, tmp, uk_rep) where {T}
+    nbandkq, nbandk, nmodes, nk = size(ep_kq_all)
+    nw = size(uks, 1)
+    if nw^2 * nmodes <= _FUSED_RQKQ_MAX_NW2NM
+        g4 = reshape(g, nw, nw, nmodes, nk)
+        threads = 256
+        blocks = cld(nbandkq * nbandk * nk, threads)
+        @cuda threads=threads blocks=blocks _fused_rqkq_rot_kernel!(
+            ep_kq_all, g4, uks, ukqs, nw, nbandkq, nbandk, nmodes, nk)
+        ep_kq_all
+    else
+        # Large nw²·nmodes: cuBLAS strided-batched is efficient; use the generic two-GEMM method.
+        invoke(ElectronPhonon.eph_apply_rotations_rqkq!,
+               Tuple{AbstractArray{Complex{T},4}, Any, Any, Any, Any, Any},
+               ep_kq_all, g, uks, ukqs, tmp, uk_rep)
+    end
+end
+
 # ---- device-resident scatter (calculator keeps g2/ωq on the device, no host streaming) --------
 #
 # One thread per (m,n,ν,j) entry: look up i = imap_i_col[n], f = imap_f[m, ikqs[j]]; if both

--- a/src/band_states.jl
+++ b/src/band_states.jl
@@ -111,7 +111,7 @@ end
 # Build a device `(nw, nk)` integer index map addressable by PHYSICAL band: row `iband` ∈ 1:nw holds
 # the flattened state index for `(iband, ik)`, and 0 where that band is absent / out of the energy
 # window. `nw` is the full (Wannier) band count — the band axis the e-ph matrix `ep_kq` is indexed by
-# — so a device kernel can look a state up directly from its physical band index. `proto` is a device
+# — so a device kernel can look a state up directly from its physical band index. `gpu_array` is a device
 # array used only as a `similar` prototype. (`s.indmap` is stored band-offset by `nband_ignore`; this
 # places its rows at their physical-band positions `nband_ignore+1 : nband_ignore+nband`.)
 #
@@ -123,10 +123,10 @@ end
 #     (the k side IS projected to nbandk). It could be stored as just `nbandk` rows by baking each k's
 #     `ibandk_offset` into its column, but this Int map is tiny next to the streamed Sᵢ (GBs), so both
 #     maps share the one physical-band (nw) layout and the k side simply offsets at read time.
-function _indmap_to_device(proto, s::BandStates, nw::Integer)
+function _indmap_to_device(gpu_array, s::BandStates, nw::Integer)
     host = zeros(Int, nw, s.kpts.n)
     @views host[s.nband_ignore+1 : s.nband_ignore+s.nband, :] .= s.indmap
-    copyto!(similar(proto, Int, nw, s.kpts.n), host)
+    copyto!(similar(gpu_array, Int, nw, s.kpts.n), host)
 end
 
 """

--- a/src/boltzmann/boltzmann_calculator.jl
+++ b/src/boltzmann/boltzmann_calculator.jl
@@ -211,7 +211,7 @@ end
 # --- GPU batched path -----------------------------------------------------------------------
 
 # GPU (batched) path: called by the GPU e-ph loop once per outer-k batch, before its k iterations.
-# `proto` is a device array (the e-ph matrix) used as the allocation prototype. On the first batch it
+# `gpu_array` is a device array (the e-ph matrix) used as the allocation prototype. On the first batch it
 # also builds the run's one-time device buffers (they need a device array, which `setup_calculator!`
 # does not have); every batch it (re)points/zeros the Sᵢ tile.
 #
@@ -219,22 +219,22 @@ end
 # array type) so the one-time device init below can move into setup_calculator! and out of this
 # per-batch hook entirely.
 function ElectronPhonon.setup_calculator_outer_batch!(calc::BoltzmannCalculator{FT};
-        kstart, kend, proto, kwargs...) where {FT}
+        kstart, kend, gpu_array, kwargs...) where {FT}
     calc.use_gpu || error("setup_calculator_outer_batch! is a GPU-only hook")
     n_i, n_f, nT = calc.el_i.n, calc.el_f.n, length(calc.occ)
 
     # One-time device copies, built on the first batch and reused across all k in the run. `nw` (the
     # full Wannier band count, from setup) sizes the physical-band index maps; see `_indmap_to_device`.
     if calc.imap_i_dev === nothing
-        calc.imap_i_dev = _indmap_to_device(proto, calc.el_i, calc.nw)
-        calc.imap_f_dev = _indmap_to_device(proto, calc.el_f, calc.nw)
-        calc.e_i_dev = copyto!(similar(proto, FT, n_i), calc.el_i.es)
-        calc.e_f_dev = copyto!(similar(proto, FT, n_f), calc.el_f.es)
-        calc.wq_dev  = copyto!(similar(proto, FT, calc.el_f.kpts.n), calc.el_f.kpts.weights)
-        calc.μ_dev = copyto!(similar(proto, FT, nT), collect(FT, calc.occ.μlist))
-        calc.T_dev = copyto!(similar(proto, FT, nT), collect(FT, calc.occ.Tlist))
-        calc.η_dev = copyto!(similar(proto, FT, nT), FT[s[2] for s in calc.smearing])
-        calc.Sₒ_dev = fill!(similar(proto, FT, n_i, nT), zero(FT))   # small, device-resident
+        calc.imap_i_dev = _indmap_to_device(gpu_array, calc.el_i, calc.nw)
+        calc.imap_f_dev = _indmap_to_device(gpu_array, calc.el_f, calc.nw)
+        calc.e_i_dev = copyto!(similar(gpu_array, FT, n_i), calc.el_i.es)
+        calc.e_f_dev = copyto!(similar(gpu_array, FT, n_f), calc.el_f.es)
+        calc.wq_dev  = copyto!(similar(gpu_array, FT, calc.el_f.kpts.n), calc.el_f.kpts.weights)
+        calc.μ_dev = copyto!(similar(gpu_array, FT, nT), collect(FT, calc.occ.μlist))
+        calc.T_dev = copyto!(similar(gpu_array, FT, nT), collect(FT, calc.occ.Tlist))
+        calc.η_dev = copyto!(similar(gpu_array, FT, nT), FT[s[2] for s in calc.smearing])
+        calc.Sₒ_dev = fill!(similar(gpu_array, FT, n_i, nT), zero(FT))   # small, device-resident
     end
 
     # Sᵢ tile for this batch (re-sized/zeroed every batch — Sᵢ is streamed per tile).
@@ -242,7 +242,7 @@ function ElectronPhonon.setup_calculator_outer_batch!(calc::BoltzmannCalculator{
     calc.tile_i0 = first(rng) - 1; calc.tile_ni = length(rng)
     ni = calc.tile_ni
     if calc.Sᵢ_tile_dev === nothing || size(calc.Sᵢ_tile_dev, 1) < ni
-        calc.Sᵢ_tile_dev = similar(proto, FT, ni, n_f, nT)
+        calc.Sᵢ_tile_dev = similar(gpu_array, FT, ni, n_f, nT)
         calc.Sᵢ_tile_host = Array{FT, 3}(undef, ni, n_f, nT)
     end
     fill!(view(calc.Sᵢ_tile_dev, 1:ni, :, :), zero(FT))

--- a/src/boltzmann/boltzmann_calculator.jl
+++ b/src/boltzmann/boltzmann_calculator.jl
@@ -5,7 +5,7 @@
 #
 # One calculator, both backends: the same calculator instance is used on CPU or GPU — the backend is
 # chosen by `run_eph_over_k_and_kq`'s `use_gpu`, which dispatches to `run_calculator!` (host loop,
-# per (ik,iq,ikq)) or `run_calculator_batched!` (device, per k-batch). Both fold the identical
+# per (ik,iq,ikq)) or `run_calculator_outer_k_batched!` (device, per k-batch). Both fold the identical
 # `bte_scattering_increments`, so they compute the same scattering (to round-off); the CPU path also
 # serves as the validation reference for the GPU path.
 #
@@ -51,7 +51,7 @@ Base.@kwdef mutable struct BoltzmannCalculator{FT} <: AbstractCalculator
     # device index maps built in setup_calculator_outer_batch!. (0 = not set yet.)
     nw::Int = 0
     # Backend selected by run_eph_over_k_and_kq (set at setup): false = CPU (run_calculator!),
-    # true = GPU (run_calculator_batched!). Each per-path hook errors if called on the wrong backend.
+    # true = GPU (run_calculator_outer_k_batched!). Each per-path hook errors if called on the wrong backend.
     use_gpu::Bool = false
 
     # --- State (BandStates) --- the (iband, ik) → state reverse map is `el_*.indmap` (via state_index)
@@ -89,7 +89,7 @@ Base.@kwdef mutable struct BoltzmannCalculator{FT} <: AbstractCalculator
 end
 
 ElectronPhonon.allow_eph_outer_k(::BoltzmannCalculator) = true
-ElectronPhonon.allow_eph_batched(::BoltzmannCalculator) = true
+ElectronPhonon.allow_eph_outer_k_batched(::BoltzmannCalculator) = true
 
 function ElectronPhonon.setup_calculator!(calc::BoltzmannCalculator{FT}, kpts, qpts, el_states;
         el_states_kq, kqpts, nelec_below_window_k, nelec_below_window_kq, nchunks_threads, rng_band,
@@ -270,7 +270,7 @@ end
 
 Accumulate the BTE scattering-out (Sₒ) and scattering-in (Sᵢ) contributions of one e-ph chunk into
 the (in-energy-window) device buffers — the transport analogue of `eph_window_scatter!`, and the
-device-resident work of `run_calculator_batched!` (its sole caller, so it lives here). For every
+device-resident work of `run_calculator_outer_k_batched!` (its sole caller, so it lives here). For every
 `(m, n, j)` of the chunk look up the outer/inner states `i = imap_i_at_k[n]`,
 `f = imap_f[m, ikqs[j]]` (skip if either is out-of-window, `== 0`), then for each temperature
 `iocc` sum the shared per-mode physics (`bte_scattering_increments`) over the `nmodes` phonon modes
@@ -316,16 +316,16 @@ function bte_window_accumulate!(Sₒ_out, Sᵢ_out, g2vals, ωqmat, imap_i_at_k,
     nothing
 end
 
-function ElectronPhonon.run_calculator_batched!(calc::BoltzmannCalculator{FT},
+function ElectronPhonon.run_calculator_outer_k_batched!(calc::BoltzmannCalculator{FT},
         ep_kq, ωq, ik, ikqs; g2=nothing, ibandk_offset=0) where {FT}
-    calc.use_gpu || error("run_calculator_batched! is a GPU-only hook")
+    calc.use_gpu || error("run_calculator_outer_k_batched! is a GPU-only hook")
     nbandkq, nbandk, nmodes, nqc = size(ep_kq)
     nT = length(calc.occ)
     # Device buffers (imap/energies/Sₒ) were built once in setup_calculator_outer_batch!.
 
     # The loop always folds g2 = |ep|²/(2ω) in get_eph_kR_to_kq_batched! and passes it here, so g2 is
     # never nothing at the call site; require it rather than recomputing.
-    g2 === nothing && error("run_calculator_batched!(BoltzmannCalculator) requires g2 from the loop")
+    g2 === nothing && error("run_calculator_outer_k_batched!(BoltzmannCalculator) requires g2 from the loop")
     g2vals = g2
     # k-side window projection: ep_kq's band-n axis covers nbandk bands starting at physical band
     # ibandk_offset+1, so shift into the physical-band imap_i by that offset (full-band runs have
@@ -345,7 +345,7 @@ function ElectronPhonon.postprocess_calculator!(calc::BoltzmannCalculator{FT}; k
     # GPU path: Sₒ is kept device-resident, so stream it to the host here. (Sᵢ was already streamed
     # one tile per outer-k batch in flush_calculator_outer_batch!.) The `!== nothing` guard covers
     # the no-batch corner: if this rank owns no outer k (empty MPI slice / empty window)
-    # run_calculator_batched! never ran, so Sₒ_dev is still unset.
+    # run_calculator_outer_k_batched! never ran, so Sₒ_dev is still unset.
     if calc.Sₒ_dev !== nothing
         Sₒ_host = Array(calc.Sₒ_dev)        # (n_i, nT)
         @inbounds for iT in 1:length(calc.occ)

--- a/src/boltzmann/covariant_derivative.jl
+++ b/src/boltzmann/covariant_derivative.jl
@@ -155,7 +155,7 @@ function compute_covariant_derivative_matrix(el_irr::QMEStates{FT}, el_irr_state
         # is on the full k grid. ik_to_ikirr_isym is the mapping from the full grid to the
         # irreducible grid.
 
-        el_sym_itp = get_interpolator.(el_sym.operators; fourier_mode)
+        itp_el_sym = get_interpolator.(el_sym.operators; fourier_mode)
 
         # Compute symmetry gauge matrix. For Sk = S_isym * k, the eigenstate at Sk is
         # U(Sk) = S_isym(k) * U(k). (Here, k is a point in the irreducible grid.)
@@ -165,7 +165,7 @@ function compute_covariant_derivative_matrix(el_irr::QMEStates{FT}, el_irr_state
             xk = el_irr.kpts.vectors[ikirr]
             is_tr = el_sym.symmetry[isym].is_tr
             # TODO: Optimize by skipping if symop is identity
-            get_symmetry_representation_wannier!(smat_all[:, :, ik], el_sym_itp[isym], xk, is_tr)
+            get_symmetry_representation_wannier!(smat_all[:, :, ik], itp_el_sym[isym], xk, is_tr)
         end
     end
 

--- a/src/boltzmann/run_coherence.jl
+++ b/src/boltzmann/run_coherence.jl
@@ -199,7 +199,7 @@ function compute_electron_phonon_bte_data_coherence(model, btedata_prefix, windo
         # Write symmetry object to file
         g = create_group(fid_btedata, "gauge/symmetry")
         dump_BTData(g, symmetry)
-        el_sym_itp = get_interpolator.(model.el_sym.operators; fourier_mode)
+        itp_el_sym = get_interpolator.(model.el_sym.operators; fourier_mode)
 
         for (isym, symop) in enumerate(symmetry)
             # Find symmetry in model.el_sym
@@ -220,7 +220,7 @@ function compute_electron_phonon_bte_data_coherence(model, btedata_prefix, windo
 
                 # Compute symmetry gauge matrix: S_H = U†(Sk) * S_W * U(k) = <u(Sk)|S|u(k)>
                 compute_symmetry_representation!(gauge[el_sk.rng, el_k.rng, ik], el_k, el_sk,
-                xk, el_sym_itp[isym_el], symop.is_tr)
+                xk, itp_el_sym[isym_el], symop.is_tr)
                 # FIXME: Perform SVD to make gauge completely unitary
 
                 # Set is_degenerate. Use more loose tolerance because symmetry can be slightly
@@ -276,7 +276,7 @@ function compute_electron_phonon_bte_data_coherence(model, btedata_prefix, windo
 
                 # Compute symmetry gauge matrix: S_H = U†(Sk) * S_W * U(k) = <u(k)|S|u(k)>
                 compute_symmetry_representation!(gauge_list[el_k.rng, el_k.rng, icount], el_k, el_k,
-                    xk, el_sym_itp[isym_el], symop.is_tr)
+                    xk, itp_el_sym[isym_el], symop.is_tr)
                 # FIXME: Perform SVD to make gauge completely unitary
             end
 

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -43,9 +43,9 @@ end
 
 # Called once per outer-loop iteration, before the multithreaded / batched inner loop: `ik` on the
 # outer-k loops, `iq` on the outer-q loop. On the GPU outer-q path it also brackets the per-q device
-# accumulator — it receives `proto` (the e-ph matrix device backend) and `k_chunk_size` so a batched
-# calculator can lazily allocate + zero its per-q device buffer here, with the matching device→host
-# scatter in `postprocess_calculator_inner!` at the end of the q.
+# accumulator — it receives `gpu_array` (a device array on the e-ph matrix backend) and `nk_batch_max`
+# so a batched calculator can lazily allocate + zero its per-q device buffer here, with the matching
+# device→host scatter in `postprocess_calculator_inner!` at the end of the q.
 function setup_calculator_inner!(::AbstractCalculator; kwargs...)
     error("setup_calculator_inner! has to be implemented")
 end

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -172,7 +172,7 @@ end
 # calculator keeps only the CURRENT batch's output on the device and copies it to the host each batch.
 # `setup_calculator_outer_batch!` (re)points/zeros the batch-sized device buffer at the start of a
 # batch; `flush_calculator_outer_batch!` copies it to the host at the batch's end. Both are no-ops by
-# default — a calculator that holds its whole output ignores them. `proto` is a device array (the e-ph
+# default — a calculator that holds its whole output ignores them. `gpu_array` is a device array (the e-ph
 # matrix backend) for buffer allocation; `kstart`/`kend` are the batch's outer-k range.
 setup_calculator_outer_batch!(::AbstractCalculator; kwargs...) = nothing
 flush_calculator_outer_batch!(::AbstractCalculator; kwargs...) = nothing

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -41,6 +41,11 @@ function setup_calculator!(::AbstractCalculator, kpts, qpts, el_states; kwargs..
     error("setup_calculator! has to be implemented")
 end
 
+# Called once per outer-loop iteration, before the multithreaded / batched inner loop: `ik` on the
+# outer-k loops, `iq` on the outer-q loop. On the GPU outer-q path it also brackets the per-q device
+# accumulator — it receives `proto` (the e-ph matrix device backend) and `k_chunk_size` so a batched
+# calculator can lazily allocate + zero its per-q device buffer here, with the matching device→host
+# scatter in `postprocess_calculator_inner!` at the end of the q.
 function setup_calculator_inner!(::AbstractCalculator; kwargs...)
     error("setup_calculator_inner! has to be implemented")
 end
@@ -49,25 +54,29 @@ function run_calculator!(::AbstractCalculator, epdata, ik, iq, ikq; kwargs...)
     error("run_calculator! has to be implemented")
 end
 
-"""
-    allow_eph_batched(calc::AbstractCalculator) -> Bool
-
-Whether the calculator implements the batched device hook [`run_calculator_batched!`] used by
-the GPU loop (`run_eph_over_k_and_kq` with `use_gpu = true`). When every calculator in a run
-returns `true`, the GPU loop keeps the e-ph matrix for a whole `(k, {k+q})` batch on the
-device and calls `run_calculator_batched!` once per batch — skipping the per-`(k,q)` host
-`run_calculator!` callback and the device→host copy of the complex e-ph matrix. The default
-opts out, so calculators keep using the host `run_calculator!` path.
-"""
-allow_eph_batched(::AbstractCalculator) = false
+# The two GPU batched-calculator hooks are named for which momentum is the OUTER loop and which is
+# batched on the INNER axis:
+#   * `*_outer_k_batched*`  — the outer-k loop `run_eph_over_k_and_kq` (outer k, inner k+q batched)
+#   * `*_outer_q_batched*`  — the outer-q loop `run_eph_outer_q`        (outer q, inner k   batched)
 
 """
-    run_calculator_batched!(calc, ep_kq, ωq, ik, ikqs; g2=nothing, ibandk_offset=0, kwargs...)
+    allow_eph_outer_k_batched(calc::AbstractCalculator) -> Bool
 
-Batched hook invoked by `run_eph_over_k_and_kq` when `use_gpu = true`. That loop is an outer-k
-loop with the inner k+q points batched, so this is called once per outer k-point `ik` with all
-of that k's k+q points at once (the outer-q loop `run_eph_outer_q` has no batched hook). Consume
-the e-ph matrix for the list of k+q points:
+Whether the calculator implements the batched device hook [`run_calculator_outer_k_batched!`] used
+by the GPU outer-k loop (`run_eph_over_k_and_kq` with `use_gpu = true`) — outer k, inner k+q
+batched. When every calculator in a run returns `true`, the GPU loop keeps the e-ph matrix for a
+whole `(k, {k+q})` batch on the device and calls `run_calculator_outer_k_batched!` once per batch —
+skipping the per-`(k,q)` host `run_calculator!` callback and the device→host copy of the complex
+e-ph matrix. The default opts out, so calculators keep using the host `run_calculator!` path.
+"""
+allow_eph_outer_k_batched(::AbstractCalculator) = false
+
+"""
+    run_calculator_outer_k_batched!(calc, ep_kq, ωq, ik, ikqs; g2=nothing, ibandk_offset=0, kwargs...)
+
+Batched hook invoked by `run_eph_over_k_and_kq` when `use_gpu = true` (outer k, inner k+q batched),
+called once per outer k-point `ik` with all of that k's k+q points at once. Consume the e-ph matrix
+for the list of k+q points:
 - `ep_kq` :: `(nbandkq, nbandk, nmodes, nq)` — eigenbasis e-ph matrix (the raw matrix elements).
 - `ωq`    :: `(nmodes, nq)` — phonon frequencies for each q in the batch.
 - `ik`    :: outer k-point index.
@@ -87,29 +96,24 @@ Runs on the backend of `ep_kq` (CPU or GPU); implementations should stay backend
 (`similar`, `copyto!`, broadcasting, scatter assignment) so no CUDA dependency leaks into the
 calculator.
 """
-function run_calculator_batched!(::AbstractCalculator, ep_kq, ωq, ik, ikqs; kwargs...)
-    error("run_calculator_batched! has to be implemented (or set allow_eph_batched = false)")
+function run_calculator_outer_k_batched!(::AbstractCalculator, ep_kq, ωq, ik, ikqs; kwargs...)
+    error("run_calculator_outer_k_batched! has to be implemented (or set allow_eph_outer_k_batched = false)")
 end
 
 """
-    allow_eph_batched_q(calc::AbstractCalculator) -> Bool
+    allow_eph_outer_q_batched(calc::AbstractCalculator) -> Bool
 
-Whether the calculator implements the batched device hook [`run_calculator_batched_q!`] used by
-the GPU outer-q loop (`run_eph_outer_q` with `use_gpu = true`). When every calculator in a run
-returns `true`, the GPU loop keeps the e-ph matrix for a whole `(q, {k-chunk})` on the device and
-calls `run_calculator_batched_q!` once per k-chunk — skipping the per-`(k,q)` host `run_calculator!`
-callback and the device→host copy of the e-ph matrix. The default opts out, so calculators keep
-using the host `run_calculator!` path. This is the outer-q sibling of [`allow_eph_batched`].
-
-Contract note: on the batched-q GPU path the k-side `ElectronState`s (the `el_states` passed to
-`setup_calculator!`) carry **eigenvalue and eigenvector only** — velocity and position are not
-computed, so their setup interpolation is skipped. A calculator whose `setup_calculator!` needs
-velocities or positions must not opt in.
+Whether the calculator implements the batched device hook [`run_calculator_outer_q_batched!`] used
+by the GPU outer-q loop (`run_eph_outer_q` with `use_gpu = true`) — outer q, inner k batched. When
+every calculator in a run returns `true`, the GPU loop keeps the e-ph matrix for a whole
+`(q, {k-chunk})` on the device and calls `run_calculator_outer_q_batched!` once per k-chunk —
+skipping the per-`(k,q)` host `run_calculator!` callback and the device→host copy of the e-ph
+matrix. The default opts out. This is the outer-q sibling of [`allow_eph_outer_k_batched`].
 """
-allow_eph_batched_q(::AbstractCalculator) = false
+allow_eph_outer_q_batched(::AbstractCalculator) = false
 
 """
-    run_calculator_batched_q!(calc, ep_kq, e_k, e_kq, uk, ukq, wtk, xks, iq; kwargs...)
+    run_calculator_outer_q_batched!(calc, ep_kq, e_k, e_kq, uk, ukq, wtk, xks, iq; kwargs...)
 
 Batched device hook for the GPU outer-q loop. For a fixed phonon momentum `q` (index `iq`),
 consume the e-ph matrix and electron states for a chunk of outer k-points at once:
@@ -125,46 +129,33 @@ consume the e-ph matrix and electron states for a chunk of outer k-points at onc
 - `xks`  :: `(nkc,)` — the chunk's k-vectors (host `Vec3` list), for any k-dependent phase factor.
 - `iq`   :: q-point index.
 
-The per-q lifecycle is bracketed by [`setup_calculator_batched_q!`] (device buffer alloc / zero at
-q start) and [`flush_calculator_batched_q!`] (device→host scatter at q end). Runs on the backend of
-`ep_kq`; implementations should stay backend-generic (`similar`, `copyto!`, broadcasting, `mul!`) so
-no CUDA dependency leaks into the calculator.
-
-Contract note: batched-q calculators receive k-side `ElectronState`s with eigenvalue/eigenvector
-only (see [`allow_eph_batched_q`](@ref)); everything a `run_calculator_batched_q!` implementation
-consumes is in the device arguments above.
+The per-q lifecycle is bracketed by the generic [`setup_calculator_inner!`] (device buffer alloc /
+zero at q start) and [`postprocess_calculator_inner!`] (device→host scatter at q end), the same
+hooks the CPU loop uses per q. Runs on the backend of `ep_kq`; implementations should stay
+backend-generic (`similar`, `copyto!`, broadcasting, `mul!`) so no CUDA dependency leaks into the
+calculator.
 
 Memory note: implementations typically preallocate device scratch sized `(…, k_chunk)`, which also
 scales with calculator-internal factors (number of frequencies, temperatures, stacked channels).
-Declare that per-k footprint via [`eph_batched_q_bytes_per_k`](@ref) so the loop's memory-adaptive
-chunk sizing accounts for it; otherwise a large `k_chunk_size` can exhaust device memory through
-the calculator's scratch alone.
+Declare that per-k footprint via [`eph_outer_q_batched_bytes_per_k`](@ref) so the loop's
+memory-adaptive chunk sizing accounts for it; otherwise a large `k_chunk_size` can exhaust device
+memory through the calculator's scratch alone.
 """
-function run_calculator_batched_q!(::AbstractCalculator, ep_kq, e_k, e_kq, uk, ukq, wtk, xks, iq; kwargs...)
-    error("run_calculator_batched_q! has to be implemented (or set allow_eph_batched_q = false)")
+function run_calculator_outer_q_batched!(::AbstractCalculator, ep_kq, e_k, e_kq, uk, ukq, wtk, xks, iq; kwargs...)
+    error("run_calculator_outer_q_batched! has to be implemented (or set allow_eph_outer_q_batched = false)")
 end
 
 """
-    eph_batched_q_bytes_per_k(calc::AbstractCalculator; nw, nmodes) -> Int
+    eph_outer_q_batched_bytes_per_k(calc::AbstractCalculator; nw, nmodes) -> Int
 
-Device bytes of per-k-point scratch that the calculator's [`run_calculator_batched_q!`](@ref) path
-holds for a k-chunk (its workspace arrays sized `(…, k_chunk)`, divided by the chunk width). The
-GPU outer-q loop sums this over the calculators and combines it with its own per-k staging cost to
-derive a memory-adaptive chunk width from `device_free_bytes`. Default `0`: the calculator declares
-no per-k device scratch (the loop then budgets only its own buffers — override this if the
-calculator allocates chunk-sized device arrays, or its scratch is not accounted for and a large
-chunk can exhaust device memory).
+Device bytes of per-k-point scratch that the calculator's [`run_calculator_outer_q_batched!`](@ref)
+path holds for a k-chunk (its workspace arrays sized `(…, k_chunk)`, divided by the chunk width).
+The GPU outer-q loop sums this over the calculators and combines it with its own per-k staging cost
+to derive a memory-adaptive chunk width from `device_free_bytes`. Default `0`: the calculator
+declares no per-k device scratch (the loop then budgets only its own buffers — override this if the
+calculator allocates chunk-sized device arrays, or a large chunk can exhaust device memory).
 """
-eph_batched_q_bytes_per_k(::AbstractCalculator; nw, nmodes, kwargs...) = 0
-
-# Per-q lifecycle hooks for the batched GPU outer-q loop (`run_eph_outer_q`, use_gpu), siblings of
-# the outer-k `setup_calculator_tile!`/`flush_calculator_tile!`. `setup_calculator_batched_q!`
-# lazily allocates and zeros the calculator's per-q device accumulator at the start of each q;
-# `flush_calculator_batched_q!` copies it to the host output at the end of q. Both no-ops by
-# default. `proto` is a device array (the e-ph matrix backend) for buffer allocation; `iq` is the
-# q index; `k_chunk_size` is the max k-chunk width (device scratch is sized to it).
-setup_calculator_batched_q!(::AbstractCalculator; kwargs...) = nothing
-flush_calculator_batched_q!(::AbstractCalculator; kwargs...) = nothing
+eph_outer_q_batched_bytes_per_k(::AbstractCalculator; nw, nmodes, kwargs...) = 0
 
 function postprocess_calculator_inner!(::AbstractCalculator; kwargs...)
     error("postprocess_calculator_inner! has to be implemented")

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -91,6 +91,81 @@ function run_calculator_batched!(::AbstractCalculator, ep_kq, ωq, ik, ikqs; kwa
     error("run_calculator_batched! has to be implemented (or set allow_eph_batched = false)")
 end
 
+"""
+    allow_eph_batched_q(calc::AbstractCalculator) -> Bool
+
+Whether the calculator implements the batched device hook [`run_calculator_batched_q!`] used by
+the GPU outer-q loop (`run_eph_outer_q` with `use_gpu = true`). When every calculator in a run
+returns `true`, the GPU loop keeps the e-ph matrix for a whole `(q, {k-chunk})` on the device and
+calls `run_calculator_batched_q!` once per k-chunk — skipping the per-`(k,q)` host `run_calculator!`
+callback and the device→host copy of the e-ph matrix. The default opts out, so calculators keep
+using the host `run_calculator!` path. This is the outer-q sibling of [`allow_eph_batched`].
+
+Contract note: on the batched-q GPU path the k-side `ElectronState`s (the `el_states` passed to
+`setup_calculator!`) carry **eigenvalue and eigenvector only** — velocity and position are not
+computed, so their setup interpolation is skipped. A calculator whose `setup_calculator!` needs
+velocities or positions must not opt in.
+"""
+allow_eph_batched_q(::AbstractCalculator) = false
+
+"""
+    run_calculator_batched_q!(calc, ep_kq, e_k, e_kq, uk, ukq, wtk, xks, iq; kwargs...)
+
+Batched device hook for the GPU outer-q loop. For a fixed phonon momentum `q` (index `iq`),
+consume the e-ph matrix and electron states for a chunk of outer k-points at once:
+- `ep_kq` :: `(nw, nw, nmodes, nkc)` — eigenbasis e-ph matrix on the device, index `[m, n, ν, k]`
+  with `m` the k+q band, `n` the k band. Out-of-window bands are already zeroed (the loop
+  window-masks the eigenvector columns on both sides), so out-of-window `(m,n)` contribute 0.
+- `e_k`  :: `(nw, nkc)` — k-side band energies `e_k[n, k]` (device; all `nw` bands).
+- `e_kq` :: `(nw, nkc)` — k+q-side band energies `e_kq[m, k]` (device).
+- `uk`   :: `(nw, nw, nkc)` — k-side eigenvectors `uk[jw, n, k]`, zero-padded outside the window.
+- `ukq`  :: `(nw, nw, nkc)` — k+q-side eigenvectors `ukq[iw, m, k]`, zero-padded outside the window.
+- `wtk`  :: `(nkc,)` — k-point integration weights (device). Padded tail entries are 0, so a
+  calculator may operate on the full (padded) chunk without special-casing the final partial chunk.
+- `xks`  :: `(nkc,)` — the chunk's k-vectors (host `Vec3` list), for any k-dependent phase factor.
+- `iq`   :: q-point index.
+
+The per-q lifecycle is bracketed by [`setup_calculator_batched_q!`] (device buffer alloc / zero at
+q start) and [`flush_calculator_batched_q!`] (device→host scatter at q end). Runs on the backend of
+`ep_kq`; implementations should stay backend-generic (`similar`, `copyto!`, broadcasting, `mul!`) so
+no CUDA dependency leaks into the calculator.
+
+Contract note: batched-q calculators receive k-side `ElectronState`s with eigenvalue/eigenvector
+only (see [`allow_eph_batched_q`](@ref)); everything a `run_calculator_batched_q!` implementation
+consumes is in the device arguments above.
+
+Memory note: implementations typically preallocate device scratch sized `(…, k_chunk)`, which also
+scales with calculator-internal factors (number of frequencies, temperatures, stacked channels).
+Declare that per-k footprint via [`eph_batched_q_bytes_per_k`](@ref) so the loop's memory-adaptive
+chunk sizing accounts for it; otherwise a large `k_chunk_size` can exhaust device memory through
+the calculator's scratch alone.
+"""
+function run_calculator_batched_q!(::AbstractCalculator, ep_kq, e_k, e_kq, uk, ukq, wtk, xks, iq; kwargs...)
+    error("run_calculator_batched_q! has to be implemented (or set allow_eph_batched_q = false)")
+end
+
+"""
+    eph_batched_q_bytes_per_k(calc::AbstractCalculator; nw, nmodes) -> Int
+
+Device bytes of per-k-point scratch that the calculator's [`run_calculator_batched_q!`](@ref) path
+holds for a k-chunk (its workspace arrays sized `(…, k_chunk)`, divided by the chunk width). The
+GPU outer-q loop sums this over the calculators and combines it with its own per-k staging cost to
+derive a memory-adaptive chunk width from `device_free_bytes`. Default `0`: the calculator declares
+no per-k device scratch (the loop then budgets only its own buffers — override this if the
+calculator allocates chunk-sized device arrays, or its scratch is not accounted for and a large
+chunk can exhaust device memory).
+"""
+eph_batched_q_bytes_per_k(::AbstractCalculator; nw, nmodes, kwargs...) = 0
+
+# Per-q lifecycle hooks for the batched GPU outer-q loop (`run_eph_outer_q`, use_gpu), siblings of
+# the outer-k `setup_calculator_tile!`/`flush_calculator_tile!`. `setup_calculator_batched_q!`
+# lazily allocates and zeros the calculator's per-q device accumulator at the start of each q;
+# `flush_calculator_batched_q!` copies it to the host output at the end of q. Both no-ops by
+# default. `proto` is a device array (the e-ph matrix backend) for buffer allocation; `iq` is the
+# q index; `k_chunk_size` is the max k-chunk width (device scratch is sized to it).
+setup_calculator_batched_q!(::AbstractCalculator; kwargs...) = nothing
+flush_calculator_batched_q!(::AbstractCalculator; kwargs...) = nothing
+
 function postprocess_calculator_inner!(::AbstractCalculator; kwargs...)
     error("postprocess_calculator_inner! has to be implemented")
 end

--- a/src/calculator/calculator_utils.jl
+++ b/src/calculator/calculator_utils.jl
@@ -25,7 +25,7 @@ The target `lin` indices are unique across the run (distinct k → distinct i, d
 distinct f), so the writes never collide (no atomics needed). Generic (CPU/fallback) method; the
 CUDA extension provides a one-kernel `CuArray` method.
 
-A helper for downstream device-resident calculators: from their `run_calculator_batched!` hook
+A helper for downstream device-resident calculators: from their `run_calculator_outer_k_batched!` hook
 they call this to scatter each e-ph batch's `g2`/`ωq` into their own window-mapped device
 accumulators. The library itself stays agnostic to any particular calculator.
 

--- a/src/calculator/run_eph_outer_q.jl
+++ b/src/calculator/run_eph_outer_q.jl
@@ -285,7 +285,6 @@ function _loop_eph_outer_q(
     ) where {FT}
 
     (; epdatas, ep_eRpq_obj, ep_eRpqs, epmat, ham_threads, vel_threads) = eph_buffers
-    (; nmodes) = model
     nk = kpts.n
     nq = qpts.n
 
@@ -304,7 +303,7 @@ function _loop_eph_outer_q(
         end
 
         if !skip_eph
-            get_eph_RR_to_Rq_basis!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis, nmodes)
+            get_eph_RR_to_Rq!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis)
         end
 
         # Multithreading setup
@@ -405,7 +404,7 @@ end
 #  calculator hook. The code is backend-generic: it calls only `to_device` and the batched drivers,
 #  so no CUDA code lives here (the device methods live in the CUDA extension).
 #
-#  Per q: interpolate g(R_el, q) on the HOST (`get_eph_RR_to_Rq_basis!`, nq is small), upload it,
+#  Per q: interpolate g(R_el, q) on the HOST (`get_eph_RR_to_Rq!`, nq is small), upload it,
 #  then loop over the outer k points in batches. Each batch: batched k+q eigensolve (window-masked
 #  by zeroing out-of-window eigenvector columns), batched Rq→kq e-ph interpolation, and one call to
 #  `run_calculator_outer_q_batched!`. The per-q device accumulator is bracketed by the generic
@@ -453,7 +452,7 @@ function _loop_eph_outer_q_gpu(
     gpu_array = el_ham_dev.op_r    # device-array prototype for `similar` / `device_free_bytes`
 
     # ----- device clone of the electron-Wannier / phonon-Bloch e-ph object -----
-    # `get_eph_RR_to_Rq_basis!` runs on the HOST per q into `ep_eRpq_obj`; its op_r is then uploaded
+    # `get_eph_RR_to_Rq!` runs on the HOST per q into `ep_eRpq_obj`; its op_r is then uploaded
     # into this device clone. Reusing the clone across q is correct because `get_fourier_batched!`
     # recomputes its phases and reads `parent.op_r` fresh on every call (it never consults `_id`).
     ep_eRpq_obj = eph_buffers.ep_eRpq_obj
@@ -490,6 +489,9 @@ function _loop_eph_outer_q_gpu(
     # the free device memory allows (30% headroom for the batched drivers' recycled temporaries);
     # `nk_batch_max` stays a hard cap (the only control on the CPU backend, where `device_free_bytes`
     # is unbounded).
+    # TODO: make memory management more structured — the per-k byte estimate is hand-counted and
+    #       omits the whole-grid k-side stack; a single helper that owns the device buffers and their
+    #       size accounting (and the k-side streaming fallback) would be more robust.
     use_polar_eph = model.polar_eph.use
 
     bytes_per_k = 16 * nw^2 * (5 * nmodes + 8 + (use_polar_eph ? 1 : 0)) +
@@ -504,8 +506,8 @@ function _loop_eph_outer_q_gpu(
               "($(round(bytes_per_k / 1e3, digits = 1)) kB/k, $(round(free / 1e9, digits = 1)) GB free)"
     end
 
-    el_ham_itp = BatchedWannierInterpolator(el_ham_dev; batch_size = nk_batch_max)
-    ep_eRpq_itp = BatchedWannierInterpolator(ep_eRpq_dev; batch_size = nk_batch_max)
+    itp_el_ham = BatchedWannierInterpolator(el_ham_dev; batch_size = nk_batch_max)
+    itp_ep_eRpq = BatchedWannierInterpolator(ep_eRpq_dev; batch_size = nk_batch_max)
 
     # ----- persistent per-batch device workspace (sized to nk_batch_max) -----
     ep_ws     = RqToKQWorkspace(ep_eRpq_dev.op_r, ndata_eRpq, nw, nw, nmodes, nk_batch_max)
@@ -534,7 +536,7 @@ function _loop_eph_outer_q_gpu(
         ph = ph_save[iq]
 
         # HOST: interpolate g(R_el, q) in the requested phonon basis, then upload to the device clone.
-        get_eph_RR_to_Rq_basis!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis, nmodes)
+        get_eph_RR_to_Rq!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis)
         copyto!(ep_eRpq_dev.op_r, ep_eRpq_obj.op_r)
         use_polar_eph && copyto!(coeffs_dev, ph.eph_dipole_coeff)
 
@@ -574,7 +576,7 @@ function _loop_eph_outer_q_gpu(
             # k+q eigensolve on the device (batched). No gauge fixing needed: χ is gauge-invariant.
             # TODO: `eigen_batched` allocates (E, U) each batch; an in-place variant into ek/Ukq
             #       scratch would remove the per-batch allocation.
-            get_fourier_batched!(Hkq_flat, el_ham_itp, kqs_batch)
+            get_fourier_batched!(Hkq_flat, itp_el_ham, kqs_batch)
             Ekq, Ukq = eigen_batched(reshape(Hkq_flat, nw, nw, nk_batch_max))   # (nw,·), (nw,nw,·)
 
             # k+q window mask: zero eigenvector COLUMNS m outside [wmin, wmax] (Ekq[m,k]). This
@@ -584,7 +586,7 @@ function _loop_eph_outer_q_gpu(
             Ukq_batch .= Ukq .* reshape(mask_kq, 1, nw, nk_batch_max)
 
             # Batched Rq→kq e-ph interpolation: ep_batch[m,n,ν,k] = Ukq(k)' * g(k) * Uk(k).
-            get_eph_Rq_to_kq_batched!(ep_batch, ep_eRpq_itp, ks_batch, Uk_batch, Ukq_batch; ws = ep_ws)
+            get_eph_Rq_to_kq_batched!(ep_batch, itp_ep_eRpq, ks_batch, Uk_batch, Ukq_batch; ws = ep_ws)
 
             use_polar_eph && add_eph_dipole_batched!(ep_batch, coeffs_dev, Ukq_batch, Uk_batch, mmats_batch)
 

--- a/src/calculator/run_eph_outer_q.jl
+++ b/src/calculator/run_eph_outer_q.jl
@@ -39,7 +39,7 @@ function run_eph_outer_q(
         verbosity::Int = 1,
         eph_buffers::Union{Nothing, EphOuterQLoopBuffers} = nothing,
         use_gpu = false,          # Run the inner-k e-ph interpolation + calculator on the GPU
-        k_chunk_size = 1 << 15,   # GPU: number of outer k points processed per batched chunk
+        nk_batch_max = 2^15,      # GPU: max number of outer k points processed per batch
     ) where {FT}
 
     if model.epmat_outer_momentum != "ph"
@@ -93,7 +93,7 @@ function run_eph_outer_q(
             setup.el_k_save, setup.ph_save, setup.eph_buffers;
             calculators, skip_eph, window_kq,
             energy_conservation, screening_params,
-            progress_print_step, eph_phonon_basis, verbosity, k_chunk_size,
+            progress_print_step, eph_phonon_basis, verbosity, nk_batch_max,
         )
     else
         _loop_eph_outer_q(model,
@@ -179,6 +179,8 @@ function _setup_eph_outer_q(
     # GPU outer-q-batched path: the loop consumes only e_full / u_full / rng from el_k_save, so skip
     # the velocity/position interpolation+rotation (the dominant setup cost after the eigensolve).
     # All other paths keep the full quantity list.
+    # TODO: calculators should declare whether they need velocity and/or position, instead of the
+    #       driver hard-coding this for the outer-q-batched path.
     el_k_quantities = (use_gpu && !isempty(calculators) && all(allow_eph_outer_q_batched, calculators)) ?
         ["eigenvalue", "eigenvector"] : ["eigenvalue", "eigenvector", "velocity", "position"]
     if verbosity > 0
@@ -242,16 +244,16 @@ function _setup_eph_outer_q(
 
 
     # Chemical potential is solved inside each calculator's `setup_calculator!` (via
-    # `set_chemical_potential!`), not here. On the GPU path we hand it a device array `proto` so that
-    # solve runs its ncarrier sums on the device (the bisection sweeps all in-window states many
+    # `set_chemical_potential!`), not here. On the GPU path we hand it a device array `gpu_array` so
+    # that solve runs its ncarrier sums on the device (the bisection sweeps all in-window states many
     # times and dominates the setup at dense grids); the generic `compute_ncarrier` broadcast+sum
     # works for every occ_type on the device, so no occ_type is special-cased.
-    proto = use_gpu ? to_device(model.el_ham).op_r : nothing
+    gpu_array = use_gpu ? to_device(model.el_ham).op_r : nothing
 
     setup_calculator!.(calculators, Ref(kpts), Ref(qpts), Ref(el_k_save);
         nw, nmodes, rng_band = iband_min:iband_max,
         el_states_kq = el_kq_save, kqpts, nelec_below_window_k, nelec_below_window_kq,
-        nchunks_threads, verbosity, use_gpu, proto,
+        nchunks_threads, verbosity, use_gpu, gpu_array,
     )
 
     return (;
@@ -302,7 +304,7 @@ function _loop_eph_outer_q(
         end
 
         if !skip_eph
-            _eph_RR_to_Rq_at_q!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis, nmodes)
+            get_eph_RR_to_Rq_basis!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis, nmodes)
         end
 
         # Multithreading setup
@@ -393,30 +395,6 @@ function _loop_eph_outer_q(
 end
 
 
-# Host interpolation of the e-ph matrix in the (electron-Wannier R_el, phonon q) representation at a
-# fixed q, in the requested phonon basis (`:eigenmode` → rotate the modes by `ph.u`; `:cartesian` →
-# identity). Shared by the CPU and GPU outer-q loops (the only per-q host e-ph work). `get_eph_RR_to_Rq!`
-# Fourier-transforms over the phonon lattice vectors R_ph → q, leaving the electron side in Wannier
-# R_el; the result lives in `ep_eRpq_obj`.
-function _eph_RR_to_Rq_at_q!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis::Symbol, nmodes)
-    u_ph_for_eph = eph_phonon_basis == :eigenmode ? ph.u : I(nmodes)
-    get_eph_RR_to_Rq!(ep_eRpq_obj, epmat, xq, u_ph_for_eph)
-end
-
-# Device polar (long-range) e-ph dipole term for a k-chunk — the batched counterpart of the active
-# branch of the CPU `epdata_compute_eph_dipole!` with ϵs ≡ 1 (no screening):
-#   ep[m,n,ν,k] += coeff[ν] · Σ_iw conj(ukq[iw,m,k]) uk[iw,n,k].
-# The zero-padded eigenvector columns make the overlap vanish for out-of-window m or n, matching the
-# CPU's `rng` band loops. `mmat` is (nw, nw, nkc) device scratch. (The CPU quadrupole `coeff_r` block
-# is commented out — a no-op — and so is omitted here.)
-function _add_eph_dipole_batched!(ep, coeff, ukq, uk, mmat)
-    nw, _, nmodes, nkc = size(ep)
-    batched_gemm!('C', 'N', ukq, uk, mmat)   # mmat[m,n,k] = Σ_iw conj(ukq[iw,m,k]) uk[iw,n,k]
-    ep .+= reshape(coeff, 1, 1, nmodes, 1) .* reshape(mmat, nw, nw, 1, nkc)
-    ep
-end
-
-
 # =============================================================================
 #  GPU calculator loop for the outer-q e-ph sweep.
 #
@@ -427,9 +405,9 @@ end
 #  calculator hook. The code is backend-generic: it calls only `to_device` and the batched drivers,
 #  so no CUDA code lives here (the device methods live in the CUDA extension).
 #
-#  Per q: interpolate g(R_el, q) on the HOST (`_eph_RR_to_Rq_at_q!`, nq is small), upload it, then
-#  loop over outer k in chunks. Each chunk: batched k+q eigensolve (window-masked by zeroing
-#  out-of-window eigenvector columns), batched Rq→kq e-ph interpolation, and one call to
+#  Per q: interpolate g(R_el, q) on the HOST (`get_eph_RR_to_Rq_basis!`, nq is small), upload it,
+#  then loop over the outer k points in batches. Each batch: batched k+q eigensolve (window-masked
+#  by zeroing out-of-window eigenvector columns), batched Rq→kq e-ph interpolation, and one call to
 #  `run_calculator_outer_q_batched!`. The per-q device accumulator is bracketed by the generic
 #  `setup_calculator_inner!` / `postprocess_calculator_inner!` hooks, the same ones the CPU loop uses.
 #
@@ -437,12 +415,7 @@ end
 #  energy_conservation = (:None, 0.0), skip_eph = false, and every calculator implements
 #  `allow_eph_outer_q_batched`. Windows are supported via eigenvector-column masking (out-of-window
 #  states contribute exactly 0), so the batched full-band nw×nw shapes stay uniform. Polar models are
-#  supported: `polar_phonon` only affects the HOST phonon setup (`ph_save` from the shared
-#  `_setup_eph_outer_q`, consumed here exactly as by the CPU loop), and the `polar_eph` dipole term
-#  is added on the device per chunk (`_add_eph_dipole_batched!`).
-#
-#  Window masking: the k side uses the host `el_k_save[ik].rng` (its eigenvectors are uploaded once,
-#  zero-padded outside `rng`); the k+q side is masked here from the device eigenvalues `Wkq`.
+#  supported: the `polar_eph` dipole term is added on the device per batch (`add_eph_dipole_batched!`).
 function _loop_eph_outer_q_gpu(
         model       :: Model{FT},
         kpts, qpts,
@@ -456,7 +429,7 @@ function _loop_eph_outer_q_gpu(
         progress_print_step = 20,
         eph_phonon_basis::Symbol = :eigenmode,
         verbosity::Int = 1,
-        k_chunk_size = 1 << 15,
+        nk_batch_max = 2^15,
     ) where {FT}
 
     (; nw, nmodes) = model
@@ -467,23 +440,22 @@ function _loop_eph_outer_q_gpu(
     skip_eph && throw(ArgumentError("use_gpu requires skip_eph = false."))
     energy_conservation === (:None, 0.0) || throw(ArgumentError(
         "use_gpu supports only energy_conservation = (:None, 0.0)."))
-    # screening_params === nothing also guarantees ϵs ≡ 1 in the polar dipole term below (the CPU
-    # loop divides the dipole coefficient by ϵs; with no screening that division is a no-op).
+    # screening_params === nothing also guarantees ϵ ≡ 1 in the polar dipole term below.
     screening_params === nothing || throw(ArgumentError("use_gpu does not support screening_params."))
     (!isempty(calculators) && all(allow_eph_outer_q_batched, calculators)) || throw(ArgumentError(
         "use_gpu (outer-q) requires every calculator to implement allow_eph_outer_q_batched " *
         "(run_calculator_outer_q_batched!). Use the CPU path otherwise."))
 
     # ----- device Hamiltonian for the k+q eigensolve (allocated once) -----
+    # TODO: `_setup_eph_outer_q` already uploads `model.el_ham` for the chemical-potential solve;
+    #       thread that device object through instead of uploading it again here.
     el_ham_dev = to_device(model.el_ham)
-    proto = el_ham_dev.op_r
+    gpu_array = el_ham_dev.op_r    # device-array prototype for `similar` / `device_free_bytes`
 
     # ----- device clone of the electron-Wannier / phonon-Bloch e-ph object -----
-    # `_eph_RR_to_Rq_at_q!` runs on the HOST per q into `ep_eRpq_obj`; its op_r is then uploaded into
-    # this device clone. The per-q `copyto!` into `op_r` is what makes reusing the clone (and its
-    # interpolator) across q correct: `get_fourier_batched!` recomputes its phases and reads
-    # `parent.op_r` fresh on every call (it never consults `_id` — only the non-batched gridopt
-    # interpolators cache against it).
+    # `get_eph_RR_to_Rq_basis!` runs on the HOST per q into `ep_eRpq_obj`; its op_r is then uploaded
+    # into this device clone. Reusing the clone across q is correct because `get_fourier_batched!`
+    # recomputes its phases and reads `parent.op_r` fresh on every call (it never consults `_id`).
     ep_eRpq_obj = eph_buffers.ep_eRpq_obj
     epmat = eph_buffers.epmat
     ep_eRpq_dev = to_device(ep_eRpq_obj)
@@ -491,16 +463,15 @@ function _loop_eph_outer_q_gpu(
     @assert ep_eRpq_dev.ndata == ndata_eRpq
 
     # ----- k-side eigenvectors / energies / weights uploaded ONCE -----
-    # `uk` is zero-padded outside each k's in-window range `rng` (columns outside `rng` are 0), so
-    # the full nw×nw Rq→kq rotation reproduces the CPU's windowed rotation with zeros outside.
-    # Memory ceiling: this whole-grid stack stays device-resident for the entire run —
-    # 16·nw²·nk bytes (nw=3, nk≈1.2M → ~0.2 GB; nw=12 → ~2.8 GB; nw=40 → ~30 GB). For large nw on
-    # dense grids this upload, not the chunk scratch, is the limit; the fallback is to stream the
-    # k side per chunk (upload only the chunk's `uk`, like the outer-k loop's per-tile `uks_host`)
-    # — not implemented here.
-    Uk_all_dev  = similar(proto, Complex{FT}, nw, nw, nk)
-    ek_all_dev  = similar(proto, FT, nw, nk)
-    wtk_all_dev = similar(proto, FT, nk)
+    # `Uk` is zero-padded outside each k's in-window range `rng`, so the full nw×nw Rq→kq rotation
+    # reproduces the CPU's windowed rotation with zeros outside.
+    # TODO: this whole-grid stack (16·nw²·nk bytes) stays device-resident for the entire run and is
+    #       NOT covered by the memory-adaptive batch sizing below — for large nw on a dense grid it,
+    #       not the per-batch scratch, is the memory limit. Stream the k side per batch (upload only
+    #       the batch's `Uk`, like the outer-k loop's per-batch `uks_host`) if it does not fit.
+    Uk_all_dev  = similar(gpu_array, Complex{FT}, nw, nw, nk)
+    ek_all_dev  = similar(gpu_array, FT, nw, nk)
+    wtk_all_dev = similar(gpu_array, FT, nk)
     let Uk_host = zeros(Complex{FT}, nw, nw, nk), ek_host = zeros(FT, nw, nk), wtk_host = zeros(FT, nk)
         for ik in 1:nk
             el = el_k_save[ik]
@@ -513,48 +484,45 @@ function _loop_eph_outer_q_gpu(
         copyto!(wtk_all_dev, wtk_host)
     end
 
-    # ----- memory-adaptive k-chunk width -----
-    # Every per-chunk device buffer scales linearly with the chunk width: the loop's own staging
-    # (Rq→kq workspace, ep_chunk, H(k+q) + eigensolve, U/e/wt slices, the two interpolator caches
-    # + phase buffers) plus each calculator's outer-q-batched scratch, declared via
-    # `eph_outer_q_batched_bytes_per_k` (dominant for χ-like calculators: it scales with nω·nocc etc.).
-    # Derive the width from the free device memory AFTER the fixed whole-run uploads above, keeping
-    # 30% headroom for the batched drivers' internal temporaries (eigensolve copy, broadcast
-    # temporaries) recycled by the device memory pool. `k_chunk_size` remains a hard cap (and the
-    # only control on the CPU backend, where `device_free_bytes` is unbounded).
+    # ----- memory-adaptive k-batch size -----
+    # Every per-batch device buffer scales with the batch size: the loop's own staging plus each
+    # calculator's per-k device scratch (`eph_outer_q_batched_bytes_per_k`). Cap the batch at what
+    # the free device memory allows (30% headroom for the batched drivers' recycled temporaries);
+    # `nk_batch_max` stays a hard cap (the only control on the CPU backend, where `device_free_bytes`
+    # is unbounded).
     use_polar_eph = model.polar_eph.use
 
-    bytes_per_k_loop = 16 * nw^2 * (5 * nmodes + 8 + (use_polar_eph ? 1 : 0)) +
-        24 * (length(model.el_ham.irvec) + length(ep_eRpq_obj.irvec))
-    bytes_per_k = bytes_per_k_loop +
+    bytes_per_k = 16 * nw^2 * (5 * nmodes + 8 + (use_polar_eph ? 1 : 0)) +
+        24 * (length(model.el_ham.irvec) + length(ep_eRpq_obj.irvec)) +
         sum(Int[eph_outer_q_batched_bytes_per_k(calc; nw, nmodes) for calc in calculators])
-    free = device_free_bytes(proto)
-    nk_chunk_max_mem = free == typemax(Int) ? nk : max(1, (free ÷ 10 * 7) ÷ bytes_per_k)
-    nk_chunk_max = min(Int(k_chunk_size), nk, nk_chunk_max_mem)
-    if verbosity > 0 && mpi_isroot() && nk_chunk_max < min(Int(k_chunk_size), nk)
-        @info "GPU outer-q: memory-adaptive k-chunk width = $nk_chunk_max " *
+    free = device_free_bytes(gpu_array)
+    nk_batch_mem = free == typemax(Int) ? nk : max(1, (free ÷ 10 * 7) ÷ bytes_per_k)
+    nk_batch_cap = min(Int(nk_batch_max), nk)
+    nk_batch_max = min(nk_batch_cap, nk_batch_mem)
+    if verbosity > 0 && mpi_isroot() && nk_batch_max < nk_batch_cap
+        @info "GPU outer-q: memory-adaptive k-batch size = $nk_batch_max " *
               "($(round(bytes_per_k / 1e3, digits = 1)) kB/k, $(round(free / 1e9, digits = 1)) GB free)"
     end
 
-    el_ham_itp = BatchedWannierInterpolator(el_ham_dev; batch_size = nk_chunk_max)
-    ep_eRpq_itp = BatchedWannierInterpolator(ep_eRpq_dev; batch_size = nk_chunk_max)
+    el_ham_itp = BatchedWannierInterpolator(el_ham_dev; batch_size = nk_batch_max)
+    ep_eRpq_itp = BatchedWannierInterpolator(ep_eRpq_dev; batch_size = nk_batch_max)
 
-    # ----- persistent per-chunk device workspace (sized to nk_chunk_max) -----
-    ep_ws     = RqToKQWorkspace(ep_eRpq_dev.op_r, ndata_eRpq, nw, nw, nmodes, nk_chunk_max)
-    ep_chunk  = similar(proto, Complex{FT}, nw, nw, nmodes, nk_chunk_max)
-    Hkq_flat  = similar(proto, Complex{FT}, nw * nw, nk_chunk_max)
-    Uk_chunk  = similar(proto, Complex{FT}, nw, nw, nk_chunk_max)
-    Ukq_chunk = similar(proto, Complex{FT}, nw, nw, nk_chunk_max)
-    ek_chunk  = similar(proto, FT, nw, nk_chunk_max)
-    wtk_chunk = similar(proto, FT, nk_chunk_max)
-    ks_chunk  = Vector{Vec3{FT}}(undef, nk_chunk_max)
-    kqs_chunk = Vector{Vec3{FT}}(undef, nk_chunk_max)
+    # ----- persistent per-batch device workspace (sized to nk_batch_max) -----
+    ep_ws     = RqToKQWorkspace(ep_eRpq_dev.op_r, ndata_eRpq, nw, nw, nmodes, nk_batch_max)
+    ep_batch  = similar(gpu_array, Complex{FT}, nw, nw, nmodes, nk_batch_max)
+    Hkq_flat  = similar(gpu_array, Complex{FT}, nw * nw, nk_batch_max)
+    Uk_batch  = similar(gpu_array, Complex{FT}, nw, nw, nk_batch_max)
+    Ukq_batch = similar(gpu_array, Complex{FT}, nw, nw, nk_batch_max)
+    ek_batch  = similar(gpu_array, FT, nw, nk_batch_max)
+    wtk_batch = similar(gpu_array, FT, nk_batch_max)
+    ks_batch  = Vector{Vec3{FT}}(undef, nk_batch_max)
+    kqs_batch = Vector{Vec3{FT}}(undef, nk_batch_max)
 
     # ----- polar e-ph dipole (long-range) scratch -----
-    # `coeff = ph.eph_dipole_coeff` is host-precomputed per q by the shared setup in the requested
-    # eph_phonon_basis; `_add_eph_dipole_batched!` applies the term on the device (see that function).
-    mmat_chunk = use_polar_eph ? similar(proto, Complex{FT}, nw, nw, nk_chunk_max) : nothing
-    coeff_dev  = use_polar_eph ? similar(proto, Complex{FT}, nmodes) : nothing
+    # `ph.eph_dipole_coeff` is host-precomputed per q by the shared setup; `add_eph_dipole_batched!`
+    # applies the term on the device.
+    mmats_batch = use_polar_eph ? similar(gpu_array, Complex{FT}, nw, nw, nk_batch_max) : nothing
+    coeffs_dev  = use_polar_eph ? similar(gpu_array, Complex{FT}, nmodes) : nothing
 
     wmin, wmax = window_kq
 
@@ -566,69 +534,71 @@ function _loop_eph_outer_q_gpu(
         ph = ph_save[iq]
 
         # HOST: interpolate g(R_el, q) in the requested phonon basis, then upload to the device clone.
-        _eph_RR_to_Rq_at_q!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis, nmodes)
+        get_eph_RR_to_Rq_basis!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis, nmodes)
         copyto!(ep_eRpq_dev.op_r, ep_eRpq_obj.op_r)
-        use_polar_eph && copyto!(coeff_dev, ph.eph_dipole_coeff)
+        use_polar_eph && copyto!(coeffs_dev, ph.eph_dipole_coeff)
 
         # Per-q calculator begin: allocate (first q) + zero the device accumulator (inner hook, same
-        # as the CPU loop; the GPU path also passes `proto` / `k_chunk_size` for the device buffer).
-        setup_calculator_inner!.(calculators; iq, proto, k_chunk_size = nk_chunk_max)
+        # as the CPU loop; the GPU path also passes `gpu_array` / `nk_batch_max` for the device buffer).
+        setup_calculator_inner!.(calculators; iq, gpu_array, nk_batch_max)
 
-        for kstart in 1:nk_chunk_max:nk
-            kend = min(kstart + nk_chunk_max - 1, nk)
-            iks_chunk = kstart:kend
-            nk_chunk = length(iks_chunk)
+        for kstart in 1:nk_batch_max:nk
+            kend = min(kstart + nk_batch_max - 1, nk)
+            iks_batch = kstart:kend
+            nk_batch = length(iks_batch)
 
             # k / k+q lists (host), tail padded with the last valid vector so the batched Fourier /
             # eigensolve see finite data (their results in the tail are discarded via wtk = 0).
-            for (a, ik) in enumerate(iks_chunk)
-                ks_chunk[a]  = kpts.vectors[ik]
-                kqs_chunk[a] = ks_chunk[a] + xq
+            for (ik_ind, ik) in enumerate(iks_batch)
+                ks_batch[ik_ind]  = kpts.vectors[ik]
+                kqs_batch[ik_ind] = ks_batch[ik_ind] + xq
             end
-            for a in (nk_chunk + 1):nk_chunk_max
-                ks_chunk[a]  = ks_chunk[nk_chunk]
-                kqs_chunk[a] = kqs_chunk[nk_chunk]
+            for ik_ind in (nk_batch + 1):nk_batch_max
+                ks_batch[ik_ind]  = ks_batch[nk_batch]
+                kqs_batch[ik_ind] = kqs_batch[nk_batch]
             end
 
             # k-side data: device→device slice, tail padded. Unlike the outer-k loop (whose padded
             # duplicates are harmless because each state scatters to a unique in-window index), here
             # a padded k column WOULD double-count into the q-summed χ, so its integration weight is
             # zeroed — the calculator multiplies by `wtk`, making the padded columns contribute 0.
-            @views copyto!(Uk_chunk[:, :, 1:nk_chunk], Uk_all_dev[:, :, iks_chunk])
-            @views copyto!(ek_chunk[:, 1:nk_chunk],    ek_all_dev[:, iks_chunk])
-            @views copyto!(wtk_chunk[1:nk_chunk],      wtk_all_dev[iks_chunk])
-            if nk_chunk < nk_chunk_max
-                @views Uk_chunk[:, :, (nk_chunk + 1):nk_chunk_max] .= Uk_chunk[:, :, nk_chunk:nk_chunk]
-                @views ek_chunk[:, (nk_chunk + 1):nk_chunk_max]    .= ek_chunk[:, nk_chunk:nk_chunk]
-                @views wtk_chunk[(nk_chunk + 1):nk_chunk_max]      .= 0
+            @views copyto!(Uk_batch[:, :, 1:nk_batch], Uk_all_dev[:, :, iks_batch])
+            @views copyto!(ek_batch[:, 1:nk_batch],    ek_all_dev[:, iks_batch])
+            @views copyto!(wtk_batch[1:nk_batch],      wtk_all_dev[iks_batch])
+            if nk_batch < nk_batch_max
+                @views Uk_batch[:, :, (nk_batch + 1):nk_batch_max] .= Uk_batch[:, :, nk_batch:nk_batch]
+                @views ek_batch[:, (nk_batch + 1):nk_batch_max]    .= ek_batch[:, nk_batch:nk_batch]
+                @views wtk_batch[(nk_batch + 1):nk_batch_max]      .= 0
             end
 
             # k+q eigensolve on the device (batched). No gauge fixing needed: χ is gauge-invariant.
-            get_fourier_batched!(Hkq_flat, el_ham_itp, kqs_chunk)
-            Wkq, Ukq_raw = eigen_batched(reshape(Hkq_flat, nw, nw, nk_chunk_max))  # (nw,·), (nw,nw,·)
+            # TODO: `eigen_batched` allocates (E, U) each batch; an in-place variant into ek/Ukq
+            #       scratch would remove the per-batch allocation.
+            get_fourier_batched!(Hkq_flat, el_ham_itp, kqs_batch)
+            Ekq, Ukq = eigen_batched(reshape(Hkq_flat, nw, nw, nk_batch_max))   # (nw,·), (nw,nw,·)
 
-            # k+q window mask: zero eigenvector COLUMNS m outside [wmin, wmax] (Wkq[m,k]). This
+            # k+q window mask: zero eigenvector COLUMNS m outside [wmin, wmax] (Ekq[m,k]). This
             # zeroes ep_kq[m,·] and every k+q-side matrix element for out-of-window m, so those
             # (m,n) pairs contribute exactly 0 — reproducing the CPU's `for m in el_kq.rng` loop.
-            maskkq = (Wkq .>= wmin) .& (Wkq .<= wmax)                     # (nw, ·) Bool
-            Ukq_chunk .= Ukq_raw .* reshape(maskkq, 1, nw, nk_chunk_max)
+            mask_kq = (Ekq .>= wmin) .& (Ekq .<= wmax)                    # (nw, ·) Bool
+            Ukq_batch .= Ukq .* reshape(mask_kq, 1, nw, nk_batch_max)
 
-            # Batched Rq→kq e-ph interpolation: ep_chunk[m,n,ν,k] = ukq(k)' * g(k) * uk(k).
-            get_eph_Rq_to_kq_batched!(ep_chunk, ep_eRpq_itp, ks_chunk, Uk_chunk, Ukq_chunk; ws = ep_ws)
+            # Batched Rq→kq e-ph interpolation: ep_batch[m,n,ν,k] = Ukq(k)' * g(k) * Uk(k).
+            get_eph_Rq_to_kq_batched!(ep_batch, ep_eRpq_itp, ks_batch, Uk_batch, Ukq_batch; ws = ep_ws)
 
-            use_polar_eph && _add_eph_dipole_batched!(ep_chunk, coeff_dev, Ukq_chunk, Uk_chunk, mmat_chunk)
+            use_polar_eph && add_eph_dipole_batched!(ep_batch, coeffs_dev, Ukq_batch, Uk_batch, mmats_batch)
 
             for calc in calculators
-                run_calculator_outer_q_batched!(calc, ep_chunk, ek_chunk, Wkq,
-                    Uk_chunk, Ukq_chunk, wtk_chunk, ks_chunk, iq)
+                run_calculator_outer_q_batched!(calc, ep_batch, ek_batch, Ekq,
+                    Uk_batch, Ukq_batch, wtk_batch, ks_batch, iq)
             end
-        end # k chunk
+        end # k batch
 
         # Per-q calculator end: device→host scatter into the per-q output arrays (inner hook).
         postprocess_calculator_inner!.(calculators; iq)
 
         # Bound the host look-ahead to one q so per-q device scratch does not pile up in the pool.
-        device_synchronize(proto)
+        device_synchronize(gpu_array)
     end # iq
 
     postprocess_calculator!.(calculators; qpts, model.symmetry)

--- a/src/calculator/run_eph_outer_q.jl
+++ b/src/calculator/run_eph_outer_q.jl
@@ -176,11 +176,10 @@ function _setup_eph_outer_q(
 
 
     # Compute and save electron state at k.
-    # GPU batched-q path: the loop consumes only e_full / u_full / rng from el_k_save, and
-    # batched-q calculators are (per the run_calculator_batched_q! contract) given k-side states
-    # with eigenvalue/eigenvector only — so skip the velocity/position interpolation+rotation, the
-    # dominant setup cost after the eigensolve. All other paths keep the full quantity list.
-    el_k_quantities = (use_gpu && !isempty(calculators) && all(allow_eph_batched_q, calculators)) ?
+    # GPU outer-q-batched path: the loop consumes only e_full / u_full / rng from el_k_save, so skip
+    # the velocity/position interpolation+rotation (the dominant setup cost after the eigensolve).
+    # All other paths keep the full quantity list.
+    el_k_quantities = (use_gpu && !isempty(calculators) && all(allow_eph_outer_q_batched, calculators)) ?
         ["eigenvalue", "eigenvector"] : ["eigenvalue", "eigenvector", "velocity", "position"]
     if verbosity > 0
         @time el_k_save = compute_electron_states(model, kpts, el_k_quantities, window_k; fourier_mode, use_gpu)
@@ -242,44 +241,17 @@ function _setup_eph_outer_q(
     end
 
 
-    # GPU: pre-solve the chemical potential on the device for calculators whose occ still needs
-    # it. The μ bisection sweeps all in-window states ~60 times; at dense grids it dominates the
-    # setup even with the threaded host reduction (6.5 s of the 7.6 s setup at nk=80 full window).
-    # Upload the flat state energies/weights once and let the existing find_chemical_potential
-    # run its ncarrier sums as device broadcast+sum (the generic compute_ncarrier method; no CUDA
-    # code here). occ.μlist caches the result, so the set_chemical_potential! inside each
-    # calculator's setup_calculator! below then no-ops — calculators are unchanged. Device-safe
-    # subset only: :FermiDirac (exp-based kernel) metals; anything else (e.g. :MV needs
-    # SpecialFunctions.erf, not kernel-safe; the :Semiconductor solve needs host band masks)
-    # silently keeps the existing host path. The device sum order shifts μ at the ~1e-15 level.
-    if use_gpu
-        e_dev = w_dev = el_flat = nothing
-        for calc in calculators
-            hasproperty(calc, :occ) || continue
-            occ = calc.occ
-            occ isa ElectronOccupationParams || continue
-            chemical_potential_is_computed(occ) && continue
-            (occ.occ_type === :FermiDirac && occ.type === :Metal) || continue
-            if el_flat === nothing
-                el_flat, _ = electron_states_to_BTStates(el_k_save, kpts, nelec_below_window_k)
-                proto = to_device(model.el_ham).op_r
-                e_dev = similar(proto, FT, length(el_flat.e));        copyto!(e_dev, el_flat.e)
-                w_dev = similar(proto, FT, length(el_flat.k_weight)); copyto!(w_dev, el_flat.k_weight)
-            end
-            ncarrier_target = @. (occ.nlist + occ.nelec) / occ.spin_degeneracy - el_flat.nstates_base
-            for i in eachindex(occ.Tlist)
-                occ.μlist[i] = find_chemical_potential(ncarrier_target[i], occ.Tlist[i], e_dev, w_dev;
-                                                       occ.occ_type)
-                mpi_isroot() && @info "n = $(occ.nlist[i]) , T = $(round(occ.Tlist[i]/unit_to_aru(:K), digits=1)) K " *
-                    "($(occ.occ_type)) , μ = $(round(occ.μlist[i]/unit_to_aru(:eV), digits=4)) eV (device solve)"
-            end
-        end
-    end
+    # Chemical potential is solved inside each calculator's `setup_calculator!` (via
+    # `set_chemical_potential!`), not here. On the GPU path we hand it a device array `proto` so that
+    # solve runs its ncarrier sums on the device (the bisection sweeps all in-window states many
+    # times and dominates the setup at dense grids); the generic `compute_ncarrier` broadcast+sum
+    # works for every occ_type on the device, so no occ_type is special-cased.
+    proto = use_gpu ? to_device(model.el_ham).op_r : nothing
 
     setup_calculator!.(calculators, Ref(kpts), Ref(qpts), Ref(el_k_save);
         nw, nmodes, rng_band = iband_min:iband_max,
         el_states_kq = el_kq_save, kqpts, nelec_below_window_k, nelec_below_window_kq,
-        nchunks_threads, verbosity,
+        nchunks_threads, verbosity, use_gpu, proto,
     )
 
     return (;
@@ -330,8 +302,7 @@ function _loop_eph_outer_q(
         end
 
         if !skip_eph
-            u_ph_for_eph = (eph_phonon_basis == :eigenmode) ? ph.u : I(nmodes)
-            get_eph_RR_to_Rq!(ep_eRpq_obj, epmat, xq, u_ph_for_eph)
+            _eph_RR_to_Rq_at_q!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis, nmodes)
         end
 
         # Multithreading setup
@@ -422,32 +393,56 @@ function _loop_eph_outer_q(
 end
 
 
+# Host interpolation of the e-ph matrix in the (electron-Wannier R_el, phonon q) representation at a
+# fixed q, in the requested phonon basis (`:eigenmode` → rotate the modes by `ph.u`; `:cartesian` →
+# identity). Shared by the CPU and GPU outer-q loops (the only per-q host e-ph work). `get_eph_RR_to_Rq!`
+# Fourier-transforms over the phonon lattice vectors R_ph → q, leaving the electron side in Wannier
+# R_el; the result lives in `ep_eRpq_obj`.
+function _eph_RR_to_Rq_at_q!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis::Symbol, nmodes)
+    u_ph_for_eph = eph_phonon_basis == :eigenmode ? ph.u : I(nmodes)
+    get_eph_RR_to_Rq!(ep_eRpq_obj, epmat, xq, u_ph_for_eph)
+end
+
+# Device polar (long-range) e-ph dipole term for a k-chunk — the batched counterpart of the active
+# branch of the CPU `epdata_compute_eph_dipole!` with ϵs ≡ 1 (no screening):
+#   ep[m,n,ν,k] += coeff[ν] · Σ_iw conj(ukq[iw,m,k]) uk[iw,n,k].
+# The zero-padded eigenvector columns make the overlap vanish for out-of-window m or n, matching the
+# CPU's `rng` band loops. `mmat` is (nw, nw, nkc) device scratch. (The CPU quadrupole `coeff_r` block
+# is commented out — a no-op — and so is omitted here.)
+function _add_eph_dipole_batched!(ep, coeff, ukq, uk, mmat)
+    nw, _, nmodes, nkc = size(ep)
+    batched_gemm!('C', 'N', ukq, uk, mmat)   # mmat[m,n,k] = Σ_iw conj(ukq[iw,m,k]) uk[iw,n,k]
+    ep .+= reshape(coeff, 1, 1, nmodes, 1) .* reshape(mmat, nw, nw, 1, nkc)
+    ep
+end
+
+
 # =============================================================================
 #  GPU calculator loop for the outer-q e-ph sweep.
 #
 #  Mirrors `_loop_eph_over_k_and_kq_gpu` (run_eph_over_k_and_kq.jl): the shared `_setup_eph_outer_q`
 #  runs on the host, and this loop moves the inner-k work — the e-ph Rq→kq interpolation, the k+q
 #  eigensolve, and the calculator reduction — onto the device via the generic batched drivers
-#  (`get_eph_Rq_to_kq_batched!`, `eigen_batched`, `get_fourier_batched!`) and the batched-q
+#  (`get_eph_Rq_to_kq_batched!`, `eigen_batched`, `get_fourier_batched!`) and the outer-q batched
 #  calculator hook. The code is backend-generic: it calls only `to_device` and the batched drivers,
 #  so no CUDA code lives here (the device methods live in the CUDA extension).
 #
-#  Per q: interpolate g(R_el, q) on the HOST (`get_eph_RR_to_Rq!`, nq is small), upload it, then loop
-#  over outer k in chunks. Each chunk: batched k+q eigensolve (window-masked by zeroing out-of-window
-#  eigenvector columns), batched Rq→kq e-ph interpolation, and one call to `run_calculator_batched_q!`.
+#  Per q: interpolate g(R_el, q) on the HOST (`_eph_RR_to_Rq_at_q!`, nq is small), upload it, then
+#  loop over outer k in chunks. Each chunk: batched k+q eigensolve (window-masked by zeroing
+#  out-of-window eigenvector columns), batched Rq→kq e-ph interpolation, and one call to
+#  `run_calculator_outer_q_batched!`. The per-q device accumulator is bracketed by the generic
+#  `setup_calculator_inner!` / `postprocess_calculator_inner!` hooks, the same ones the CPU loop uses.
 #
 #  Scope (asserted below; the CPU path handles the rest): no screening,
 #  energy_conservation = (:None, 0.0), skip_eph = false, and every calculator implements
-#  `allow_eph_batched_q`. Windows are supported via eigenvector-column masking (out-of-window states
-#  contribute exactly 0), so the batched full-band nw×nw shapes stay uniform. Polar models are
+#  `allow_eph_outer_q_batched`. Windows are supported via eigenvector-column masking (out-of-window
+#  states contribute exactly 0), so the batched full-band nw×nw shapes stay uniform. Polar models are
 #  supported: `polar_phonon` only affects the HOST phonon setup (`ph_save` from the shared
 #  `_setup_eph_outer_q`, consumed here exactly as by the CPU loop), and the `polar_eph` dipole term
-#  is added on the device per chunk (see the `use_polar_eph` block below).
+#  is added on the device per chunk (`_add_eph_dipole_batched!`).
 #
 #  Window masking: the k side uses the host `el_k_save[ik].rng` (its eigenvectors are uploaded once,
-#  zero-padded outside `rng`); the k+q side is masked here from the device eigenvalues `Wkq`. The
-#  final partial k-chunk is padded to `kb` with duplicated (finite) data and its integration weight
-#  set to 0, so the padded columns contribute 0 without any partial-chunk special-casing downstream.
+#  zero-padded outside `rng`); the k+q side is masked here from the device eigenvalues `Wkq`.
 function _loop_eph_outer_q_gpu(
         model       :: Model{FT},
         kpts, qpts,
@@ -475,16 +470,16 @@ function _loop_eph_outer_q_gpu(
     # screening_params === nothing also guarantees ϵs ≡ 1 in the polar dipole term below (the CPU
     # loop divides the dipole coefficient by ϵs; with no screening that division is a no-op).
     screening_params === nothing || throw(ArgumentError("use_gpu does not support screening_params."))
-    (!isempty(calculators) && all(allow_eph_batched_q, calculators)) || throw(ArgumentError(
-        "use_gpu (outer-q) requires every calculator to implement allow_eph_batched_q " *
-        "(run_calculator_batched_q!). Use the CPU path otherwise."))
+    (!isempty(calculators) && all(allow_eph_outer_q_batched, calculators)) || throw(ArgumentError(
+        "use_gpu (outer-q) requires every calculator to implement allow_eph_outer_q_batched " *
+        "(run_calculator_outer_q_batched!). Use the CPU path otherwise."))
 
     # ----- device Hamiltonian for the k+q eigensolve (allocated once) -----
     el_ham_dev = to_device(model.el_ham)
     proto = el_ham_dev.op_r
 
     # ----- device clone of the electron-Wannier / phonon-Bloch e-ph object -----
-    # `get_eph_RR_to_Rq!` runs on the HOST per q into `ep_eRpq_obj`; its op_r is then uploaded into
+    # `_eph_RR_to_Rq_at_q!` runs on the HOST per q into `ep_eRpq_obj`; its op_r is then uploaded into
     # this device clone. The per-q `copyto!` into `op_r` is what makes reusing the clone (and its
     # interpolator) across q correct: `get_fourier_batched!` recomputes its phases and reads
     # `parent.op_r` fresh on every call (it never consults `_id` — only the non-batched gridopt
@@ -521,8 +516,8 @@ function _loop_eph_outer_q_gpu(
     # ----- memory-adaptive k-chunk width -----
     # Every per-chunk device buffer scales linearly with the chunk width: the loop's own staging
     # (Rq→kq workspace, ep_chunk, H(k+q) + eigensolve, U/e/wt slices, the two interpolator caches
-    # + phase buffers) plus each calculator's batched-q scratch, declared via
-    # `eph_batched_q_bytes_per_k` (dominant for χ-like calculators: it scales with nω·nocc etc.).
+    # + phase buffers) plus each calculator's outer-q-batched scratch, declared via
+    # `eph_outer_q_batched_bytes_per_k` (dominant for χ-like calculators: it scales with nω·nocc etc.).
     # Derive the width from the free device memory AFTER the fixed whole-run uploads above, keeping
     # 30% headroom for the batched drivers' internal temporaries (eigensolve copy, broadcast
     # temporaries) recycled by the device memory pool. `k_chunk_size` remains a hard cap (and the
@@ -532,40 +527,34 @@ function _loop_eph_outer_q_gpu(
     bytes_per_k_loop = 16 * nw^2 * (5 * nmodes + 8 + (use_polar_eph ? 1 : 0)) +
         24 * (length(model.el_ham.irvec) + length(ep_eRpq_obj.irvec))
     bytes_per_k = bytes_per_k_loop +
-        sum(Int[eph_batched_q_bytes_per_k(calc; nw, nmodes) for calc in calculators])
+        sum(Int[eph_outer_q_batched_bytes_per_k(calc; nw, nmodes) for calc in calculators])
     free = device_free_bytes(proto)
-    kb_mem = free == typemax(Int) ? nk : max(1, (free ÷ 10 * 7) ÷ bytes_per_k)
-    kb = min(Int(k_chunk_size), nk, kb_mem)
-    if verbosity > 0 && mpi_isroot() && kb < min(Int(k_chunk_size), nk)
-        @info "GPU outer-q: memory-adaptive k-chunk width kb = $kb " *
+    nk_chunk_max_mem = free == typemax(Int) ? nk : max(1, (free ÷ 10 * 7) ÷ bytes_per_k)
+    nk_chunk_max = min(Int(k_chunk_size), nk, nk_chunk_max_mem)
+    if verbosity > 0 && mpi_isroot() && nk_chunk_max < min(Int(k_chunk_size), nk)
+        @info "GPU outer-q: memory-adaptive k-chunk width = $nk_chunk_max " *
               "($(round(bytes_per_k / 1e3, digits = 1)) kB/k, $(round(free / 1e9, digits = 1)) GB free)"
     end
 
-    el_ham_itp = BatchedWannierInterpolator(el_ham_dev; batch_size = kb)
-    ep_eRpq_itp = BatchedWannierInterpolator(ep_eRpq_dev; batch_size = kb)
+    el_ham_itp = BatchedWannierInterpolator(el_ham_dev; batch_size = nk_chunk_max)
+    ep_eRpq_itp = BatchedWannierInterpolator(ep_eRpq_dev; batch_size = nk_chunk_max)
 
-    # ----- persistent per-chunk device workspace (sized to kb) -----
-    ep_ws     = RqToKQWorkspace(ep_eRpq_dev.op_r, ndata_eRpq, nw, nw, nmodes, kb)
-    ep_chunk  = similar(proto, Complex{FT}, nw, nw, nmodes, kb)
-    Hkq_flat  = similar(proto, Complex{FT}, nw * nw, kb)
-    Uk_chunk  = similar(proto, Complex{FT}, nw, nw, kb)
-    Ukq_chunk = similar(proto, Complex{FT}, nw, nw, kb)
-    ek_chunk  = similar(proto, FT, nw, kb)
-    wtk_chunk = similar(proto, FT, kb)
-    xk_chunk  = Vector{Vec3{FT}}(undef, kb)
-    xkq_chunk = Vector{Vec3{FT}}(undef, kb)
+    # ----- persistent per-chunk device workspace (sized to nk_chunk_max) -----
+    ep_ws     = RqToKQWorkspace(ep_eRpq_dev.op_r, ndata_eRpq, nw, nw, nmodes, nk_chunk_max)
+    ep_chunk  = similar(proto, Complex{FT}, nw, nw, nmodes, nk_chunk_max)
+    Hkq_flat  = similar(proto, Complex{FT}, nw * nw, nk_chunk_max)
+    Uk_chunk  = similar(proto, Complex{FT}, nw, nw, nk_chunk_max)
+    Ukq_chunk = similar(proto, Complex{FT}, nw, nw, nk_chunk_max)
+    ek_chunk  = similar(proto, FT, nw, nk_chunk_max)
+    wtk_chunk = similar(proto, FT, nk_chunk_max)
+    ks_chunk  = Vector{Vec3{FT}}(undef, nk_chunk_max)
+    kqs_chunk = Vector{Vec3{FT}}(undef, nk_chunk_max)
 
-    # ----- polar e-ph dipole (long-range) buffers -----
-    # CPU counterpart: `epdata_compute_eph_dipole!(epdata, ϵs; model)` with ϵs ≡ 1 (guaranteed by
-    # the screening_params === nothing assert above), whose active branch adds
-    # `(coeff[ν] / ϵs[ν]) · Σ_iw conj(ukq[iw,m]) uk[iw,n]` to ep[m,n,ν] for in-window (m,n), with
-    # `coeff = ph.eph_dipole_coeff` host-precomputed per q by the shared setup in the requested
-    # eph_phonon_basis. The quadrupole (`coeff_r`) block is commented out on the CPU — a no-op —
-    # and is ported as a no-op here.
-    if use_polar_eph
-        mmat_chunk = similar(proto, Complex{FT}, nw, nw, kb)
-        coeff_dev  = similar(proto, Complex{FT}, nmodes)
-    end
+    # ----- polar e-ph dipole (long-range) scratch -----
+    # `coeff = ph.eph_dipole_coeff` is host-precomputed per q by the shared setup in the requested
+    # eph_phonon_basis; `_add_eph_dipole_batched!` applies the term on the device (see that function).
+    mmat_chunk = use_polar_eph ? similar(proto, Complex{FT}, nw, nw, nk_chunk_max) : nothing
+    coeff_dev  = use_polar_eph ? similar(proto, Complex{FT}, nmodes) : nothing
 
     wmin, wmax = window_kq
 
@@ -577,73 +566,66 @@ function _loop_eph_outer_q_gpu(
         ph = ph_save[iq]
 
         # HOST: interpolate g(R_el, q) in the requested phonon basis, then upload to the device clone.
-        u_ph_for_eph = (eph_phonon_basis == :eigenmode) ? ph.u : Matrix{Complex{FT}}(I, nmodes, nmodes)
-        get_eph_RR_to_Rq!(ep_eRpq_obj, epmat, xq, u_ph_for_eph)
+        _eph_RR_to_Rq_at_q!(ep_eRpq_obj, epmat, xq, ph, eph_phonon_basis, nmodes)
         copyto!(ep_eRpq_dev.op_r, ep_eRpq_obj.op_r)
         use_polar_eph && copyto!(coeff_dev, ph.eph_dipole_coeff)
 
-        # Per-q calculator begin: allocate (first q) + zero the device accumulator.
-        for calc in calculators
-            setup_calculator_batched_q!(calc; iq, proto, k_chunk_size = kb)
-        end
+        # Per-q calculator begin: allocate (first q) + zero the device accumulator (inner hook, same
+        # as the CPU loop; the GPU path also passes `proto` / `k_chunk_size` for the device buffer).
+        setup_calculator_inner!.(calculators; iq, proto, k_chunk_size = nk_chunk_max)
 
-        for kstart in 1:kb:nk
-            kend = min(kstart + kb - 1, nk)
-            nkc = kend - kstart + 1
+        for kstart in 1:nk_chunk_max:nk
+            kend = min(kstart + nk_chunk_max - 1, nk)
+            iks_chunk = kstart:kend
+            nk_chunk = length(iks_chunk)
 
             # k / k+q lists (host), tail padded with the last valid vector so the batched Fourier /
             # eigensolve see finite data (their results in the tail are discarded via wtk = 0).
-            for (a, ik) in enumerate(kstart:kend)
-                xk_chunk[a]  = kpts.vectors[ik]
-                xkq_chunk[a] = xk_chunk[a] + xq
+            for (a, ik) in enumerate(iks_chunk)
+                ks_chunk[a]  = kpts.vectors[ik]
+                kqs_chunk[a] = ks_chunk[a] + xq
             end
-            for a in (nkc + 1):kb
-                xk_chunk[a]  = xk_chunk[nkc]
-                xkq_chunk[a] = xkq_chunk[nkc]
+            for a in (nk_chunk + 1):nk_chunk_max
+                ks_chunk[a]  = ks_chunk[nk_chunk]
+                kqs_chunk[a] = kqs_chunk[nk_chunk]
             end
 
-            # k-side data: device→device slice, tail padded (weights → 0 so padded columns vanish).
-            @views copyto!(Uk_chunk[:, :, 1:nkc], Uk_all_dev[:, :, kstart:kend])
-            @views copyto!(ek_chunk[:, 1:nkc],    ek_all_dev[:, kstart:kend])
-            @views copyto!(wtk_chunk[1:nkc],      wtk_all_dev[kstart:kend])
-            if nkc < kb
-                @views Uk_chunk[:, :, (nkc + 1):kb] .= Uk_chunk[:, :, nkc:nkc]
-                @views ek_chunk[:, (nkc + 1):kb]    .= ek_chunk[:, nkc:nkc]
-                @views wtk_chunk[(nkc + 1):kb]      .= 0
+            # k-side data: device→device slice, tail padded. Unlike the outer-k loop (whose padded
+            # duplicates are harmless because each state scatters to a unique in-window index), here
+            # a padded k column WOULD double-count into the q-summed χ, so its integration weight is
+            # zeroed — the calculator multiplies by `wtk`, making the padded columns contribute 0.
+            @views copyto!(Uk_chunk[:, :, 1:nk_chunk], Uk_all_dev[:, :, iks_chunk])
+            @views copyto!(ek_chunk[:, 1:nk_chunk],    ek_all_dev[:, iks_chunk])
+            @views copyto!(wtk_chunk[1:nk_chunk],      wtk_all_dev[iks_chunk])
+            if nk_chunk < nk_chunk_max
+                @views Uk_chunk[:, :, (nk_chunk + 1):nk_chunk_max] .= Uk_chunk[:, :, nk_chunk:nk_chunk]
+                @views ek_chunk[:, (nk_chunk + 1):nk_chunk_max]    .= ek_chunk[:, nk_chunk:nk_chunk]
+                @views wtk_chunk[(nk_chunk + 1):nk_chunk_max]      .= 0
             end
 
             # k+q eigensolve on the device (batched). No gauge fixing needed: χ is gauge-invariant.
-            get_fourier_batched!(Hkq_flat, el_ham_itp, xkq_chunk)
-            Wkq, Ukq_raw = eigen_batched(reshape(Hkq_flat, nw, nw, kb))   # (nw,kb), (nw,nw,kb)
+            get_fourier_batched!(Hkq_flat, el_ham_itp, kqs_chunk)
+            Wkq, Ukq_raw = eigen_batched(reshape(Hkq_flat, nw, nw, nk_chunk_max))  # (nw,·), (nw,nw,·)
 
             # k+q window mask: zero eigenvector COLUMNS m outside [wmin, wmax] (Wkq[m,k]). This
             # zeroes ep_kq[m,·] and every k+q-side matrix element for out-of-window m, so those
             # (m,n) pairs contribute exactly 0 — reproducing the CPU's `for m in el_kq.rng` loop.
-            maskkq = (Wkq .>= wmin) .& (Wkq .<= wmax)                      # (nw, kb) Bool
-            Ukq_chunk .= Ukq_raw .* reshape(maskkq, 1, nw, kb)
+            maskkq = (Wkq .>= wmin) .& (Wkq .<= wmax)                     # (nw, ·) Bool
+            Ukq_chunk .= Ukq_raw .* reshape(maskkq, 1, nw, nk_chunk_max)
 
             # Batched Rq→kq e-ph interpolation: ep_chunk[m,n,ν,k] = ukq(k)' * g(k) * uk(k).
-            get_eph_Rq_to_kq_batched!(ep_chunk, ep_eRpq_itp, xk_chunk, Uk_chunk, Ukq_chunk; ws = ep_ws)
+            get_eph_Rq_to_kq_batched!(ep_chunk, ep_eRpq_itp, ks_chunk, Uk_chunk, Ukq_chunk; ws = ep_ws)
 
-            if use_polar_eph
-                # Polar dipole term: ep[m,n,ν,k] += coeff[ν] · mmat[m,n,k] with the overlap
-                # mmat[m,n,k] = Σ_iw conj(Ukq[iw,m,k]) Uk[iw,n,k]. The zero-padded eigenvector
-                # columns make mmat vanish for out-of-window m or n, matching the CPU rng loops
-                # (ϵs ≡ 1, so no division; see the buffer comment above).
-                batched_gemm!('C', 'N', Ukq_chunk, Uk_chunk, mmat_chunk)
-                ep_chunk .+= reshape(coeff_dev, 1, 1, nmodes) .* reshape(mmat_chunk, nw, nw, 1, kb)
-            end
+            use_polar_eph && _add_eph_dipole_batched!(ep_chunk, coeff_dev, Ukq_chunk, Uk_chunk, mmat_chunk)
 
             for calc in calculators
-                run_calculator_batched_q!(calc, ep_chunk, ek_chunk, Wkq,
-                    Uk_chunk, Ukq_chunk, wtk_chunk, xk_chunk, iq)
+                run_calculator_outer_q_batched!(calc, ep_chunk, ek_chunk, Wkq,
+                    Uk_chunk, Ukq_chunk, wtk_chunk, ks_chunk, iq)
             end
         end # k chunk
 
-        # Per-q calculator end: device→host scatter into the per-q output arrays.
-        for calc in calculators
-            flush_calculator_batched_q!(calc; iq)
-        end
+        # Per-q calculator end: device→host scatter into the per-q output arrays (inner hook).
+        postprocess_calculator_inner!.(calculators; iq)
 
         # Bound the host look-ahead to one q so per-q device scratch does not pile up in the pool.
         device_synchronize(proto)

--- a/src/calculator/run_eph_outer_q.jl
+++ b/src/calculator/run_eph_outer_q.jl
@@ -38,6 +38,8 @@ function run_eph_outer_q(
         eph_phonon_basis::Symbol = :eigenmode,  # :eigenmode or :cartesian
         verbosity::Int = 1,
         eph_buffers::Union{Nothing, EphOuterQLoopBuffers} = nothing,
+        use_gpu = false,          # Run the inner-k e-ph interpolation + calculator on the GPU
+        k_chunk_size = 1 << 15,   # GPU: number of outer k points processed per batched chunk
     ) where {FT}
 
     if model.epmat_outer_momentum != "ph"
@@ -76,18 +78,34 @@ function run_eph_outer_q(
         mpi_comm_k, mpi_comm_q, fourier_mode, window_k, window_kq,
         el_kq_from_unfolding, precompute_el_kq, use_symmetry,
         keep_all_qpts, eph_phonon_basis, calculators, nchunks_threads,
-        verbosity, eph_buffers,
+        verbosity, eph_buffers, use_gpu,
     )
 
-    _loop_eph_outer_q(model,
-        setup.kpts, setup.qpts, setup.kqpts,
-        setup.el_k_save, setup.el_kq_save, setup.ph_save,
-        setup.precompute_el_kq, setup.eph_buffers;
-        calculators, skip_eph, window_kq,
-        energy_conservation, screening_params,
-        progress_print_step, nchunks_threads,
-        eph_phonon_basis, verbosity,
-    )
+    if use_gpu
+        # GPU path: setup stays on the host (filter/states/setup_calculator!); the inner-k e-ph
+        # interpolation, k+q eigensolve, and calculator reduction run on the device. Extra flags
+        # must be off; `_loop_eph_outer_q_gpu` asserts the rest (no polar/screening, full-band via
+        # window masking, directly-computed k+q, energy_conservation = (:None, 0.0)).
+        precompute_el_kq && throw(ArgumentError(
+            "use_gpu does not support precompute_el_kq (k+q states are eigensolved on the device)."))
+        _loop_eph_outer_q_gpu(model,
+            setup.kpts, setup.qpts,
+            setup.el_k_save, setup.ph_save, setup.eph_buffers;
+            calculators, skip_eph, window_kq,
+            energy_conservation, screening_params,
+            progress_print_step, eph_phonon_basis, verbosity, k_chunk_size,
+        )
+    else
+        _loop_eph_outer_q(model,
+            setup.kpts, setup.qpts, setup.kqpts,
+            setup.el_k_save, setup.el_kq_save, setup.ph_save,
+            setup.precompute_el_kq, setup.eph_buffers;
+            calculators, skip_eph, window_kq,
+            energy_conservation, screening_params,
+            progress_print_step, nchunks_threads,
+            eph_phonon_basis, verbosity,
+        )
+    end
 
     (; setup.kpts, setup.qpts, setup.el_k_save, setup.el_kq_save, setup.ph_save)
 end
@@ -115,19 +133,20 @@ function _setup_eph_outer_q(
         nchunks_threads = nthreads(),
         verbosity::Int = 1,
         eph_buffers::Union{Nothing, EphOuterQLoopBuffers} = nothing,
+        use_gpu = false,
     ) where {FT}
 
     (; nw, nmodes) = model
 
     symmetry = use_symmetry ? model.symmetry : nothing
 
-    # Generate k points
+    # Generate k points (use_gpu: batched device eigensolve for the window test)
     if verbosity > 0
         @time kpts, iband_min, iband_max, nelec_below_window_k = filter_kpoints(
-            kpts_input, nw, model.el_ham, window_k, mpi_comm_k; symmetry, fourier_mode)
+            kpts_input, nw, model.el_ham, window_k, mpi_comm_k; symmetry, fourier_mode, use_gpu)
     else
         kpts, iband_min, iband_max, nelec_below_window_k = filter_kpoints(
-            kpts_input, nw, model.el_ham, window_k, mpi_comm_k; symmetry, fourier_mode)
+            kpts_input, nw, model.el_ham, window_k, mpi_comm_k; symmetry, fourier_mode, use_gpu)
     end
     nk = kpts.n
 
@@ -156,12 +175,18 @@ function _setup_eph_outer_q(
     end
 
 
-    # Compute and save electron state at k
+    # Compute and save electron state at k.
+    # GPU batched-q path: the loop consumes only e_full / u_full / rng from el_k_save, and
+    # batched-q calculators are (per the run_calculator_batched_q! contract) given k-side states
+    # with eigenvalue/eigenvector only — so skip the velocity/position interpolation+rotation, the
+    # dominant setup cost after the eigensolve. All other paths keep the full quantity list.
+    el_k_quantities = (use_gpu && !isempty(calculators) && all(allow_eph_batched_q, calculators)) ?
+        ["eigenvalue", "eigenvector"] : ["eigenvalue", "eigenvector", "velocity", "position"]
     if verbosity > 0
-        @time el_k_save = compute_electron_states(model, kpts, ["eigenvalue", "eigenvector", "velocity", "position"], window_k; fourier_mode)
+        @time el_k_save = compute_electron_states(model, kpts, el_k_quantities, window_k; fourier_mode, use_gpu)
         @time ph_save = compute_phonon_states(model, qpts, ["eigenvalue", "eigenvector", "velocity_diagonal", "eph_dipole_coeff"]; fourier_mode, eph_phonon_basis)
     else
-        el_k_save = compute_electron_states(model, kpts, ["eigenvalue", "eigenvector", "velocity", "position"], window_k; fourier_mode)
+        el_k_save = compute_electron_states(model, kpts, el_k_quantities, window_k; fourier_mode, use_gpu)
         ph_save = compute_phonon_states(model, qpts, ["eigenvalue", "eigenvector", "velocity_diagonal", "eph_dipole_coeff"]; fourier_mode, eph_phonon_basis)
     end
 
@@ -216,6 +241,40 @@ function _setup_eph_outer_q(
         @info "Number of q points = $nq"
     end
 
+
+    # GPU: pre-solve the chemical potential on the device for calculators whose occ still needs
+    # it. The μ bisection sweeps all in-window states ~60 times; at dense grids it dominates the
+    # setup even with the threaded host reduction (6.5 s of the 7.6 s setup at nk=80 full window).
+    # Upload the flat state energies/weights once and let the existing find_chemical_potential
+    # run its ncarrier sums as device broadcast+sum (the generic compute_ncarrier method; no CUDA
+    # code here). occ.μlist caches the result, so the set_chemical_potential! inside each
+    # calculator's setup_calculator! below then no-ops — calculators are unchanged. Device-safe
+    # subset only: :FermiDirac (exp-based kernel) metals; anything else (e.g. :MV needs
+    # SpecialFunctions.erf, not kernel-safe; the :Semiconductor solve needs host band masks)
+    # silently keeps the existing host path. The device sum order shifts μ at the ~1e-15 level.
+    if use_gpu
+        e_dev = w_dev = el_flat = nothing
+        for calc in calculators
+            hasproperty(calc, :occ) || continue
+            occ = calc.occ
+            occ isa ElectronOccupationParams || continue
+            chemical_potential_is_computed(occ) && continue
+            (occ.occ_type === :FermiDirac && occ.type === :Metal) || continue
+            if el_flat === nothing
+                el_flat, _ = electron_states_to_BTStates(el_k_save, kpts, nelec_below_window_k)
+                proto = to_device(model.el_ham).op_r
+                e_dev = similar(proto, FT, length(el_flat.e));        copyto!(e_dev, el_flat.e)
+                w_dev = similar(proto, FT, length(el_flat.k_weight)); copyto!(w_dev, el_flat.k_weight)
+            end
+            ncarrier_target = @. (occ.nlist + occ.nelec) / occ.spin_degeneracy - el_flat.nstates_base
+            for i in eachindex(occ.Tlist)
+                occ.μlist[i] = find_chemical_potential(ncarrier_target[i], occ.Tlist[i], e_dev, w_dev;
+                                                       occ.occ_type)
+                mpi_isroot() && @info "n = $(occ.nlist[i]) , T = $(round(occ.Tlist[i]/unit_to_aru(:K), digits=1)) K " *
+                    "($(occ.occ_type)) , μ = $(round(occ.μlist[i]/unit_to_aru(:eV), digits=4)) eV (device solve)"
+            end
+        end
+    end
 
     setup_calculator!.(calculators, Ref(kpts), Ref(qpts), Ref(el_k_save);
         nw, nmodes, rng_band = iband_min:iband_max,
@@ -357,6 +416,237 @@ function _loop_eph_outer_q(
         # Multithreading collect
         postprocess_calculator_inner!.(calculators; iq)
 
+    end # iq
+
+    postprocess_calculator!.(calculators; qpts, model.symmetry)
+end
+
+
+# =============================================================================
+#  GPU calculator loop for the outer-q e-ph sweep.
+#
+#  Mirrors `_loop_eph_over_k_and_kq_gpu` (run_eph_over_k_and_kq.jl): the shared `_setup_eph_outer_q`
+#  runs on the host, and this loop moves the inner-k work — the e-ph Rq→kq interpolation, the k+q
+#  eigensolve, and the calculator reduction — onto the device via the generic batched drivers
+#  (`get_eph_Rq_to_kq_batched!`, `eigen_batched`, `get_fourier_batched!`) and the batched-q
+#  calculator hook. The code is backend-generic: it calls only `to_device` and the batched drivers,
+#  so no CUDA code lives here (the device methods live in the CUDA extension).
+#
+#  Per q: interpolate g(R_el, q) on the HOST (`get_eph_RR_to_Rq!`, nq is small), upload it, then loop
+#  over outer k in chunks. Each chunk: batched k+q eigensolve (window-masked by zeroing out-of-window
+#  eigenvector columns), batched Rq→kq e-ph interpolation, and one call to `run_calculator_batched_q!`.
+#
+#  Scope (asserted below; the CPU path handles the rest): no screening,
+#  energy_conservation = (:None, 0.0), skip_eph = false, and every calculator implements
+#  `allow_eph_batched_q`. Windows are supported via eigenvector-column masking (out-of-window states
+#  contribute exactly 0), so the batched full-band nw×nw shapes stay uniform. Polar models are
+#  supported: `polar_phonon` only affects the HOST phonon setup (`ph_save` from the shared
+#  `_setup_eph_outer_q`, consumed here exactly as by the CPU loop), and the `polar_eph` dipole term
+#  is added on the device per chunk (see the `use_polar_eph` block below).
+#
+#  Window masking: the k side uses the host `el_k_save[ik].rng` (its eigenvectors are uploaded once,
+#  zero-padded outside `rng`); the k+q side is masked here from the device eigenvalues `Wkq`. The
+#  final partial k-chunk is padded to `kb` with duplicated (finite) data and its integration weight
+#  set to 0, so the padded columns contribute 0 without any partial-chunk special-casing downstream.
+function _loop_eph_outer_q_gpu(
+        model       :: Model{FT},
+        kpts, qpts,
+        el_k_save, ph_save,
+        eph_buffers :: EphOuterQLoopBuffers{FT};
+        calculators = [],
+        skip_eph = false,
+        window_kq = (-Inf, Inf),
+        energy_conservation = (:None, 0.0),
+        screening_params = nothing,
+        progress_print_step = 20,
+        eph_phonon_basis::Symbol = :eigenmode,
+        verbosity::Int = 1,
+        k_chunk_size = 1 << 15,
+    ) where {FT}
+
+    (; nw, nmodes) = model
+    nk = kpts.n
+    nq = qpts.n
+
+    # ----- scope asserts -----
+    skip_eph && throw(ArgumentError("use_gpu requires skip_eph = false."))
+    energy_conservation === (:None, 0.0) || throw(ArgumentError(
+        "use_gpu supports only energy_conservation = (:None, 0.0)."))
+    # screening_params === nothing also guarantees ϵs ≡ 1 in the polar dipole term below (the CPU
+    # loop divides the dipole coefficient by ϵs; with no screening that division is a no-op).
+    screening_params === nothing || throw(ArgumentError("use_gpu does not support screening_params."))
+    (!isempty(calculators) && all(allow_eph_batched_q, calculators)) || throw(ArgumentError(
+        "use_gpu (outer-q) requires every calculator to implement allow_eph_batched_q " *
+        "(run_calculator_batched_q!). Use the CPU path otherwise."))
+
+    # ----- device Hamiltonian for the k+q eigensolve (allocated once) -----
+    el_ham_dev = to_device(model.el_ham)
+    proto = el_ham_dev.op_r
+
+    # ----- device clone of the electron-Wannier / phonon-Bloch e-ph object -----
+    # `get_eph_RR_to_Rq!` runs on the HOST per q into `ep_eRpq_obj`; its op_r is then uploaded into
+    # this device clone. The per-q `copyto!` into `op_r` is what makes reusing the clone (and its
+    # interpolator) across q correct: `get_fourier_batched!` recomputes its phases and reads
+    # `parent.op_r` fresh on every call (it never consults `_id` — only the non-batched gridopt
+    # interpolators cache against it).
+    ep_eRpq_obj = eph_buffers.ep_eRpq_obj
+    epmat = eph_buffers.epmat
+    ep_eRpq_dev = to_device(ep_eRpq_obj)
+    ndata_eRpq = nw^2 * nmodes
+    @assert ep_eRpq_dev.ndata == ndata_eRpq
+
+    # ----- k-side eigenvectors / energies / weights uploaded ONCE -----
+    # `uk` is zero-padded outside each k's in-window range `rng` (columns outside `rng` are 0), so
+    # the full nw×nw Rq→kq rotation reproduces the CPU's windowed rotation with zeros outside.
+    # Memory ceiling: this whole-grid stack stays device-resident for the entire run —
+    # 16·nw²·nk bytes (nw=3, nk≈1.2M → ~0.2 GB; nw=12 → ~2.8 GB; nw=40 → ~30 GB). For large nw on
+    # dense grids this upload, not the chunk scratch, is the limit; the fallback is to stream the
+    # k side per chunk (upload only the chunk's `uk`, like the outer-k loop's per-tile `uks_host`)
+    # — not implemented here.
+    Uk_all_dev  = similar(proto, Complex{FT}, nw, nw, nk)
+    ek_all_dev  = similar(proto, FT, nw, nk)
+    wtk_all_dev = similar(proto, FT, nk)
+    let Uk_host = zeros(Complex{FT}, nw, nw, nk), ek_host = zeros(FT, nw, nk), wtk_host = zeros(FT, nk)
+        for ik in 1:nk
+            el = el_k_save[ik]
+            @views Uk_host[:, el.rng, ik] .= el.u_full[:, el.rng]
+            ek_host[:, ik] .= el.e_full
+            wtk_host[ik] = kpts.weights[ik]
+        end
+        copyto!(Uk_all_dev, Uk_host)
+        copyto!(ek_all_dev, ek_host)
+        copyto!(wtk_all_dev, wtk_host)
+    end
+
+    # ----- memory-adaptive k-chunk width -----
+    # Every per-chunk device buffer scales linearly with the chunk width: the loop's own staging
+    # (Rq→kq workspace, ep_chunk, H(k+q) + eigensolve, U/e/wt slices, the two interpolator caches
+    # + phase buffers) plus each calculator's batched-q scratch, declared via
+    # `eph_batched_q_bytes_per_k` (dominant for χ-like calculators: it scales with nω·nocc etc.).
+    # Derive the width from the free device memory AFTER the fixed whole-run uploads above, keeping
+    # 30% headroom for the batched drivers' internal temporaries (eigensolve copy, broadcast
+    # temporaries) recycled by the device memory pool. `k_chunk_size` remains a hard cap (and the
+    # only control on the CPU backend, where `device_free_bytes` is unbounded).
+    use_polar_eph = model.polar_eph.use
+
+    bytes_per_k_loop = 16 * nw^2 * (5 * nmodes + 8 + (use_polar_eph ? 1 : 0)) +
+        24 * (length(model.el_ham.irvec) + length(ep_eRpq_obj.irvec))
+    bytes_per_k = bytes_per_k_loop +
+        sum(Int[eph_batched_q_bytes_per_k(calc; nw, nmodes) for calc in calculators])
+    free = device_free_bytes(proto)
+    kb_mem = free == typemax(Int) ? nk : max(1, (free ÷ 10 * 7) ÷ bytes_per_k)
+    kb = min(Int(k_chunk_size), nk, kb_mem)
+    if verbosity > 0 && mpi_isroot() && kb < min(Int(k_chunk_size), nk)
+        @info "GPU outer-q: memory-adaptive k-chunk width kb = $kb " *
+              "($(round(bytes_per_k / 1e3, digits = 1)) kB/k, $(round(free / 1e9, digits = 1)) GB free)"
+    end
+
+    el_ham_itp = BatchedWannierInterpolator(el_ham_dev; batch_size = kb)
+    ep_eRpq_itp = BatchedWannierInterpolator(ep_eRpq_dev; batch_size = kb)
+
+    # ----- persistent per-chunk device workspace (sized to kb) -----
+    ep_ws     = RqToKQWorkspace(ep_eRpq_dev.op_r, ndata_eRpq, nw, nw, nmodes, kb)
+    ep_chunk  = similar(proto, Complex{FT}, nw, nw, nmodes, kb)
+    Hkq_flat  = similar(proto, Complex{FT}, nw * nw, kb)
+    Uk_chunk  = similar(proto, Complex{FT}, nw, nw, kb)
+    Ukq_chunk = similar(proto, Complex{FT}, nw, nw, kb)
+    ek_chunk  = similar(proto, FT, nw, kb)
+    wtk_chunk = similar(proto, FT, kb)
+    xk_chunk  = Vector{Vec3{FT}}(undef, kb)
+    xkq_chunk = Vector{Vec3{FT}}(undef, kb)
+
+    # ----- polar e-ph dipole (long-range) buffers -----
+    # CPU counterpart: `epdata_compute_eph_dipole!(epdata, ϵs; model)` with ϵs ≡ 1 (guaranteed by
+    # the screening_params === nothing assert above), whose active branch adds
+    # `(coeff[ν] / ϵs[ν]) · Σ_iw conj(ukq[iw,m]) uk[iw,n]` to ep[m,n,ν] for in-window (m,n), with
+    # `coeff = ph.eph_dipole_coeff` host-precomputed per q by the shared setup in the requested
+    # eph_phonon_basis. The quadrupole (`coeff_r`) block is commented out on the CPU — a no-op —
+    # and is ported as a no-op here.
+    if use_polar_eph
+        mmat_chunk = similar(proto, Complex{FT}, nw, nw, kb)
+        coeff_dev  = similar(proto, Complex{FT}, nmodes)
+    end
+
+    wmin, wmax = window_kq
+
+    for iq in 1:nq
+        if verbosity > 0 && mod(iq, progress_print_step) == 0 && mpi_isroot()
+            @info "iq = $iq"; flush(stdout); flush(stderr)
+        end
+        xq = qpts.vectors[iq]
+        ph = ph_save[iq]
+
+        # HOST: interpolate g(R_el, q) in the requested phonon basis, then upload to the device clone.
+        u_ph_for_eph = (eph_phonon_basis == :eigenmode) ? ph.u : Matrix{Complex{FT}}(I, nmodes, nmodes)
+        get_eph_RR_to_Rq!(ep_eRpq_obj, epmat, xq, u_ph_for_eph)
+        copyto!(ep_eRpq_dev.op_r, ep_eRpq_obj.op_r)
+        use_polar_eph && copyto!(coeff_dev, ph.eph_dipole_coeff)
+
+        # Per-q calculator begin: allocate (first q) + zero the device accumulator.
+        for calc in calculators
+            setup_calculator_batched_q!(calc; iq, proto, k_chunk_size = kb)
+        end
+
+        for kstart in 1:kb:nk
+            kend = min(kstart + kb - 1, nk)
+            nkc = kend - kstart + 1
+
+            # k / k+q lists (host), tail padded with the last valid vector so the batched Fourier /
+            # eigensolve see finite data (their results in the tail are discarded via wtk = 0).
+            for (a, ik) in enumerate(kstart:kend)
+                xk_chunk[a]  = kpts.vectors[ik]
+                xkq_chunk[a] = xk_chunk[a] + xq
+            end
+            for a in (nkc + 1):kb
+                xk_chunk[a]  = xk_chunk[nkc]
+                xkq_chunk[a] = xkq_chunk[nkc]
+            end
+
+            # k-side data: device→device slice, tail padded (weights → 0 so padded columns vanish).
+            @views copyto!(Uk_chunk[:, :, 1:nkc], Uk_all_dev[:, :, kstart:kend])
+            @views copyto!(ek_chunk[:, 1:nkc],    ek_all_dev[:, kstart:kend])
+            @views copyto!(wtk_chunk[1:nkc],      wtk_all_dev[kstart:kend])
+            if nkc < kb
+                @views Uk_chunk[:, :, (nkc + 1):kb] .= Uk_chunk[:, :, nkc:nkc]
+                @views ek_chunk[:, (nkc + 1):kb]    .= ek_chunk[:, nkc:nkc]
+                @views wtk_chunk[(nkc + 1):kb]      .= 0
+            end
+
+            # k+q eigensolve on the device (batched). No gauge fixing needed: χ is gauge-invariant.
+            get_fourier_batched!(Hkq_flat, el_ham_itp, xkq_chunk)
+            Wkq, Ukq_raw = eigen_batched(reshape(Hkq_flat, nw, nw, kb))   # (nw,kb), (nw,nw,kb)
+
+            # k+q window mask: zero eigenvector COLUMNS m outside [wmin, wmax] (Wkq[m,k]). This
+            # zeroes ep_kq[m,·] and every k+q-side matrix element for out-of-window m, so those
+            # (m,n) pairs contribute exactly 0 — reproducing the CPU's `for m in el_kq.rng` loop.
+            maskkq = (Wkq .>= wmin) .& (Wkq .<= wmax)                      # (nw, kb) Bool
+            Ukq_chunk .= Ukq_raw .* reshape(maskkq, 1, nw, kb)
+
+            # Batched Rq→kq e-ph interpolation: ep_chunk[m,n,ν,k] = ukq(k)' * g(k) * uk(k).
+            get_eph_Rq_to_kq_batched!(ep_chunk, ep_eRpq_itp, xk_chunk, Uk_chunk, Ukq_chunk; ws = ep_ws)
+
+            if use_polar_eph
+                # Polar dipole term: ep[m,n,ν,k] += coeff[ν] · mmat[m,n,k] with the overlap
+                # mmat[m,n,k] = Σ_iw conj(Ukq[iw,m,k]) Uk[iw,n,k]. The zero-padded eigenvector
+                # columns make mmat vanish for out-of-window m or n, matching the CPU rng loops
+                # (ϵs ≡ 1, so no division; see the buffer comment above).
+                batched_gemm!('C', 'N', Ukq_chunk, Uk_chunk, mmat_chunk)
+                ep_chunk .+= reshape(coeff_dev, 1, 1, nmodes) .* reshape(mmat_chunk, nw, nw, 1, kb)
+            end
+
+            for calc in calculators
+                run_calculator_batched_q!(calc, ep_chunk, ek_chunk, Wkq,
+                    Uk_chunk, Ukq_chunk, wtk_chunk, xk_chunk, iq)
+            end
+        end # k chunk
+
+        # Per-q calculator end: device→host scatter into the per-q output arrays.
+        for calc in calculators
+            flush_calculator_batched_q!(calc; iq)
+        end
+
+        # Bound the host look-ahead to one q so per-q device scratch does not pile up in the pool.
+        device_synchronize(proto)
     end # iq
 
     postprocess_calculator!.(calculators; qpts, model.symmetry)

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -545,9 +545,9 @@ function _loop_eph_over_k_and_kq_gpu(
     # batched device hook; a non-batched calculator fails loudly rather than silently falling back
     # to a slow host path — a hard-to-spot performance cliff (see README_GPU.md "Decisions").
     isempty(calculators) && throw(ArgumentError("use_gpu requires at least one calculator."))
-    all(allow_eph_batched, calculators) || throw(ArgumentError(
+    all(allow_eph_outer_k_batched, calculators) || throw(ArgumentError(
         "use_gpu requires every calculator to implement the batched device hook " *
-        "(allow_eph_batched = true); the GPU path does not fall back to the host run_calculator! loop."))
+        "(allow_eph_outer_k_batched = true); the GPU path does not fall back to the host run_calculator! loop."))
 
     # The k+q side of the interpolation runs full-band (uniform nw×nw, using the full eigenvectors
     # `el.u_full`); the energy window is applied in the calculator scatter, where out-of-window
@@ -763,7 +763,7 @@ function _loop_eph_over_k_and_kq_gpu(
             # copy of the first nq_batch k+q indices (a SubArray-view copy would go scalar).
             copyto!(ikqs_dev, 1, ikqs_host, 1, nq_batch)
             for calc in calculators
-                run_calculator_batched!(calc,
+                run_calculator_outer_k_batched!(calc,
                     view(epkq_dev, :, :, :, rng_q), view(ωq_dev, :, rng_q),
                     ik, view(ikqs_dev, rng_q); g2 = view(g2_dev, :, :, :, rng_q),
                     ibandk_offset = ibandk_offsets[ik])

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -575,13 +575,13 @@ function _loop_eph_over_k_and_kq_gpu(
 
     # ----- device interpolators (allocated once) -----
     epmat_dev = to_device(model.epmat)
-    epmat_itp = BatchedWannierInterpolator(epmat_dev; batch_size = nk_batch_max)
+    itp_epmat = BatchedWannierInterpolator(epmat_dev; batch_size = nk_batch_max)
     ep_ekpR_dev = to_device(get_next_wannier_object(model.epmat))
     ndata_ekpR = nw * nbandk_max * nmodes
     # Set ndata BEFORE building the interpolator (its Fourier cache is sized to parent.ndata):
     # under the k-side projection only the first nw·nbandk_max·nmodes rows of op_r are filled/read.
     ep_ekpR_dev.ndata = ndata_ekpR
-    ep_ekpR_itp = BatchedWannierInterpolator(ep_ekpR_dev; batch_size = nq_batch_max)
+    itp_ep_ekpR = BatchedWannierInterpolator(ep_ekpR_dev; batch_size = nq_batch_max)
     nr_ep = ep_ekpR_dev.nr
 
     # ----- persistent workspace (allocated once, reused across all (k, q)) -----
@@ -684,12 +684,12 @@ function _loop_eph_over_k_and_kq_gpu(
         copyto!(uks_dev, uks_host)
 
         # One batched RR->kR over the whole batch: g(k, R_ep) for all k in the batch.
-        get_eph_RR_to_kR_batched!(ep_ekpR_all, epmat_itp, ks_batch, uks_dev)
+        get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat, ks_batch, uks_dev)
 
         # Outer-batch-resident calculators (re)point/zero their per-batch device buffer here, before
         # this batch's scatters; no-op (default hooks) for calculators that hold their whole output.
         for calc in calculators
-            setup_calculator_outer_batch!(calc; kstart, kend, proto = epmat_dev.op_r)
+            setup_calculator_outer_batch!(calc; kstart, kend, gpu_array = epmat_dev.op_r)
         end
 
     for (ik_ind, ik) in enumerate(iks_batch)
@@ -754,7 +754,7 @@ function _loop_eph_over_k_and_kq_gpu(
 
             # One batched Wannier->Bloch over this batch's q: ep_kq(q) (nw, nw, nmodes), folding
             # g2 = |ep|²/(2ω) into the same fused kernel pass.
-            get_eph_kR_to_kq_batched!(view(epkq_dev, :, :, :, rng_q), ep_ekpR_itp, view(qs_batch, rng_q),
+            get_eph_kR_to_kq_batched!(view(epkq_dev, :, :, :, rng_q), itp_ep_ekpR, view(qs_batch, rng_q),
                 view(uphs_dev, :, :, rng_q), ukqs_used; ws=kRkq_ws,
                 g2_out = view(g2_dev, :, :, :, rng_q), ωq = view(ωq_dev, :, rng_q))
 

--- a/src/common/fermi_energy.jl
+++ b/src/common/fermi_energy.jl
@@ -10,6 +10,8 @@ export find_fermi_energy
 # `if occ_type == :…` chain and the string-interpolating `throw` do not lower to a device kernel);
 # as a `Val` the chain constant-folds to the single occupation formula, and `erf`/`erfc` map to
 # libdevice intrinsics — so :FermiDirac, :MV, :Gaussian, :MP all run device-side.
+# TODO: thread `Val{occ_type}` through the occupation API everywhere (occ_fermion / occ_fermion_derivative
+#       and their callers), instead of the runtime `occ_type` keyword + this local wrapper.
 @inline _occ_fermion(e, T, ::Val{occ_type}) where {occ_type} = occ_fermion(e, T; occ_type)
 
 """

--- a/src/common/fermi_energy.jl
+++ b/src/common/fermi_energy.jl
@@ -2,8 +2,41 @@
 # Functions related to finding Fermi energy
 
 using Roots
+using ChunkSplitters
+using Base.Threads: @threads
 
 export find_fermi_energy
+
+# Threaded deterministic reduction over the state index used by the ncarrier sums below. The
+# chunking is FIXED (size-based, depends only on `n`), each chunk is summed serially, and the
+# per-chunk partials are summed serially in chunk order — so the result is run-to-run
+# deterministic (independent of thread scheduling and of `nthreads()`). The summation ORDER
+# differs from the plain serial loop, so results may differ from it at the floating-point
+# rounding level (~1e-15 relative); this shifts the bisected chemical potential by a
+# comparable amount. Small problems stay on the serial path (threading overhead dominates).
+# `f(i) -> FT` is the per-state summand.
+const _NCARRIER_SERIAL_MAX = 1 << 14
+const _NCARRIER_CHUNK = 1 << 12
+
+function _ncarrier_sum(f, n::Int, ::Type{FT}) where {FT}
+    if n <= _NCARRIER_SERIAL_MAX
+        acc = zero(FT)
+        for i in 1:n
+            acc += f(i)
+        end
+        return acc
+    end
+    ck = chunks(1:n; size = _NCARRIER_CHUNK)
+    partials = zeros(FT, length(ck))
+    @threads for (ic, is) in enumerate(ck)
+        acc = zero(FT)
+        for i in is
+            acc += f(i)
+        end
+        partials[ic] = acc
+    end
+    sum(partials)
+end
 
 """
     compute_ncarrier(μ, T, energy, weights; occ_type = :FermiDirac)
@@ -13,21 +46,45 @@ Compute number of electrons per unit cell.
 - `T`: temperature
 - `occ_type`: occupation type, default: `:FermiDirac`. (See [`occ_fermion`](@ref) for all options.)
 - `weights`: k-point weights.
+
+Threaded over the states with a deterministic chunked reduction (see `_ncarrier_sum`).
 """
 function compute_ncarrier(μ, T, energy::AbstractMatrix, weights; occ_type = :FermiDirac)
-    nk = size(energy, 2)
+    nband, nk = size(energy)
     @assert length(weights) == nk
-    ncarrier = zero(eltype(energy))
-    for ik in 1:nk
-        for iband in 1:size(energy, 1)
-            ncarrier += weights[ik] * occ_fermion(energy[iband, ik] - μ, T; occ_type)
-        end
+    _ncarrier_sum(nband * nk, eltype(energy)) do i
+        iband = (i - 1) % nband + 1
+        ik = (i - 1) ÷ nband + 1
+        weights[ik] * occ_fermion(energy[iband, ik] - μ, T; occ_type)
     end
-    ncarrier
 end
 
+function compute_ncarrier(μ, T, energy::Vector, weights; occ_type = :FermiDirac)
+    _ncarrier_sum(length(energy), eltype(energy)) do i
+        weights[i] * occ_fermion(energy[i] - μ, T; occ_type)
+    end
+end
+
+"""
+    compute_ncarrier(μ, T, energy::AbstractVector, weights; occ_type = :FermiDirac)
+
+Generic (device-capable) method: a plain broadcast + `sum`, so it runs on any array backend
+(e.g. `CuArray`) without scalar indexing or a CUDA dependency. `:FermiDirac` only — the other
+occupation types need `erf`/`erfc` (SpecialFunctions), which are not device-kernel-safe; callers
+keep those on the host. The `Vector` method above (the deterministic chunked-threads host path)
+takes precedence for host arrays and is unchanged. The broadcast `sum` reduction order differs
+from the host method's, so results agree with it only to the rounding level (~1e-15 relative).
+"""
 function compute_ncarrier(μ, T, energy::AbstractVector, weights; occ_type = :FermiDirac)
-    sum(@. weights * occ_fermion(energy - μ, T; occ_type))
+    occ_type === :FermiDirac || throw(ArgumentError(
+        "the generic (device) compute_ncarrier supports occ_type = :FermiDirac only (got $occ_type)"))
+    if T > sqrt(eps(Float64))
+        sum(weights ./ (exp.((energy .- μ) ./ T) .+ 1))
+    elseif T >= 0
+        sum(weights .* ((1 .- sign.(energy .- μ)) ./ 2))
+    else
+        throw(ArgumentError("Temperature must be positive"))
+    end
 end
 
 """
@@ -35,7 +92,9 @@ end
 Compute number of holes per unit cell. See [`compute_ncarrier`](@ref) for arguments.
 """
 function compute_ncarrier_hole(μ, T, energy::AbstractVector, weights; occ_type = :FermiDirac)
-    sum(@. weights * (1 - occ_fermion(energy - μ, T; occ_type)))
+    _ncarrier_sum(length(energy), eltype(energy)) do i
+        weights[i] * (1 - occ_fermion(energy[i] - μ, T; occ_type))
+    end
 end
 
 """

--- a/src/common/fermi_energy.jl
+++ b/src/common/fermi_energy.jl
@@ -2,41 +2,15 @@
 # Functions related to finding Fermi energy
 
 using Roots
-using ChunkSplitters
-using Base.Threads: @threads
 
 export find_fermi_energy
 
-# Threaded deterministic reduction over the state index used by the ncarrier sums below. The
-# chunking is FIXED (size-based, depends only on `n`), each chunk is summed serially, and the
-# per-chunk partials are summed serially in chunk order — so the result is run-to-run
-# deterministic (independent of thread scheduling and of `nthreads()`). The summation ORDER
-# differs from the plain serial loop, so results may differ from it at the floating-point
-# rounding level (~1e-15 relative); this shifts the bisected chemical potential by a
-# comparable amount. Small problems stay on the serial path (threading overhead dominates).
-# `f(i) -> FT` is the per-state summand.
-const _NCARRIER_SERIAL_MAX = 1 << 14
-const _NCARRIER_CHUNK = 1 << 12
-
-function _ncarrier_sum(f, n::Int, ::Type{FT}) where {FT}
-    if n <= _NCARRIER_SERIAL_MAX
-        acc = zero(FT)
-        for i in 1:n
-            acc += f(i)
-        end
-        return acc
-    end
-    ck = chunks(1:n; size = _NCARRIER_CHUNK)
-    partials = zeros(FT, length(ck))
-    @threads for (ic, is) in enumerate(ck)
-        acc = zero(FT)
-        for i in is
-            acc += f(i)
-        end
-        partials[ic] = acc
-    end
-    sum(partials)
-end
+# occ_fermion with the occupation type as a COMPILE-TIME `Val` parameter, so a broadcast over it
+# compiles on any backend including the GPU. `occ_fermion`'s `occ_type` is a runtime keyword (its
+# `if occ_type == :…` chain and the string-interpolating `throw` do not lower to a device kernel);
+# as a `Val` the chain constant-folds to the single occupation formula, and `erf`/`erfc` map to
+# libdevice intrinsics — so :FermiDirac, :MV, :Gaussian, :MP all run device-side.
+@inline _occ_fermion(e, T, ::Val{occ_type}) where {occ_type} = occ_fermion(e, T; occ_type)
 
 """
     compute_ncarrier(μ, T, energy, weights; occ_type = :FermiDirac)
@@ -46,45 +20,24 @@ Compute number of electrons per unit cell.
 - `T`: temperature
 - `occ_type`: occupation type, default: `:FermiDirac`. (See [`occ_fermion`](@ref) for all options.)
 - `weights`: k-point weights.
-
-Threaded over the states with a deterministic chunked reduction (see `_ncarrier_sum`).
 """
 function compute_ncarrier(μ, T, energy::AbstractMatrix, weights; occ_type = :FermiDirac)
-    nband, nk = size(energy)
+    nk = size(energy, 2)
     @assert length(weights) == nk
-    _ncarrier_sum(nband * nk, eltype(energy)) do i
-        iband = (i - 1) % nband + 1
-        ik = (i - 1) ÷ nband + 1
-        weights[ik] * occ_fermion(energy[iband, ik] - μ, T; occ_type)
+    ncarrier = zero(eltype(energy))
+    for ik in 1:nk
+        for iband in 1:size(energy, 1)
+            ncarrier += weights[ik] * occ_fermion(energy[iband, ik] - μ, T; occ_type)
+        end
     end
+    ncarrier
 end
 
-function compute_ncarrier(μ, T, energy::Vector, weights; occ_type = :FermiDirac)
-    _ncarrier_sum(length(energy), eltype(energy)) do i
-        weights[i] * occ_fermion(energy[i] - μ, T; occ_type)
-    end
-end
-
-"""
-    compute_ncarrier(μ, T, energy::AbstractVector, weights; occ_type = :FermiDirac)
-
-Generic (device-capable) method: a plain broadcast + `sum`, so it runs on any array backend
-(e.g. `CuArray`) without scalar indexing or a CUDA dependency. `:FermiDirac` only — the other
-occupation types need `erf`/`erfc` (SpecialFunctions), which are not device-kernel-safe; callers
-keep those on the host. The `Vector` method above (the deterministic chunked-threads host path)
-takes precedence for host arrays and is unchanged. The broadcast `sum` reduction order differs
-from the host method's, so results agree with it only to the rounding level (~1e-15 relative).
-"""
+# Broadcast + `sum`, so it runs on any array backend (host `Array` or `CuArray`) without scalar
+# indexing or a CUDA dependency: this is the reduction used by the on-device chemical-potential
+# solve. `Val(occ_type)` keeps the broadcast kernel device-compilable (see `_occ_fermion`).
 function compute_ncarrier(μ, T, energy::AbstractVector, weights; occ_type = :FermiDirac)
-    occ_type === :FermiDirac || throw(ArgumentError(
-        "the generic (device) compute_ncarrier supports occ_type = :FermiDirac only (got $occ_type)"))
-    if T > sqrt(eps(Float64))
-        sum(weights ./ (exp.((energy .- μ) ./ T) .+ 1))
-    elseif T >= 0
-        sum(weights .* ((1 .- sign.(energy .- μ)) ./ 2))
-    else
-        throw(ArgumentError("Temperature must be positive"))
-    end
+    sum(weights .* _occ_fermion.(energy .- μ, T, Val(occ_type)))
 end
 
 """
@@ -92,9 +45,7 @@ end
 Compute number of holes per unit cell. See [`compute_ncarrier`](@ref) for arguments.
 """
 function compute_ncarrier_hole(μ, T, energy::AbstractVector, weights; occ_type = :FermiDirac)
-    _ncarrier_sum(length(energy), eltype(energy)) do i
-        weights[i] * (1 - occ_fermion(energy[i] - μ, T; occ_type))
-    end
+    sum(weights .* (1 .- _occ_fermion.(energy .- μ, T, Val(occ_type))))
 end
 
 """

--- a/src/common/gpu_utils.jl
+++ b/src/common/gpu_utils.jl
@@ -12,26 +12,26 @@ package defines no method, so calling this without the relevant extension loaded
 function to_device end
 
 """
-    device_free_bytes(proto) -> Int
+    device_free_bytes(gpu_array) -> Int
 
-Free memory (bytes) on the backend `proto` lives on, used to decide whether a large buffer fits
+Free memory (bytes) on the backend `gpu_array` lives on, used to decide whether a large buffer fits
 on the device. Generic fallback returns `typemax(Int)` (host memory: assume it always fits — the
 caller's host allocation is governed by RAM, not this check). The CUDA extension returns
-`CUDA.free_memory()` for a `CuArray` proto.
+`CUDA.free_memory()` for a `CuArray` gpu_array.
 
 TODO: no in-repo caller yet — this exists for the deferred device memory-estimate helper
 (see README_GPU.md). Wire it up when that helper is written, or remove it.
 """
-device_free_bytes(proto) = typemax(Int)
+device_free_bytes(gpu_array) = typemax(Int)
 
 """
-    device_synchronize(proto)
+    device_synchronize(gpu_array)
 
-Block until queued device work on `proto`'s backend completes. Generic fallback is a no-op
+Block until queued device work on `gpu_array`'s backend completes. Generic fallback is a no-op
 (host work is synchronous); the CUDA extension calls `CUDA.synchronize()`. Used to bound the
 host look-ahead in the GPU e-ph loop so per-tile scratch does not pile up in the memory pool.
 """
-device_synchronize(proto) = nothing
+device_synchronize(gpu_array) = nothing
 
 @inline _batched_op(t::Char, X) = t == 'N' ? X : (t == 'T' ? transpose(X) : adjoint(X))
 

--- a/src/common/occupation.jl
+++ b/src/common/occupation.jl
@@ -124,20 +124,24 @@ function chemical_potential_is_computed(occ :: ElectronOccupationParams)
 end
 
 """
-    set_chemical_potential!(occ, el_states, kpts, nelec_below_window; do_print = true)
+    set_chemical_potential!(occ, el_states, kpts, nelec_below_window; do_print = true, proto = nothing)
 If `occ.μlist` is not set, compute the chemical potential and set it.
 If `occ.μlist` is already set to some value that is not NaN, do nothing.
+Pass a device array `proto` (e.g. `to_device(model.el_ham).op_r`) to run the bisection's ncarrier
+sums on that backend (GPU); the default `nothing` keeps the whole solve on the host.
 """
-function set_chemical_potential!(occ, el_states, kpts, nelec_below_window; do_print = true)
+function set_chemical_potential!(occ, el_states, kpts, nelec_below_window; do_print = true, proto = nothing)
     if !chemical_potential_is_computed(occ)
         el, _ = electron_states_to_BTStates(el_states, kpts, nelec_below_window)
-        bte_compute_μ!(occ, el; do_print)
+        bte_compute_μ!(occ, el; do_print, proto)
     end
     occ
 end
 
+# Move a host vector onto `proto`'s backend (identity when proto === nothing / already host).
+_ncarrier_backend(x, proto) = proto === nothing ? x : copyto!(similar(proto, eltype(x), size(x)), x)
 
-function bte_compute_μ!(occ :: ElectronOccupationParams, el; do_print=true)
+function bte_compute_μ!(occ :: ElectronOccupationParams, el; do_print=true, proto=nothing)
     if occ.type == :Metal
         # For metals, compute the total electron density.
         # Since occ.n is the difference of number of electrons per cell from nband_valence,
@@ -151,18 +155,24 @@ function bte_compute_μ!(occ :: ElectronOccupationParams, el; do_print=true)
         # FIXME: BUG: nband_valence must be provided by the user. By mistake one may set nelec instead of nlist in a metal, then this leads to very wrong result. Also we should rename nelec to nelec_semiconductor or something like that to indicate that this is intended for doped semiconductors.
         nband_valence = round(Int, occ.nelec / occ.spin_degeneracy)
         ncarrier_target = @. occ.nlist / occ.spin_degeneracy
-        e_e = el.e[el.iband .>  nband_valence]
-        e_h = el.e[el.iband .<= nband_valence]
-        w_e = el.k_weight[el.iband .>  nband_valence]
-        w_h = el.k_weight[el.iband .<= nband_valence]
+        # Band masking is a host operation; the resulting energy/weight lists are then moved to the
+        # solve backend below.
+        e_e = _ncarrier_backend(el.e[el.iband .>  nband_valence], proto)
+        e_h = _ncarrier_backend(el.e[el.iband .<= nband_valence], proto)
+        w_e = _ncarrier_backend(el.k_weight[el.iband .>  nband_valence], proto)
+        w_h = _ncarrier_backend(el.k_weight[el.iband .<= nband_valence], proto)
     else
         throw(DomainError("Invalid occ.type $(occ.type)"))
     end
 
+    # Move the metal energy/weight lists onto the solve backend (device when `proto` is a CuArray).
+    e_metal = occ.type == :Metal ? _ncarrier_backend(el.e, proto) : el.e
+    w_metal = occ.type == :Metal ? _ncarrier_backend(el.k_weight, proto) : el.k_weight
+
     for i in axes(occ.Tlist, 1)
         T = occ.Tlist[i]
         if occ.type == :Metal
-            μ = find_chemical_potential(ncarrier_target[i], T, el.e, el.k_weight; occ.occ_type)
+            μ = find_chemical_potential(ncarrier_target[i], T, e_metal, w_metal; occ.occ_type)
         elseif occ.type == :Semiconductor
             μ = find_chemical_potential_semiconductor(ncarrier_target[i], T, e_e, e_h, w_e, w_h; occ.occ_type)
         end

--- a/src/common/occupation.jl
+++ b/src/common/occupation.jl
@@ -124,24 +124,24 @@ function chemical_potential_is_computed(occ :: ElectronOccupationParams)
 end
 
 """
-    set_chemical_potential!(occ, el_states, kpts, nelec_below_window; do_print = true, proto = nothing)
+    set_chemical_potential!(occ, el_states, kpts, nelec_below_window; do_print = true, gpu_array = nothing)
 If `occ.μlist` is not set, compute the chemical potential and set it.
 If `occ.μlist` is already set to some value that is not NaN, do nothing.
-Pass a device array `proto` (e.g. `to_device(model.el_ham).op_r`) to run the bisection's ncarrier
+Pass a device array `gpu_array` (e.g. `to_device(model.el_ham).op_r`) to run the bisection's ncarrier
 sums on that backend (GPU); the default `nothing` keeps the whole solve on the host.
 """
-function set_chemical_potential!(occ, el_states, kpts, nelec_below_window; do_print = true, proto = nothing)
+function set_chemical_potential!(occ, el_states, kpts, nelec_below_window; do_print = true, gpu_array = nothing)
     if !chemical_potential_is_computed(occ)
         el, _ = electron_states_to_BTStates(el_states, kpts, nelec_below_window)
-        bte_compute_μ!(occ, el; do_print, proto)
+        bte_compute_μ!(occ, el; do_print, gpu_array)
     end
     occ
 end
 
-# Move a host vector onto `proto`'s backend (identity when proto === nothing / already host).
-_ncarrier_backend(x, proto) = proto === nothing ? x : copyto!(similar(proto, eltype(x), size(x)), x)
+function bte_compute_μ!(occ :: ElectronOccupationParams, el; do_print=true, gpu_array=nothing)
+    # Move a host vector onto `gpu_array`'s backend for the ncarrier sums (identity on the host).
+    _to_device(x) = gpu_array === nothing ? x : copyto!(similar(gpu_array, eltype(x), size(x)), x)
 
-function bte_compute_μ!(occ :: ElectronOccupationParams, el; do_print=true, proto=nothing)
     if occ.type == :Metal
         # For metals, compute the total electron density.
         # Since occ.n is the difference of number of electrons per cell from nband_valence,
@@ -149,6 +149,8 @@ function bte_compute_μ!(occ :: ElectronOccupationParams, el; do_print=true, pro
         # Also, el.nstates_base is the contribution to the ncarrier from occupied states
         # outside the window (i.e. not included in `energy`). So it is subtracted.
         ncarrier_target = @. (occ.nlist + occ.nelec) / occ.spin_degeneracy - el.nstates_base
+        e_solve = _to_device(el.e)
+        w_solve = _to_device(el.k_weight)
     elseif occ.type == :Semiconductor
         # For semiconductors, count the doped carriers to minimize floating point error.
         # FIXME: nband_valence needs to be a field
@@ -156,23 +158,19 @@ function bte_compute_μ!(occ :: ElectronOccupationParams, el; do_print=true, pro
         nband_valence = round(Int, occ.nelec / occ.spin_degeneracy)
         ncarrier_target = @. occ.nlist / occ.spin_degeneracy
         # Band masking is a host operation; the resulting energy/weight lists are then moved to the
-        # solve backend below.
-        e_e = _ncarrier_backend(el.e[el.iband .>  nband_valence], proto)
-        e_h = _ncarrier_backend(el.e[el.iband .<= nband_valence], proto)
-        w_e = _ncarrier_backend(el.k_weight[el.iband .>  nband_valence], proto)
-        w_h = _ncarrier_backend(el.k_weight[el.iband .<= nband_valence], proto)
+        # solve backend.
+        e_e = _to_device(el.e[el.iband .>  nband_valence])
+        e_h = _to_device(el.e[el.iband .<= nband_valence])
+        w_e = _to_device(el.k_weight[el.iband .>  nband_valence])
+        w_h = _to_device(el.k_weight[el.iband .<= nband_valence])
     else
         throw(DomainError("Invalid occ.type $(occ.type)"))
     end
 
-    # Move the metal energy/weight lists onto the solve backend (device when `proto` is a CuArray).
-    e_metal = occ.type == :Metal ? _ncarrier_backend(el.e, proto) : el.e
-    w_metal = occ.type == :Metal ? _ncarrier_backend(el.k_weight, proto) : el.k_weight
-
     for i in axes(occ.Tlist, 1)
         T = occ.Tlist[i]
         if occ.type == :Metal
-            μ = find_chemical_potential(ncarrier_target[i], T, e_metal, w_metal; occ.occ_type)
+            μ = find_chemical_potential(ncarrier_target[i], T, e_solve, w_solve; occ.occ_type)
         elseif occ.type == :Semiconductor
             μ = find_chemical_potential_semiconductor(ncarrier_target[i], T, e_e, e_h, w_e, w_h; occ.occ_type)
         end

--- a/src/wannier_to_bloch.jl
+++ b/src/wannier_to_bloch.jl
@@ -300,6 +300,18 @@ Multithreading is not supported because of large buffer array size.
 end
 
 """
+    get_eph_RR_to_Rq_basis!(epobj_eRpq, epmat, xq, ph, eph_phonon_basis, nmodes)
+
+`get_eph_RR_to_Rq!` with the phonon-mode rotation chosen by `eph_phonon_basis`: `:eigenmode` rotates
+by the phonon eigenvectors `ph.u`, `:cartesian` leaves the modes in the Cartesian basis (identity).
+The per-q host e-ph step shared by the CPU and GPU outer-q loops.
+"""
+function get_eph_RR_to_Rq_basis!(epobj_eRpq, epmat, xq, ph, eph_phonon_basis::Symbol, nmodes)
+    u_ph = eph_phonon_basis == :eigenmode ? ph.u : I(nmodes)
+    get_eph_RR_to_Rq!(epobj_eRpq, epmat, xq, u_ph)
+end
+
+"""
     get_eph_Rq_to_kq!(ep_kq, epobj_eRpq, xk, uk, ukq)
 Compute electron-phonon coupling matrix in electron and phonon Bloch basis.
 

--- a/src/wannier_to_bloch.jl
+++ b/src/wannier_to_bloch.jl
@@ -300,14 +300,15 @@ Multithreading is not supported because of large buffer array size.
 end
 
 """
-    get_eph_RR_to_Rq_basis!(epobj_eRpq, epmat, xq, ph, eph_phonon_basis, nmodes)
+    get_eph_RR_to_Rq!(epobj_eRpq, epmat, xq, ph, eph_phonon_basis::Symbol)
 
-`get_eph_RR_to_Rq!` with the phonon-mode rotation chosen by `eph_phonon_basis`: `:eigenmode` rotates
-by the phonon eigenvectors `ph.u`, `:cartesian` leaves the modes in the Cartesian basis (identity).
-The per-q host e-ph step shared by the CPU and GPU outer-q loops.
+Phonon state `ph` + basis overload of [`get_eph_RR_to_Rq!`](@ref): choose the phonon-mode rotation
+from `eph_phonon_basis` — `:eigenmode` rotates by the phonon eigenvectors `ph.u`, `:cartesian` leaves
+the modes in the Cartesian basis (identity). The per-q host e-ph step shared by the CPU and GPU
+outer-q loops.
 """
-function get_eph_RR_to_Rq_basis!(epobj_eRpq, epmat, xq, ph, eph_phonon_basis::Symbol, nmodes)
-    u_ph = eph_phonon_basis == :eigenmode ? ph.u : I(nmodes)
+function get_eph_RR_to_Rq!(epobj_eRpq, epmat, xq, ph, eph_phonon_basis::Symbol)
+    u_ph = eph_phonon_basis == :eigenmode ? ph.u : I(length(ph.e))
     get_eph_RR_to_Rq!(epobj_eRpq, epmat, xq, u_ph)
 end
 

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -252,6 +252,110 @@ function get_eph_kR_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
 end
 
 """
+    RqToKQWorkspace(proto, ndata, nbandkq, nbandk, nmodes, nk)
+
+Preallocated scratch for [`get_eph_Rq_to_kq_batched!`](@ref), reused across the per-q calls of the
+outer-q loop so the driver does no per-call `similar`. `proto` is an array on the target backend
+(e.g. `epobj_eRpq_itp.parent.op_r`); the buffers follow its backend and element type.
+`ndata = nw^2*nmodes` is the parent (electron-Wannier / phonon-Bloch) data size.
+"""
+struct RqToKQWorkspace{MT<:AbstractMatrix, AT<:AbstractArray, BT<:AbstractArray}
+    g::MT       # (ndata, nk)                   — Fourier output g(k, R_ep summed) for all k
+    tmp::AT     # (nbandkq, nw*nmodes, nk)      — after the ukq' rotation
+    uk_rep::BT  # (nw, nbandk, nmodes*nk)       — uk replicated over the phonon modes
+end
+function RqToKQWorkspace(proto, ndata::Int, nbandkq::Int, nbandk::Int, nmodes::Int, nk::Int)
+    T = real(eltype(proto))
+    nw = isqrt(div(ndata, nmodes))
+    nw^2 * nmodes == ndata || throw(ArgumentError("ndata=$ndata is not nw^2*nmodes for nmodes=$nmodes"))
+    RqToKQWorkspace(similar(proto, Complex{T}, ndata, nk),
+                    similar(proto, Complex{T}, nbandkq, nw * nmodes, nk),
+                    similar(proto, Complex{T}, nw, nbandk, nmodes * nk))
+end
+
+"""
+    get_eph_Rq_to_kq_batched!(ep_kq_all, epobj_eRpq_itp::BatchedWannierInterpolator, ks, uks, ukqs; ws=nothing)
+
+Batched over a list of k-points `ks` (for a fixed q). Counterpart of [`get_eph_Rq_to_kq!`](@ref)
+that runs on the backend of `epobj_eRpq_itp.parent.op_r` — the list-batched inner-k step of the
+outer-q e-ph loop. `uks` is `(nw, nbandk, nk)` and `ukqs` is `(nw, nbandkq, nk)` (one eigenvector
+per k / k+q). Writes `ep_kq_all`, shape `(nbandkq, nbandk, nmodes, nk)`.
+
+The parent is the electron-Wannier / phonon-Bloch object (`op_r` `(nw^2*nmodes, nr_el)`, produced by
+[`get_eph_RR_to_Rq!`](@ref) at the current q). One batched Fourier over `R_el` gives
+`g(k)` `(nw^2*nmodes, nk)`, viewed as `g[iw, jw, ν, k]`, then the per-k rotation
+`ep_kq_all[m,n,ν,k] = Σ_{iw,jw} conj(ukqs[iw,m,k]) · g[iw,jw,ν,k] · uks[jw,n,k]` is applied as two
+`batched_gemm!`s (`ukq(k)'` on the left over batch `k`, `uk(k)` on the right over batch `(ν,k)`).
+
+Pass an [`RqToKQWorkspace`](@ref) (sized for this `nk`) as `ws` to reuse the `g`/`tmp`/`uk_rep`
+scratch across calls instead of allocating it each call — the per-q hot loop does this.
+
+Full-band only: like [`get_eph_RR_to_kR_batched!`](@ref), all `nk` k-points must share the same
+`nbandk`/`nbandkq` (energy windows are handled by callers with masks).
+"""
+function get_eph_Rq_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
+                                   epobj_eRpq_itp::BatchedWannierInterpolator{T}, ks, uks, ukqs;
+                                   ws::Union{Nothing,RqToKQWorkspace}=nothing) where {T}
+    nbandkq, nbandk, nmodes, nk = size(ep_kq_all)
+    nw = size(uks, 1)
+    @assert size(uks) == (nw, nbandk, nk)
+    @assert size(ukqs) == (nw, nbandkq, nk)
+    @assert length(ks) == nk
+    parent = epobj_eRpq_itp.parent
+    @assert parent.ndata == nw^2 * nmodes
+
+    if ws === nothing
+        g      = similar(parent.op_r, Complex{T}, parent.ndata, nk)
+        tmp    = similar(parent.op_r, Complex{T}, nbandkq, nw * nmodes, nk)
+        uk_rep = similar(parent.op_r, Complex{T}, nw, nbandk, nmodes * nk)
+    else
+        g, tmp, uk_rep = ws.g, ws.tmp, ws.uk_rep
+        @assert size(g) == (parent.ndata, nk)
+        @assert size(tmp) == (nbandkq, nw * nmodes, nk)
+        @assert size(uk_rep) == (nw, nbandk, nmodes * nk)
+    end
+
+    # Fourier over R_el at every k -> g(k) in (nw, nw, nmodes, nk); index legend g[iw, jw, ν, k]
+    # with iw the k+q-side (ukq) leg and jw the k-side (uk) leg.
+    get_fourier_batched!(g, epobj_eRpq_itp, ks)                        # (nw^2*nmodes, nk)
+
+    eph_apply_rotations_rqkq!(ep_kq_all, g, uks, ukqs, tmp, uk_rep)
+    ep_kq_all
+end
+
+"""
+    eph_apply_rotations_rqkq!(ep_kq_all, g, uks, ukqs, tmp, uk_rep)
+
+Apply the two per-k electron gauge rotations of the Rq→kq driver to the Fourier-interpolated `g`
+(`(nw²·nmodes, nk)`, viewed as `g[iw, jw, ν, k]`), writing
+`ep_kq_all[m, n, ν, k] = Σ_{iw,jw} conj(ukqs[iw,m,k]) · g[iw,jw,ν,k] · uks[jw,n,k]`.
+
+Generic method: two `batched_gemm!`s (`ukq(k)'` on the left over batch `k`; `uk(k)` on the right
+over batch `(ν,k)` after replicating `uks` over the modes into `uk_rep`), so any backend works.
+The CUDA extension overrides this with a fused per-(m,n,k) kernel for small `nw²·nmodes` — the
+right-rotation GEMMs are `nw×nw` matmuls at an `nmodes·nk` batch count, deep inside cuBLAS'
+tiny-batched-matmul overhead regime (cf. the outer-k `eph_apply_rotations!` fused kernel).
+"""
+function eph_apply_rotations_rqkq!(ep_kq_all::AbstractArray{Complex{T},4}, g,
+                                   uks, ukqs, tmp, uk_rep) where {T}
+    nbandkq, nbandk, nmodes, nk = size(ep_kq_all)
+    nw = size(uks, 1)
+
+    # 1. left rotation ukq(k)', batched over k: tmp[m, (jw,ν), k] = Σ_iw conj(ukqs[iw,m,k]) g[iw,(jw,ν),k]
+    batched_gemm!('C', 'N', ukqs, reshape(g, nw, nw * nmodes, nk), tmp) # (nbandkq, nw*nmodes, nk)
+
+    # 2. right rotation uk(k), batched over b = (ν, k): reshape tmp to (nbandkq, nw, nmodes*nk)
+    #    (contiguous: splits the (jw,ν) axis into jw and ν, ν fastest in the batch), and replicate
+    #    uk over the modes so each batch slice carries its own uk. ep_kq_all reshaped to
+    #    (nbandkq, nbandk, nmodes*nk) receives ep[m,n,(ν,k)] = Σ_jw tmp[m,jw,(ν,k)] uks[jw,n,k].
+    uk_rep4 = reshape(uk_rep, nw, nbandk, nmodes, nk)
+    uk_rep4 .= reshape(uks, nw, nbandk, 1, nk)                         # broadcast uk over ν
+    batched_gemm!('N', 'N', reshape(tmp, nbandkq, nw, nmodes * nk), uk_rep,
+                  reshape(ep_kq_all, nbandkq, nbandk, nmodes * nk))
+    ep_kq_all
+end
+
+"""
     eph_apply_rotations!(ep_kq_all, g, ukqs, u_phs, tmp; g2_out=nothing, ωq=nothing)
 
 Apply the two e-ph gauge rotations to the Fourier-interpolated `g` (`(ndata, nq)`, reshaped to

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -356,6 +356,22 @@ function eph_apply_rotations_rqkq!(ep_kq_all::AbstractArray{Complex{T},4}, g,
 end
 
 """
+    add_eph_dipole_batched!(eps, coeffs, ukqs, uks, mmats)
+
+Add the polar (long-range) e-ph dipole term to a batch of e-ph matrices `eps` `(nw, nw, nmodes, nk)`,
+the batched counterpart of the per-k `epdata_compute_eph_dipole!` (unscreened, ϵ ≡ 1):
+`eps[m,n,ν,k] += coeffs[ν] · Σ_iw conj(ukqs[iw,m,k]) uks[iw,n,k]`. Window-masked eigenvector columns
+make the overlap vanish for out-of-window `m`/`n`. `mmats` is `(nw, nw, nk)` scratch on the same
+backend. Runs on the backend of `eps` (the `batched_gemm!` + broadcast are backend-generic).
+"""
+function add_eph_dipole_batched!(eps, coeffs, ukqs, uks, mmats)
+    nw, _, nmodes, nk = size(eps)
+    batched_gemm!('C', 'N', ukqs, uks, mmats)   # mmats[m,n,k] = Σ_iw conj(ukqs[iw,m,k]) uks[iw,n,k]
+    eps .+= reshape(coeffs, 1, 1, nmodes, 1) .* reshape(mmats, nw, nw, 1, nk)
+    eps
+end
+
+"""
     eph_apply_rotations!(ep_kq_all, g, ukqs, u_phs, tmp; g2_out=nothing, ωq=nothing)
 
 Apply the two e-ph gauge rotations to the Fourier-interpolated `g` (`(ndata, nq)`, reshaped to

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -153,7 +153,7 @@ end
 #  wins on the GPU. Rotation matrices are stacked along the batch dimension.
 
 """
-    get_eph_RR_to_kR_batched!(ep_ekpR_all, epmat_itp::BatchedWannierInterpolator, ks, uks)
+    get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat::BatchedWannierInterpolator, ks, uks)
 
 Batched over a list of k-points `ks`. `uks` is `(nw, nband, nk)` (one `uk` per k).
 Writes `ep_ekpR_all`, shape `(nw*nband*nmodes, nr_ep, nk)` — column `k` is the `op_r` of the
@@ -169,8 +169,8 @@ every k onto the same `nbandk_max`-wide eigenvector window (`nband = nbandk_max`
 `nband = nw` special case.
 """
 function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
-                                   epmat_itp::BatchedWannierInterpolator{T}, ks, uks) where {T}
-    epmat = epmat_itp.parent
+                                   itp_epmat::BatchedWannierInterpolator{T}, ks, uks) where {T}
+    epmat = itp_epmat.parent
     nr_ep = length(epmat.irvec_next)
     nw, nband, nk = size(uks)
     nmodes = div(epmat.ndata, nw^2 * nr_ep)
@@ -180,7 +180,7 @@ function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
     @assert size(ep_ekpR_all) == (nw * nband * nmodes, nr_ep, nk)
 
     g = similar(epmat.op_r, Complex{T}, epmat.ndata, nk)
-    get_fourier_batched!(g, epmat_itp, ks)                              # (nw^2*nmodes*nr_ep, nk)
+    get_fourier_batched!(g, itp_epmat, ks)                              # (nw^2*nmodes*nr_ep, nk)
 
     gp = permutedims(reshape(g, nw, nw, M, nk), (2, 1, 3, 4))           # (jw, iw, M, k)
     C = similar(g, Complex{T}, nband, nw * M, nk)
@@ -191,10 +191,10 @@ function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
 end
 
 """
-    KRtoKQWorkspace(proto, ndata, nbandkq, nbandk, nmodes, nq)
+    KRtoKQWorkspace(gpu_array, ndata, nbandkq, nbandk, nmodes, nq)
 
 Preallocated scratch for [`get_eph_kR_to_kq_batched!`](@ref), reused across the per-k calls so the
-driver does no per-call `similar`. `proto` is an array on the target backend (e.g. `parent.op_r`);
+driver does no per-call `similar`. `gpu_array` is an array on the target backend (e.g. `parent.op_r`);
 the buffers follow its backend and element type. `ndata = nw*nbandk*nmodes`.
 
 TODO: merge this with the other Wannier→Bloch scratch (the eigensolve / velocity buffers) into a
@@ -204,14 +204,14 @@ struct KRtoKQWorkspace{MT<:AbstractMatrix, AT<:AbstractArray}
     g::MT      # (ndata, nq)                  — Fourier output g(k+R_ep) for all q
     tmp::AT    # (nbandkq, nbandk*nmodes, nq) — after the ukq' rotation
 end
-function KRtoKQWorkspace(proto, ndata::Int, nbandkq::Int, nbandk::Int, nmodes::Int, nq::Int)
-    T = real(eltype(proto))
-    KRtoKQWorkspace(similar(proto, Complex{T}, ndata, nq),
-                    similar(proto, Complex{T}, nbandkq, nbandk * nmodes, nq))
+function KRtoKQWorkspace(gpu_array, ndata::Int, nbandkq::Int, nbandk::Int, nmodes::Int, nq::Int)
+    T = real(eltype(gpu_array))
+    KRtoKQWorkspace(similar(gpu_array, Complex{T}, ndata, nq),
+                    similar(gpu_array, Complex{T}, nbandkq, nbandk * nmodes, nq))
 end
 
 """
-    get_eph_kR_to_kq_batched!(ep_kq_all, ep_ekpR_itp::BatchedWannierInterpolator, qs, u_phs, ukqs; ws=nothing)
+    get_eph_kR_to_kq_batched!(ep_kq_all, itp_ep_ekpR::BatchedWannierInterpolator, qs, u_phs, ukqs; ws=nothing)
 
 Batched over a list of q-points `qs` (for a fixed k). `ukqs` is `(nw, nbandkq, nq)` and
 `u_phs` is `(nmodes, nmodes, nq)`. Writes `ep_kq_all`, shape `(nbandkq, nbandk, nmodes, nq)`.
@@ -224,14 +224,14 @@ scratch across calls instead of allocating it each call — the per-k hot path i
 this, sizing `ws` for the max chunk width and passing `nq ≤` that for a partial final chunk.
 """
 function get_eph_kR_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
-                                   ep_ekpR_itp::BatchedWannierInterpolator{T}, qs, u_phs, ukqs;
+                                   itp_ep_ekpR::BatchedWannierInterpolator{T}, qs, u_phs, ukqs;
                                    ws::Union{Nothing,KRtoKQWorkspace}=nothing,
                                    g2_out=nothing, ωq=nothing) where {T}
     nbandkq, nbandk, nmodes, nq = size(ep_kq_all)
     nw = size(ukqs, 1)
     @assert size(ukqs) == (nw, nbandkq, nq)
     @assert size(u_phs) == (nmodes, nmodes, nq)
-    parent = ep_ekpR_itp.parent
+    parent = itp_ep_ekpR.parent
     @assert parent.ndata == nw * nbandk * nmodes
 
     if ws === nothing
@@ -246,17 +246,17 @@ function get_eph_kR_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
         tmp = view(ws.tmp, :, :, 1:nq)
     end
 
-    get_fourier_batched!(g, ep_ekpR_itp, qs)                           # (nw*nbandk*nmodes, nq)
+    get_fourier_batched!(g, itp_ep_ekpR, qs)                           # (nw*nbandk*nmodes, nq)
     eph_apply_rotations!(ep_kq_all, g, ukqs, u_phs, tmp; g2_out, ωq)
     ep_kq_all
 end
 
 """
-    RqToKQWorkspace(proto, ndata, nbandkq, nbandk, nmodes, nk)
+    RqToKQWorkspace(gpu_array, ndata, nbandkq, nbandk, nmodes, nk)
 
 Preallocated scratch for [`get_eph_Rq_to_kq_batched!`](@ref), reused across the per-q calls of the
-outer-q loop so the driver does no per-call `similar`. `proto` is an array on the target backend
-(e.g. `epobj_eRpq_itp.parent.op_r`); the buffers follow its backend and element type.
+outer-q loop so the driver does no per-call `similar`. `gpu_array` is an array on the target backend
+(e.g. `itp_epobj_eRpq.parent.op_r`); the buffers follow its backend and element type.
 `ndata = nw^2*nmodes` is the parent (electron-Wannier / phonon-Bloch) data size.
 """
 struct RqToKQWorkspace{MT<:AbstractMatrix, AT<:AbstractArray, BT<:AbstractArray}
@@ -264,20 +264,20 @@ struct RqToKQWorkspace{MT<:AbstractMatrix, AT<:AbstractArray, BT<:AbstractArray}
     tmp::AT     # (nbandkq, nw*nmodes, nk)      — after the ukq' rotation
     uk_rep::BT  # (nw, nbandk, nmodes*nk)       — uk replicated over the phonon modes
 end
-function RqToKQWorkspace(proto, ndata::Int, nbandkq::Int, nbandk::Int, nmodes::Int, nk::Int)
-    T = real(eltype(proto))
+function RqToKQWorkspace(gpu_array, ndata::Int, nbandkq::Int, nbandk::Int, nmodes::Int, nk::Int)
+    T = real(eltype(gpu_array))
     nw = isqrt(div(ndata, nmodes))
     nw^2 * nmodes == ndata || throw(ArgumentError("ndata=$ndata is not nw^2*nmodes for nmodes=$nmodes"))
-    RqToKQWorkspace(similar(proto, Complex{T}, ndata, nk),
-                    similar(proto, Complex{T}, nbandkq, nw * nmodes, nk),
-                    similar(proto, Complex{T}, nw, nbandk, nmodes * nk))
+    RqToKQWorkspace(similar(gpu_array, Complex{T}, ndata, nk),
+                    similar(gpu_array, Complex{T}, nbandkq, nw * nmodes, nk),
+                    similar(gpu_array, Complex{T}, nw, nbandk, nmodes * nk))
 end
 
 """
-    get_eph_Rq_to_kq_batched!(ep_kq_all, epobj_eRpq_itp::BatchedWannierInterpolator, ks, uks, ukqs; ws=nothing)
+    get_eph_Rq_to_kq_batched!(ep_kq_all, itp_epobj_eRpq::BatchedWannierInterpolator, ks, uks, ukqs; ws=nothing)
 
 Batched over a list of k-points `ks` (for a fixed q). Counterpart of [`get_eph_Rq_to_kq!`](@ref)
-that runs on the backend of `epobj_eRpq_itp.parent.op_r` — the list-batched inner-k step of the
+that runs on the backend of `itp_epobj_eRpq.parent.op_r` — the list-batched inner-k step of the
 outer-q e-ph loop. `uks` is `(nw, nbandk, nk)` and `ukqs` is `(nw, nbandkq, nk)` (one eigenvector
 per k / k+q). Writes `ep_kq_all`, shape `(nbandkq, nbandk, nmodes, nk)`.
 
@@ -294,14 +294,14 @@ Full-band only: like [`get_eph_RR_to_kR_batched!`](@ref), all `nk` k-points must
 `nbandk`/`nbandkq` (energy windows are handled by callers with masks).
 """
 function get_eph_Rq_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
-                                   epobj_eRpq_itp::BatchedWannierInterpolator{T}, ks, uks, ukqs;
+                                   itp_epobj_eRpq::BatchedWannierInterpolator{T}, ks, uks, ukqs;
                                    ws::Union{Nothing,RqToKQWorkspace}=nothing) where {T}
     nbandkq, nbandk, nmodes, nk = size(ep_kq_all)
     nw = size(uks, 1)
     @assert size(uks) == (nw, nbandk, nk)
     @assert size(ukqs) == (nw, nbandkq, nk)
     @assert length(ks) == nk
-    parent = epobj_eRpq_itp.parent
+    parent = itp_epobj_eRpq.parent
     @assert parent.ndata == nw^2 * nmodes
 
     if ws === nothing
@@ -317,7 +317,7 @@ function get_eph_Rq_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
 
     # Fourier over R_el at every k -> g(k) in (nw, nw, nmodes, nk); index legend g[iw, jw, ν, k]
     # with iw the k+q-side (ukq) leg and jw the k-side (uk) leg.
-    get_fourier_batched!(g, epobj_eRpq_itp, ks)                        # (nw^2*nmodes, nk)
+    get_fourier_batched!(g, itp_epobj_eRpq, ks)                        # (nw^2*nmodes, nk)
 
     eph_apply_rotations_rqkq!(ep_kq_all, g, uks, ukqs, tmp, uk_rep)
     ep_kq_all

--- a/src/wfpt.jl
+++ b/src/wfpt.jl
@@ -108,7 +108,7 @@ function compute_debye_waller_active_space(model, kpts, el_mom, window; fourier_
 
     dw_active = zeros(ComplexF64, nw, nw, 3, nmodes, kpts.n)
 
-    mom_itp = get_interpolator(el_mom; fourier_mode)
+    itp_mom = get_interpolator(el_mom; fourier_mode)
 
     for (ik, xk) in enumerate(kpts.vectors)
         epdata.el_k  = el_k_save[ik]
@@ -118,7 +118,7 @@ function compute_debye_waller_active_space(model, kpts, el_mom, window; fourier_
         get_eph_RR_to_kR!(ep_ekpR_obj, epmat, xk, no_offset_view(uk))
         get_eph_kR_to_kq!(no_offset_view(epdata.ep), ep_ekpR, xq, I(model.nmodes), no_offset_view(uk))
 
-        ElectronPhonon.set_velocity!(epdata.el_k, mom_itp, xk, :Direct)
+        ElectronPhonon.set_velocity!(epdata.el_k, itp_mom, xk, :Direct)
 
         for imode in 1:nmodes, idir in 1:3
             for ib in 1:nw, jb in 1:nw, pb in 1:nw
@@ -191,7 +191,7 @@ function run_wfpt(folder, outdir, prefix, model, window_wfpt, kpts, occupation_p
         # @threads for (id_chunk, iqs) in enumerate(chunks(1:qpts_coarse.n; n = nchunks_threads))
             epdata = take!(epdatas)
             ep_ekpR = take!(ep_ekpRs)
-            dw_itp = take!(dw_itps)
+            itp_dw = take!(dw_itps)
             Σ_Fan_chunk = Σ_Fan_channel[id_chunk]
             Σ_DW_chunk = Σ_DW_channel[id_chunk]
 
@@ -201,8 +201,8 @@ function run_wfpt(folder, outdir, prefix, model, window_wfpt, kpts, occupation_p
                 xq = qpts_coarse.vectors[iq]
 
                 ph = ph_save[iq]
-                dg_itp = get_interpolator(dgmat[iq]; fourier_mode = "normal")
-                sth_itp = get_interpolator(sthmat[iq]; fourier_mode = "normal")
+                itp_dg = get_interpolator(dgmat[iq]; fourier_mode = "normal")
+                itp_sth = get_interpolator(sthmat[iq]; fourier_mode = "normal")
 
                 el_kq = compute_electron_states(model, Kpoints(xk + xq), ["eigenvalue", "eigenvector"])[1]
 
@@ -213,23 +213,23 @@ function run_wfpt(folder, outdir, prefix, model, window_wfpt, kpts, occupation_p
                 u_ph = ph_save[iq].u
 
                 # Interpolate WFPT matrix elements from (Re, q) to (k, q)
-                get_fourier!(dw_itp.out, dw_itp, xk)
-                get_fourier!(dg_itp.out, dg_itp, xk)
-                get_fourier!(sth_itp.out, sth_itp, xk)
+                get_fourier!(itp_dw.out, itp_dw, xk)
+                get_fourier!(itp_dg.out, itp_dg, xk)
+                get_fourier!(itp_sth.out, itp_sth, xk)
 
-                dg_k_tmp = reshape(dg_itp.out, nw, nw, nmodes)
+                dg_k_tmp = reshape(itp_dg.out, nw, nw, nmodes)
                 dg_k = zeros(ComplexF64, nw, nw, nmodes)
                 @views for imode in 1:nmodes, jmode in 1:nmodes
                     dg_k[:, :, imode] .+= dg_k_tmp[:, :, jmode] .* u_ph[jmode, imode]
                 end
 
-                sth_k_tmp = reshape(sth_itp.out, nw, nw, nmodes, nmodes)
+                sth_k_tmp = reshape(itp_sth.out, nw, nw, nmodes, nmodes)
                 sth_k = zeros(ComplexF64, nw, nw, nmodes)
                 @views for imode in 1:nmodes, jmode in 1:nmodes, kmode in 1:nmodes
                     sth_k[:, :, imode] .+= sth_k_tmp[:, :, kmode, jmode] .* conj(u_ph[kmode, imode]) .* u_ph[jmode, imode]
                 end
 
-                dw_k_tmp = reshape(dw_itp.out, nw, nw, 3, nmodes)
+                dw_k_tmp = reshape(itp_dw.out, nw, nw, 3, nmodes)
                 dw_k_tmp .-= view(dw_active, :, :, :, :, ik)  # Subtract active-space Debye-Waller contribution
 
                 dw_k = zeros(ComplexF64, nw, nw, nmodes)
@@ -282,7 +282,7 @@ function run_wfpt(folder, outdir, prefix, model, window_wfpt, kpts, occupation_p
 
             put!(ep_ekpRs, ep_ekpR)
             put!(epdatas, epdata)
-            put!(dw_itps, dw_itp)
+            put!(dw_itps, itp_dw)
 
         end # iq chunk
     end # ik
@@ -313,7 +313,7 @@ function compute_self_energy_active_DW(folder, outdir, prefix, model, window, kp
 
     dw_active = ElectronPhonon.compute_debye_waller_active_space(model, kpts, el_mom, window; wannier_gauge=false)
 
-    # dw_itp = get_interpolator(dwmat)
+    # itp_dw = get_interpolator(dwmat)
     el_k_save = compute_electron_states(model, kpts, ["eigenvalue", "eigenvector"]; fourier_mode);
 
     Σ = [zeros(nw, length(occupation_params.Tlist)) for _ in 1:kpts.n]
@@ -329,7 +329,7 @@ function compute_self_energy_active_DW(folder, outdir, prefix, model, window, kp
             # uk = el_k.u
             u_ph = ph.u
 
-            # get_fourier!(dw_itp.out, dw_itp, xk)
+            # get_fourier!(itp_dw.out, itp_dw, xk)
 
             # dw_active is in the Wannier gauge, so we don't need to multiply uk
             dw_k_tmp = view(dw_active, :, :, :, :, ik)

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -127,10 +127,10 @@ ElectronPhonon.postprocess_calculator_inner!(c::_OptInQCalc; kwargs...) = (c.flu
         _PlainQCalc(), nothing, nothing, nothing, nothing, nothing, nothing, nothing, 1)
 
     # Opt-in calculator: hook returns true and the per-q inner hooks dispatch to the override
-    # (the GPU outer-q loop passes iq / proto / k_chunk_size through them).
+    # (the GPU outer-q loop passes iq / gpu_array / nk_batch_max through them).
     c = _OptInQCalc(0, 0)
     @test ElectronPhonon.allow_eph_outer_q_batched(c) == true
-    ElectronPhonon.setup_calculator_inner!(c; iq=1, proto=zeros(1), k_chunk_size=4)
+    ElectronPhonon.setup_calculator_inner!(c; iq=1, gpu_array=zeros(1), nk_batch_max=4)
     ElectronPhonon.postprocess_calculator_inner!(c; iq=1)
     @test (c.setup, c.flush) == (1, 1)
 end
@@ -407,6 +407,92 @@ end
         @test_throws Exception ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
             calculators=[_RecordCalcBatched()], symmetry=nothing, use_gpu=true,
             energy_conservation=(:Fixed, 0.1), progress_print_step=10^9)
+    end
+end
+
+# Outer-q analogue of `_RecordCalc`/`_RecordCalcBatched` above: a calculator for
+# `run_eph_outer_q` that accumulates a per-q, GAUGE-INVARIANT scalar
+#   A[iq] = Σ_{m,n,ν,k} wtk[k] · |ep[m,n,ν,k]|²
+# (the band-summed |g|² is invariant under the electron/phonon eigenvector gauge, so the
+# degenerate-band gauge difference between the CPU LAPACK and GPU batched eigensolvers — see the
+# note in the outer-k test above — does not matter here). This lets the SAME calculator validate
+# both the CPU (`run_calculator!`) and GPU-batched (`run_calculator_outer_q_batched!`) hooks of
+# `run_eph_outer_q` against each other directly, without restricting to eigenvalues only.
+#
+# Thread-safety: `run_calculator!` on the CPU path is called from multiple threads (one per
+# k-chunk) for the SAME iq, so the per-q sum is accumulated into a per-chunk slot (`id_chunk`,
+# passed by the driver) and reduced in `postprocess_calculator_inner!`; no cross-thread races.
+mutable struct _RecordCalcOuterQ <: ElectronPhonon.AbstractCalculator
+    A::Vector{Float64}       # (nq,) final per-q gauge-invariant sum
+    Achunk::Vector{Float64}  # (nchunks,) per-thread-chunk partial sum for the CURRENT q (CPU path)
+    Adev::Any                # length-1 device accumulator for the CURRENT q (GPU path), or nothing
+    _RecordCalcOuterQ() = new(zeros(0), zeros(0), nothing)
+end
+ElectronPhonon.allow_eph_outer_q(::_RecordCalcOuterQ) = true
+ElectronPhonon.allow_eph_outer_q_batched(::_RecordCalcOuterQ) = true
+ElectronPhonon.allowed_eph_phonon_basis(::_RecordCalcOuterQ) = [:eigenmode]
+function ElectronPhonon.setup_calculator!(c::_RecordCalcOuterQ, kpts, qpts, el_states;
+        nchunks_threads=nthreads(), kwargs...)
+    c.A = zeros(qpts.n)
+    c.Achunk = zeros(nchunks_threads)
+    c.Adev = nothing
+    c
+end
+# CPU path: zero this q's per-chunk accumulator. GPU path (gpu_array !== nothing): (re)allocate and
+# zero this q's length-1 device accumulator.
+function ElectronPhonon.setup_calculator_inner!(c::_RecordCalcOuterQ; gpu_array=nothing, kwargs...)
+    if gpu_array !== nothing
+        c.Adev = fill!(similar(gpu_array, Float64, 1), 0.0)
+    else
+        fill!(c.Achunk, 0.0)
+    end
+    c
+end
+# Reduce this q's accumulator (per-chunk sum, or device→host copy) into A[iq].
+function ElectronPhonon.postprocess_calculator_inner!(c::_RecordCalcOuterQ; iq, kwargs...)
+    c.A[iq] = c.Adev === nothing ? sum(c.Achunk) : Array(c.Adev)[1]
+    c.Adev = nothing
+    c
+end
+ElectronPhonon.postprocess_calculator!(c::_RecordCalcOuterQ; kwargs...) = c
+# CPU hook: epdata.ep is already an OffsetArray restricted to (el_kq.rng, el_k.rng, :), so summing
+# all of it covers exactly the in-window (m, n, ν) triples.
+function ElectronPhonon.run_calculator!(c::_RecordCalcOuterQ, epdata, ik, iq, ikq; id_chunk, kwargs...)
+    c.Achunk[id_chunk] += epdata.wtk * sum(abs2, epdata.ep)
+    c
+end
+# GPU batched hook: `ep` is (nw,nw,nmodes,nkc) on the device, full-band (out-of-window bands already
+# zeroed by the loop's eigenvector-column masking); `wtk` is (nkc,) with padded tail entries = 0, so
+# no special-casing of the final partial k-batch is needed. `sum` of a device broadcast expression
+# reduces on-device and returns a host scalar without any scalar indexing (allowed under
+# CUDA.allowscalar(false)).
+function ElectronPhonon.run_calculator_outer_q_batched!(c::_RecordCalcOuterQ, ep, e_k, e_kq, uk, ukq, wtk, xks, iq; kwargs...)
+    nkc = size(ep, 4)
+    val = sum(abs2.(ep) .* reshape(wtk, 1, 1, 1, nkc))
+    c.Adev .+= val
+    c
+end
+
+@testset "run_eph_outer_q CPU vs GPU equivalence" begin
+    if !GPU_AVAILABLE
+        @info "CUDA not available/functional — skipping run_eph_outer_q CPU-vs-GPU test"
+    else
+        model = _load_model_from_artifacts("pb"; epmat_outer_momentum = "ph")
+        grid = (4, 4, 4)
+
+        calc_cpu = _RecordCalcOuterQ()
+        ElectronPhonon.run_eph_outer_q(model, grid, grid;
+            calculators=[calc_cpu], use_symmetry=false, keep_all_qpts=true,
+            use_gpu=false, progress_print_step=10^9)
+
+        calc_gpu = _RecordCalcOuterQ()
+        ElectronPhonon.run_eph_outer_q(model, grid, grid;
+            calculators=[calc_gpu], use_symmetry=false, keep_all_qpts=true,
+            use_gpu=true, progress_print_step=10^9)
+
+        rdiff = maximum(abs, calc_cpu.A .- calc_gpu.A) / maximum(abs, calc_cpu.A)
+        @info "run_eph_outer_q CPU vs GPU" cpu_A=calc_cpu.A gpu_A=calc_gpu.A rdiff
+        @test isapprox(calc_cpu.A, calc_gpu.A; rtol=1e-8)
     end
 end
 

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -109,28 +109,29 @@ end
     check_eph_batched(identity, identity; rtol=1e-10)
 end
 
-# Plumbing of the outer-q batched calculator hook (allow_eph_batched_q / run_calculator_batched_q!
-# and the per-q lifecycle hooks) used by `run_eph_outer_q(...; use_gpu=true)`. Backend-agnostic, so
-# no GPU is needed — it only checks the opt-in defaults and the not-implemented error paths.
+# Plumbing of the outer-q batched calculator hook (allow_eph_outer_q_batched /
+# run_calculator_outer_q_batched!) used by `run_eph_outer_q(...; use_gpu=true)`. The per-q device
+# lifecycle reuses the generic setup_calculator_inner! / postprocess_calculator_inner! hooks (same
+# as the CPU outer-q loop). Backend-agnostic, so no GPU is needed — checks the opt-in default and
+# the not-implemented error path.
 struct _PlainQCalc <: ElectronPhonon.AbstractCalculator end
 mutable struct _OptInQCalc <: ElectronPhonon.AbstractCalculator; setup::Int; flush::Int; end
-ElectronPhonon.allow_eph_batched_q(::_OptInQCalc) = true
-ElectronPhonon.setup_calculator_batched_q!(c::_OptInQCalc; kwargs...) = (c.setup += 1; nothing)
-ElectronPhonon.flush_calculator_batched_q!(c::_OptInQCalc; kwargs...) = (c.flush += 1; nothing)
+ElectronPhonon.allow_eph_outer_q_batched(::_OptInQCalc) = true
+ElectronPhonon.setup_calculator_inner!(c::_OptInQCalc; kwargs...) = (c.setup += 1; nothing)
+ElectronPhonon.postprocess_calculator_inner!(c::_OptInQCalc; kwargs...) = (c.flush += 1; nothing)
 
 @testset "outer-q batched calculator hook plumbing" begin
-    # Default opts out; the lifecycle hooks are no-ops; the main hook errors if unimplemented.
-    @test ElectronPhonon.allow_eph_batched_q(_PlainQCalc()) == false
-    @test ElectronPhonon.setup_calculator_batched_q!(_PlainQCalc(); iq=1, proto=zeros(1)) === nothing
-    @test ElectronPhonon.flush_calculator_batched_q!(_PlainQCalc(); iq=1) === nothing
-    @test_throws Exception ElectronPhonon.run_calculator_batched_q!(
+    # Default opts out; the batched-q hook errors if unimplemented.
+    @test ElectronPhonon.allow_eph_outer_q_batched(_PlainQCalc()) == false
+    @test_throws Exception ElectronPhonon.run_calculator_outer_q_batched!(
         _PlainQCalc(), nothing, nothing, nothing, nothing, nothing, nothing, nothing, 1)
 
-    # Opt-in calculator: hook returns true and the lifecycle hooks dispatch to the override.
+    # Opt-in calculator: hook returns true and the per-q inner hooks dispatch to the override
+    # (the GPU outer-q loop passes iq / proto / k_chunk_size through them).
     c = _OptInQCalc(0, 0)
-    @test ElectronPhonon.allow_eph_batched_q(c) == true
-    ElectronPhonon.setup_calculator_batched_q!(c; iq=1, proto=zeros(1), k_chunk_size=4)
-    ElectronPhonon.flush_calculator_batched_q!(c; iq=1)
+    @test ElectronPhonon.allow_eph_outer_q_batched(c) == true
+    ElectronPhonon.setup_calculator_inner!(c; iq=1, proto=zeros(1), k_chunk_size=4)
+    ElectronPhonon.postprocess_calculator_inner!(c; iq=1)
     @test (c.setup, c.flush) == (1, 1)
 end
 
@@ -307,16 +308,16 @@ function ElectronPhonon.run_calculator!(c::_RecordCalc, epdata, ik, iq, ikq; kwa
 end
 
 # Device-native counterpart of `_RecordCalc`: opts into the batched hook so the GPU loop keeps
-# the e-ph matrix on the device and calls `run_calculator_batched!` once per (k, batch). It
+# the e-ph matrix on the device and calls `run_calculator_outer_k_batched!` once per (k, batch). It
 # records the same `g2 = |ep|²/2ω` and ωq as `_RecordCalc`, exercising the loop's device-native
-# branch (allow_eph_batched, ωq/ikqs staging, on-device g2) without MigdalEliashberg.
+# branch (allow_eph_outer_k_batched, ωq/ikqs staging, on-device g2) without MigdalEliashberg.
 mutable struct _RecordCalcBatched <: ElectronPhonon.AbstractCalculator
     g2::Array{Float64,5}
     ωq::Array{Float64,5}
     _RecordCalcBatched() = new(zeros(0, 0, 0, 0, 0), zeros(0, 0, 0, 0, 0))
 end
 ElectronPhonon.allow_eph_outer_k(::_RecordCalcBatched) = true
-ElectronPhonon.allow_eph_batched(::_RecordCalcBatched) = true
+ElectronPhonon.allow_eph_outer_k_batched(::_RecordCalcBatched) = true
 function ElectronPhonon.setup_calculator!(c::_RecordCalcBatched, kpts, qpts, el_states;
         el_states_kq, kqpts, nw, nmodes, kwargs...)
     c.g2 = zeros(nw, nw, nmodes, kpts.n, kqpts.n)
@@ -329,7 +330,7 @@ ElectronPhonon.postprocess_calculator!(c::_RecordCalcBatched; kwargs...) = c
 # Computes g2 from `ep_kq` itself (independent check of the fused-kernel ep_kq output). The GPU
 # loop now also folds g2 into the kRkq kernel and passes it as `g2=`; when present, assert it
 # matches the abs2/(2ω) recomputation — this guards the production g2 output in-package.
-function ElectronPhonon.run_calculator_batched!(c::_RecordCalcBatched, ep_kq, ωq, ik, ikqs;
+function ElectronPhonon.run_calculator_outer_k_batched!(c::_RecordCalcBatched, ep_kq, ωq, ik, ikqs;
         g2=nothing, ibandk_offset=0)
     nbandkq, nbandk, nm, nqc = size(ep_kq)
     g2dev = abs2.(ep_kq) ./ (2 .* reshape(ωq, 1, 1, nm, nqc))
@@ -393,7 +394,7 @@ end
             nk_batch_max=5, nq_batch_max=7, progress_print_step=10^9)
         @test maximum(abs, cg.g2 .- cbk.g2) < 1e-9 * scale
 
-        # Fully-GPU policy: a non-batched calculator (no allow_eph_batched) must be rejected, not
+        # Fully-GPU policy: a non-batched calculator (no allow_eph_outer_k_batched) must be rejected, not
         # silently run on the host path.
         @test_throws Exception ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
             calculators=[_RecordCalc()], symmetry=nothing, use_gpu=true, progress_print_step=10^9)

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -1,10 +1,10 @@
 using Test
 using ElectronPhonon
-using ElectronPhonon: WannierObject, Vec3, get_eph_RR_to_kR!, get_eph_kR_to_kq!, to_device
+using ElectronPhonon: WannierObject, Vec3, get_eph_RR_to_kR!, get_eph_kR_to_kq!, get_eph_Rq_to_kq!, to_device
 # Batched drivers / primitives are internal (unexported); import the ones the tests use.
 using ElectronPhonon: eigvals_batched, eigen_batched, get_el_eigen_batched, get_el_eigen_valueonly_batched,
     get_el_velocity_direct_batched, get_eph_RR_to_kR_batched!, get_eph_kR_to_kq_batched!,
-    eph_apply_rotations!, KRtoKQWorkspace, batched_gemm!
+    get_eph_Rq_to_kq_batched!, eph_apply_rotations!, eph_apply_rotations_rqkq!, KRtoKQWorkspace, batched_gemm!
 using LinearAlgebra
 
 # CUDA is a weak dependency (not a test dependency), so load it defensively and skip the GPU
@@ -42,6 +42,7 @@ function check_eph_batched(to_dev, arr_dev; rtol)
     uks  = cat([rand(ComplexF64, nwe, nband) for _ in 1:nk2]...; dims = 3)
     uphs = cat([rand(ComplexF64, nmodes, nmodes) for _ in 1:nq2]...; dims = 3)
     ukqs = cat([rand(ComplexF64, nwe, nband) for _ in 1:nq2]...; dims = 3)
+    ukqs_k = cat([rand(ComplexF64, nwe, nband) for _ in 1:nk2]...; dims = 3)  # k+q eigvecs, one per k
 
     # Independent per-k/q CPU references (ground truth). q-sweep uses k = ks[1].
     refs_RR = map(1:nk2) do ik
@@ -75,6 +76,23 @@ function check_eph_batched(to_dev, arr_dev; rtol)
         @test isapprox(ep_kq_h[:, :, :, iq], ep_ref[:, :, :, iq]; rtol)
     end
 
+    # list-batched Rq→kq over all k (fixed q) — electron-Wannier / phonon-Bloch object interpolated
+    # over R_el at each k, then rotated by uk (right) and ukq (left). Check every slice.
+    eRpq_obj = WannierObject(irvec_el, rand(ComplexF64, nwe^2 * nmodes, nr_el))
+    ep_rqkq_ref = zeros(ComplexF64, nband, nband, nmodes, nk2)
+    for ik in 1:nk2
+        get_eph_Rq_to_kq!(view(ep_rqkq_ref, :, :, :, ik), get_interpolator(eRpq_obj; fourier_mode="normal"),
+                          ks[ik], uks[:, :, ik], ukqs_k[:, :, ik])
+    end
+    eRpq_d = to_dev(eRpq_obj)
+    ep_rqkq = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nk2))
+    get_eph_Rq_to_kq_batched!(ep_rqkq, get_interpolator(eRpq_d; fourier_mode="batched", batch_size=nk2),
+                              ks, arr_dev(uks), arr_dev(ukqs_k))
+    ep_rqkq_h = Array(ep_rqkq)
+    for ik in 1:nk2
+        @test isapprox(ep_rqkq_h[:, :, :, ik], ep_rqkq_ref[:, :, :, ik]; rtol)
+    end
+
     # g2 fold: the driver can also write g2 = |ep|²/(2ω) in the same pass — the GPU fused kernel
     # writes it from registers, the CPU / large-nw path uses the generic broadcast. Check against
     # the independent per-q reference ep_ref. (Exercises both `eph_apply_rotations!` g2 paths.)
@@ -89,6 +107,53 @@ end
 
 @testset "batched e-ph drivers (CPU)" begin
     check_eph_batched(identity, identity; rtol=1e-10)
+end
+
+# Plumbing of the outer-q batched calculator hook (allow_eph_batched_q / run_calculator_batched_q!
+# and the per-q lifecycle hooks) used by `run_eph_outer_q(...; use_gpu=true)`. Backend-agnostic, so
+# no GPU is needed — it only checks the opt-in defaults and the not-implemented error paths.
+struct _PlainQCalc <: ElectronPhonon.AbstractCalculator end
+mutable struct _OptInQCalc <: ElectronPhonon.AbstractCalculator; setup::Int; flush::Int; end
+ElectronPhonon.allow_eph_batched_q(::_OptInQCalc) = true
+ElectronPhonon.setup_calculator_batched_q!(c::_OptInQCalc; kwargs...) = (c.setup += 1; nothing)
+ElectronPhonon.flush_calculator_batched_q!(c::_OptInQCalc; kwargs...) = (c.flush += 1; nothing)
+
+@testset "outer-q batched calculator hook plumbing" begin
+    # Default opts out; the lifecycle hooks are no-ops; the main hook errors if unimplemented.
+    @test ElectronPhonon.allow_eph_batched_q(_PlainQCalc()) == false
+    @test ElectronPhonon.setup_calculator_batched_q!(_PlainQCalc(); iq=1, proto=zeros(1)) === nothing
+    @test ElectronPhonon.flush_calculator_batched_q!(_PlainQCalc(); iq=1) === nothing
+    @test_throws Exception ElectronPhonon.run_calculator_batched_q!(
+        _PlainQCalc(), nothing, nothing, nothing, nothing, nothing, nothing, nothing, 1)
+
+    # Opt-in calculator: hook returns true and the lifecycle hooks dispatch to the override.
+    c = _OptInQCalc(0, 0)
+    @test ElectronPhonon.allow_eph_batched_q(c) == true
+    ElectronPhonon.setup_calculator_batched_q!(c; iq=1, proto=zeros(1), k_chunk_size=4)
+    ElectronPhonon.flush_calculator_batched_q!(c; iq=1)
+    @test (c.setup, c.flush) == (1, 1)
+end
+
+@testset "Rq→kq rotation: GPU cuBLAS fallback (large nw²·nmodes)" begin
+    # check_eph_batched exercises the FUSED rqkq kernel (nw²·nmodes ≤ _FUSED_RQKQ_MAX_NW2NM);
+    # here nw=8, nmodes=12 ⇒ 768 > 512 forces the `invoke`-to-generic (cuBLAS two-GEMM) branch of
+    # the CUDA `eph_apply_rotations_rqkq!`. Compare it to the generic CPU method (ground truth).
+    if !GPU_AVAILABLE
+        @info "CUDA not available/functional — skipping GPU rqkq fallback test"
+    else
+        nw, nmodes, nk, nbandk, nbandkq = 8, 12, 10, 8, 8
+        g   = rand(ComplexF64, nw * nw * nmodes, nk)
+        uks = rand(ComplexF64, nw, nbandk, nk)
+        ukqs = rand(ComplexF64, nw, nbandkq, nk)
+        ep_cpu = zeros(ComplexF64, nbandkq, nbandk, nmodes, nk)
+        eph_apply_rotations_rqkq!(ep_cpu, copy(g), uks, ukqs,
+            zeros(ComplexF64, nbandkq, nw * nmodes, nk), zeros(ComplexF64, nw, nbandk, nmodes * nk))
+        ep_gpu = CuArray(zeros(ComplexF64, nbandkq, nbandk, nmodes, nk))
+        eph_apply_rotations_rqkq!(ep_gpu, CuArray(copy(g)), CuArray(uks), CuArray(ukqs),
+            CuArray(zeros(ComplexF64, nbandkq, nw * nmodes, nk)),
+            CuArray(zeros(ComplexF64, nw, nbandk, nmodes * nk)))
+        @test isapprox(Array(ep_gpu), ep_cpu; rtol=1e-9)
+    end
 end
 
 @testset "batched eigensolve (CPU)" begin

--- a/test/test_symmetry_operator.jl
+++ b/test/test_symmetry_operator.jl
@@ -26,7 +26,7 @@ using ElectronPhonon: get_symmetry_representation_wannier!
         kpts = GridKpoints(kpts);
         els = compute_electron_states(model, kpts, ["eigenvalue", "eigenvector", "velocity"]; fourier_mode);
         ham = get_interpolator(model.el_ham; fourier_mode)
-        el_sym_itp = get_interpolator.(model.el_sym.operators; fourier_mode)
+        itp_el_sym = get_interpolator.(model.el_sym.operators; fourier_mode)
 
         nw = model.nw
         sym_W = zeros(ComplexF64, nw, nw)
@@ -41,8 +41,8 @@ using ElectronPhonon: get_symmetry_representation_wannier!
                 sxk = symop.is_tr ? -symop.S * xk : symop.S * xk
                 isk = xk_to_ik(sxk, kpts)
 
-                get_symmetry_representation_wannier!(sym_W, el_sym_itp[isym], xk, symop.is_tr)
-                compute_symmetry_representation!(sym_H, els[ik], els[isk], xk, el_sym_itp[isym], symop.is_tr)
+                get_symmetry_representation_wannier!(sym_W, itp_el_sym[isym], xk, symop.is_tr)
+                compute_symmetry_representation!(sym_H, els[ik], els[isk], xk, itp_el_sym[isym], symop.is_tr)
 
                 @test norm(sym_W' * sym_W - I(nw)) < 3e-6
 


### PR DESCRIPTION
## Summary

Ports the **outer-q GPU e-ph loop** (`run_eph_outer_q(...; use_gpu=true)`) onto `main`, on top of the already-merged BTE GPU infrastructure (#6). This is the phonon self-energy / susceptibility counterpart of the outer-k GPU loop: for a fixed phonon momentum `q`, the e-ph matrix for a whole `(q, {k-chunk})` is kept on the device and handed to a batched-q calculator hook, skipping the per-`(k,q)` host callback and the device→host copy.

The work previously lived in a separate worktree (branch `gpu-phself`); this PR reconciles it onto `main`, which had since reorganized the shared GPU files (file rename `wannier_to_bloch_gpu.jl` → `wannier_to_bloch_batched.jl`, relocation of `device_free_bytes`/`eph_window_scatter!`, and the internal-vs-exported convention).

## Changes

- **`calculator/run_eph_outer_q.jl`** — GPU path: device eigen-only k states, device chemical-potential solve (FermiDirac metals; other occ types keep the host solve), memory-adaptive k-chunk sizing, and the batched-q calculator loop.
- **`calculator/AbstractCalculator.jl`** — batched-q calculator hooks: `allow_eph_batched_q`, `run_calculator_batched_q!`, `eph_batched_q_bytes_per_k`, `setup_calculator_batched_q!`, `flush_calculator_batched_q!`.
- **`wannier_to_bloch_batched.jl`** — list-batched Rq→kq e-ph driver (`get_eph_Rq_to_kq_batched!` + `RqToKQWorkspace`) and the generic backend `eph_apply_rotations_rqkq!`.
- **`ext/ElectronPhononCUDAExt.jl`** — fused per-`(m,n,k)` Rq→kq rotation kernel for small `nw²·nmodes` (cuBLAS strided-batched fallback above the threshold).
- **`common/fermi_energy.jl`** — threaded `compute_ncarrier` host reduction.
- **`test/test_gpu.jl`** — Rq→kq driver test (CPU + GPU, both the fused kernel and the cuBLAS fallback) and outer-q batched calculator hook plumbing.

## Verification

- Package + CUDA extension precompile cleanly.
- `eph_apply_rotations_rqkq!` (fused kernel and cuBLAS fallback) matches a reference to ~1e-15.
- End-to-end phonon self-energy run (Sr2RuO4 `HubbardDielectricCalculator`), GPU vs CPU: `Π_1loop` agrees to ~1e-6 relative (`Π_static` to ~1e-10) for both `:FermiDirac` and `:MV` occupations.
- `test/test_gpu.jl` passes fully (CPU + GPU), including the new testsets.

Draft pending final review.