### PR TITLE
Speed up the GPU outer-k e-ph loop 3.3x: dense q-index lookup and k+q-convention phase hoist

### DIFF
--- a/README_GPU.md
+++ b/README_GPU.md
@@ -152,7 +152,7 @@ batches the inner `ikq` loop (in tiles of `nq_batch_max`) through one `get_eph_k
 Its nesting is `k-batch -> q-tile -> k -> q(device)`: the q-tile loop sits **outside** the per-k
 loop. `get_eph_RR_to_kR_batched!` stores the kR intermediate in the **k+q convention**
 (`g̃(k, R_p) = conj(exp(2πi R_p·x_k)) · g(k, R_p)`, folded into its output copy via the
-`kq_convention_phase` argument), so the kR→kq Fourier phase is `exp(2πi R_p·x_{k+q})` — built from
+`additional_phase` argument), so the kR→kq Fourier phase is `exp(2πi R_p·x_{k+q})` — built from
 the fixed k+q list and therefore identical for every k of the batch. One built phase tile is reused
 by all `nk_outer_batch_max` outer k, and the q-vector never enters the interpolation.
 

--- a/README_GPU.md
+++ b/README_GPU.md
@@ -160,8 +160,10 @@ by all `nk_outer_batch_max` outer k, and the q-vector never enters the interpola
 The k-strip level exists because that phase tile is not only built once but also **read** once per
 k: `nk_b = _krkq_strip_width(...)` consecutive outer k are stacked into a single tall kR→kq GEMM
 whose `M = nw·nbandk_max·nmodes·nk_b` also fills a cuBLAS DMMA tile that `M = ndata` alone leaves
-2/3 empty. `ep_ekpR_all` is therefore laid out `(ndata, nk, nr_ep)`, k in the middle, so a strip is
-a plain `lda` view of its 2-D reshape. `nk_b` is shape-derived and internal (not a knob): it is 1 —
+partly empty: the selected kernel `cutlass_80_tensorop_z884gemm_32x32_16x4_nn_align1` has a 32-row
+M-tile, so `M = ndata = 21` at the Cu shapes leaves 1/3 of it idle. `ep_ekpR_all` is therefore laid
+out `(ndata, nk, nr_ep)`, k in the middle, so a strip is a plain `lda` view of its 2-D reshape.
+`nk_b` is shape-derived and internal (not a knob): it is 1 —
 the loop exactly as it was — when `ndata` already fills the M-tile, and also whenever
 `nw·nmodes > _FUSED_ROT_MAX_NWNM`, because a strip's per-k `g` slice is strided in q and only the
 fused rotation kernel reads that. So it is a narrow-window / small-`nw` optimization; a full-band

--- a/README_GPU.md
+++ b/README_GPU.md
@@ -77,18 +77,20 @@ on the host).
 The existing `BatchedWannierInterpolator` (`src/wannier/batched_interpolator.jl`) is the single
 batching mechanism for CPU and GPU:
 
-- Buffer fields (`cached_results`, `phase_batch`, `rdotk`, `out`, …) follow the backend of
+- Buffer fields (`cached_results`, `phase_batch`, `out`, …) follow the backend of
   `parent.op_r` (allocated via `similar`; host fallback for `DiskWannierObject`).
-- The phase computation is a GEMM + broadcast (no scalar indexing), so it runs on any backend
-  and is faster on the CPU too:
+- The phase computation is a single fused broadcast (no scalar indexing, no `nr × batch` real
+  scratch), so it runs on any backend and is faster on the CPU too:
 
   ```julia
   # irvec_mat :: (nr × 3) real, on backend (built once in the constructor)
   # xkmat     :: (3 × batch) real, on backend
-  mul!(rdotk, irvec_mat, xkmat)              # (nr × batch) real    GEMM
-  phase_batch .= cispi.(2 .* rdotk)          # (nr × batch) complex broadcast
-  mul!(cached_results, op_r, phase_batch)    # (ndata × batch) GEMM → op_k for all k
+  fourier_phase!(phase_batch, irvec_mat, xkmat)   # (nr × batch) complex, one broadcast
+  mul!(cached_results, op_r, phase_batch)         # (ndata × batch) GEMM → op_k for all k
   ```
+
+  `fourier_phase!` is stateless, so a caller whose k-list is loop-invariant can build one phase
+  matrix and reuse it — which is what the GPU outer-k e-ph loop does (next section).
 
 - The per-k query API (`register_kpoints!` + sequential `get_fourier!`) used by the calculators
   is unchanged. A new whole-batch entry point `get_fourier_batched!(out, itp, xk_list)` returns
@@ -145,7 +147,14 @@ device loop. `use_gpu` is the only user-facing switch; below the driver entry a 
 (`CPUBackend()` / `GPUBackend(proto)`) is resolved once, uploaded `to_device(model.epmat)` once,
 and carried in `LoopContext`. The CPU loop and per-(k,q) CPU e-ph functions are unchanged. The GPU
 outer-k loop processes a batch of outer k with one list-batched `get_eph_RR_to_kR_batched!` and
-batches the inner `ikq` loop (in batches of `nq_batch_max`) through one `get_eph_kR_to_kq_batched!`.
+batches the inner `ikq` loop (in tiles of `nq_batch_max`) through one `get_eph_kR_to_kq_batched!`.
+
+Its nesting is `k-batch -> q-tile -> k -> q(device)`: the q-tile loop sits **outside** the per-k
+loop. `get_eph_RR_to_kR_batched!` stores the kR intermediate in the **k+q convention**
+(`g̃(k, R_p) = conj(exp(2πi R_p·x_k)) · g(k, R_p)`, folded into its output copy via the
+`kq_convention_phase` argument), so the kR→kq Fourier phase is `exp(2πi R_p·x_{k+q})` — built from
+the fixed k+q list and therefore identical for every k of the batch. One built phase tile is reused
+by all `nk_outer_batch_max` outer k, and the q-vector never enters the interpolation.
 
 To run on the GPU a calculator opts into a **device-native batched payload** so the e-ph matrix for
 a whole batch stays on the device and the reduction/scatter happens there. Each loop has its own
@@ -155,7 +164,11 @@ payload, named for which momentum is the outer loop and which is batched on the 
   (1) declare `supports(calc, ::Type{EPDataQBatched}) = true` and (2) implement
   `run_calculator!(calc, p::EPDataQBatched, ctx)`. The payload `p` carries the batch's
   `eps` / `g2s` / `ωqs` on the device plus `ik`, `ikqs`, `ibandk_offset`. The loop calls it once
-  per `(k, {k+q})` batch (outer k is still serial: one `OuterIteration` bracket + payload per k).
+  per `(k, q-tile)`, once per outer k when there is a single q-tile. Outer k is still serial and
+  each payload carries exactly one `ik`, but a k's q-tiles are **not** contiguous (the tile loop is
+  outside the k loop), and this loop fires **only** the `OuterIterationBatch` bracket — there is no
+  per-k `OuterIteration` bracket in the batched outer-k loop. A calculator that needs a per-k device
+  reduction must do it at `OuterIterationBatch` scope.
 - **Outer-q loop (`run_eph_over_q_and_k`, outer q / inner k batched).** A calculator MUST
   (1) declare `supports(calc, ::Type{EPDataKBatched}) = true` and (2) implement
   `run_calculator!(calc, p::EPDataKBatched, ctx)`. The payload carries `eps`, k/k+q
@@ -187,7 +200,7 @@ payload, named for which momentum is the outer loop and which is batched on the 
 **Distinguishing the per-point host loop from the device-batched loop.** `LoopContext` carries a
 loop *mode* (`SingleMode` / `BatchedMode`) that names the loop shape independently of the backend.
 Hooks a calculator shares between the two loop shapes — most commonly the `OuterIteration` brackets,
-which the batched outer-k loop *also* fires per k — must key off the mode, not the backend: either
+which the batched outer-**q** loop also fires per q — must key off the mode, not the backend: either
 dispatch (`ctx::LoopContext{<:AbstractBackend, SingleMode}` vs `{<:AbstractBackend, BatchedMode}`, as
 `BoltzmannCalculator` / `EliashbergCalculator` do) or branch at runtime on `ctx.mode isa BatchedMode`
 (as the outer-q calculators do). Dispatching these on `LoopContext{CPUBackend}` / `{<:GPUBackend}`

--- a/README_GPU.md
+++ b/README_GPU.md
@@ -147,28 +147,14 @@ device loop. `use_gpu` is the only user-facing switch; below the driver entry a 
 (`CPUBackend()` / `GPUBackend(proto)`) is resolved once, uploaded `to_device(model.epmat)` once,
 and carried in `LoopContext`. The CPU loop and per-(k,q) CPU e-ph functions are unchanged. The GPU
 outer-k loop processes a batch of outer k with one list-batched `get_eph_RR_to_kR_batched!` and
-batches the inner `ikq` loop (in tiles of `nq_batch_max`) through `eph_kR_to_kq_fourier!` +
-`eph_apply_rotations!`.
+batches the inner `ikq` loop (in tiles of `nq_batch_max`) through one `get_eph_kR_to_kq_batched!`.
 
-Its nesting is `k-batch -> q-tile -> k-strip -> k -> q(device)`: the q-tile loop sits **outside**
-the per-k loop. `get_eph_RR_to_kR_batched!` stores the kR intermediate in the **k+q convention**
+Its nesting is `k-batch -> q-tile -> k -> q(device)`: the q-tile loop sits **outside** the per-k
+loop. `get_eph_RR_to_kR_batched!` stores the kR intermediate in the **k+q convention**
 (`g̃(k, R_p) = conj(exp(2πi R_p·x_k)) · g(k, R_p)`, folded into its output copy via the
 `kq_convention_phase` argument), so the kR→kq Fourier phase is `exp(2πi R_p·x_{k+q})` — built from
 the fixed k+q list and therefore identical for every k of the batch. One built phase tile is reused
 by all `nk_outer_batch_max` outer k, and the q-vector never enters the interpolation.
-
-The k-strip level exists because that phase tile is not only built once but also **read** once per
-k: `nk_b = _krkq_strip_width(...)` consecutive outer k are stacked into a single tall kR→kq GEMM
-whose `M = nw·nbandk_max·nmodes·nk_b` also fills a cuBLAS DMMA tile that `M = ndata` alone leaves
-partly empty: the selected kernel `cutlass_80_tensorop_z884gemm_32x32_16x4_nn_align1` has a 32-row
-M-tile, so `M = ndata = 21` at the Cu shapes leaves 1/3 of it idle. `ep_ekpR_all` is therefore laid
-out `(ndata, nk, nr_ep)`, k in the middle, so a strip is a plain `lda` view of its 2-D reshape.
-`nk_b` is shape-derived and internal (not a knob): it is 1 —
-the loop exactly as it was — when `ndata` already fills the M-tile, and also whenever
-`nw·nmodes > _FUSED_ROT_MAX_NWNM`, because a strip's per-k `g` slice is strided in q and only the
-fused rotation kernel reads that. So it is a narrow-window / small-`nw` optimization; a full-band
-large-`nw` run is unaffected. Everything below the GEMM stays strictly per-k, so the payload
-stream, the call order and the brackets are unchanged.
 
 To run on the GPU a calculator opts into a **device-native batched payload** so the e-ph matrix for
 a whole batch stays on the device and the reduction/scatter happens there. Each loop has its own

--- a/README_GPU.md
+++ b/README_GPU.md
@@ -147,14 +147,26 @@ device loop. `use_gpu` is the only user-facing switch; below the driver entry a 
 (`CPUBackend()` / `GPUBackend(proto)`) is resolved once, uploaded `to_device(model.epmat)` once,
 and carried in `LoopContext`. The CPU loop and per-(k,q) CPU e-ph functions are unchanged. The GPU
 outer-k loop processes a batch of outer k with one list-batched `get_eph_RR_to_kR_batched!` and
-batches the inner `ikq` loop (in tiles of `nq_batch_max`) through one `get_eph_kR_to_kq_batched!`.
+batches the inner `ikq` loop (in tiles of `nq_batch_max`) through `eph_kR_to_kq_fourier!` +
+`eph_apply_rotations!`.
 
-Its nesting is `k-batch -> q-tile -> k -> q(device)`: the q-tile loop sits **outside** the per-k
-loop. `get_eph_RR_to_kR_batched!` stores the kR intermediate in the **k+q convention**
+Its nesting is `k-batch -> q-tile -> k-strip -> k -> q(device)`: the q-tile loop sits **outside**
+the per-k loop. `get_eph_RR_to_kR_batched!` stores the kR intermediate in the **k+q convention**
 (`g̃(k, R_p) = conj(exp(2πi R_p·x_k)) · g(k, R_p)`, folded into its output copy via the
 `kq_convention_phase` argument), so the kR→kq Fourier phase is `exp(2πi R_p·x_{k+q})` — built from
 the fixed k+q list and therefore identical for every k of the batch. One built phase tile is reused
 by all `nk_outer_batch_max` outer k, and the q-vector never enters the interpolation.
+
+The k-strip level exists because that phase tile is not only built once but also **read** once per
+k: `nk_b = _krkq_strip_width(...)` consecutive outer k are stacked into a single tall kR→kq GEMM
+whose `M = nw·nbandk_max·nmodes·nk_b` also fills a cuBLAS DMMA tile that `M = ndata` alone leaves
+2/3 empty. `ep_ekpR_all` is therefore laid out `(ndata, nk, nr_ep)`, k in the middle, so a strip is
+a plain `lda` view of its 2-D reshape. `nk_b` is shape-derived and internal (not a knob): it is 1 —
+the loop exactly as it was — when `ndata` already fills the M-tile, and also whenever
+`nw·nmodes > _FUSED_ROT_MAX_NWNM`, because a strip's per-k `g` slice is strided in q and only the
+fused rotation kernel reads that. So it is a narrow-window / small-`nw` optimization; a full-band
+large-`nw` run is unaffected. Everything below the GEMM stays strictly per-k, so the payload
+stream, the call order and the brackets are unchanged.
 
 To run on the GPU a calculator opts into a **device-native batched payload** so the e-ph matrix for
 a whole batch stays on the device and the reduction/scatter happens there. Each loop has its own

--- a/benchmark/bench_eph_gpu.jl
+++ b/benchmark/bench_eph_gpu.jl
@@ -3,8 +3,9 @@
 #   RR_to_kR : Fourier of the (large) e-ph operator over R_el + rotation by uk, for nk k-points
 #   kR_to_kq : Fourier over R_ep + rotation by ukq, u_ph, for nq q-points (fixed k)
 #
-# Compares the per-k/q drivers (one call per point) against the list-batched drivers
-# (get_eph_RR_to_kR_batched! / get_eph_kR_to_kq_batched! over a whole list).
+# Compares one call per point (a batch of ONE — the batched drivers are list-only, there is no
+# single-point entry point) against one call for the whole list
+# (get_eph_RR_to_kR_batched! / get_eph_kR_to_kq_batched!).
 #
 # Run with both ElectronPhonon (this gpu branch) and CUDA in the environment:
 #   julia --project=<env> benchmark/bench_eph_gpu.jl
@@ -12,7 +13,8 @@
 using ElectronPhonon
 using CUDA
 using LinearAlgebra
-using ElectronPhonon: WannierObject, Vec3, to_device
+using ElectronPhonon: WannierObject, Vec3, to_device,
+    get_eph_RR_to_kR_batched!, get_eph_kR_to_kq_batched!
 using Printf
 
 const PB_FOLDER = "/mnt/home/jlihm/ceph/superconductivity/Pb/tutorial/1_epw/"
@@ -26,36 +28,39 @@ qs = [Vec3(rand(3)...) for _ in 1:nq]
 uks  = cat([Matrix(qr(rand(ComplexF64, nw, nw)).Q) for _ in 1:nk]...; dims=3)
 ukqs = cat([Matrix(qr(rand(ComplexF64, nw, nw)).Q) for _ in 1:nq]...; dims=3)
 uphs = cat([rand(ComplexF64, nmodes, nmodes) for _ in 1:nq]...; dims=3)
-mkobj() = WannierObject(model.epmat.irvec_next, zeros(ComplexF64, nw*nband*nmodes, nr_ep))
 
 cput(f) = (f(); minimum(@elapsed(f()) for _ in 1:3))
 gput(f) = (CUDA.@sync f(); minimum(CUDA.@elapsed(CUDA.@sync f()) for _ in 1:3))
 
 # ---- RR_to_kR over nk k-points ----
 epmat_c   = model.epmat
-epmat_cit = get_interpolator(epmat_c; fourier_mode="batched")            # per-k Fourier
+epmat_cit = get_interpolator(epmat_c; fourier_mode="batched", batch_size=1)   # per-k Fourier
 epmat_ck  = get_interpolator(epmat_c; fourier_mode="batched", batch_size=nk)
 epmat_g   = to_device(ElectronPhonon.gpu_backend(), epmat_c)
-epmat_git = get_interpolator(epmat_g; fourier_mode="batched")
+epmat_git = get_interpolator(epmat_g; fourier_mode="batched", batch_size=1)
 epmat_gk  = get_interpolator(epmat_g; fourier_mode="batched", batch_size=nk)
 uks_g = CuArray(uks)
 
-oc = mkobj(); og = to_device(ElectronPhonon.gpu_backend(), mkobj())
-ep_all_c = zeros(ComplexF64, nw*nband*nmodes, nr_ep, nk)
-ep_all_g = CUDA.zeros(ComplexF64, nw*nband*nmodes, nr_ep, nk)
+# `ep_ekpR_all` is (ndata, nk, nr_ep) — k in the MIDDLE axis (see get_eph_RR_to_kR_batched!).
+ep_all_c = zeros(ComplexF64, nw*nband*nmodes, nk, nr_ep)
+ep_all_g = CUDA.zeros(ComplexF64, nw*nband*nmodes, nk, nr_ep)
+ep_one_c = zeros(ComplexF64, nw*nband*nmodes, 1, nr_ep)
+ep_one_g = CUDA.zeros(ComplexF64, nw*nband*nmodes, 1, nr_ep)
 
-rr_perk!(obj, itp, U) = for ik in 1:nk; get_eph_RR_to_kR_batched!(obj, itp, ks[ik], @view U[:, :, ik]); end
+rr_perk!(out, itp, U) = for ik in 1:nk
+    get_eph_RR_to_kR_batched!(out, itp, view(ks, ik:ik), @view U[:, :, ik:ik])
+end
 
-t = (cput(()->rr_perk!(oc, epmat_cit, uks)),  gput(()->rr_perk!(og, epmat_git, uks_g)),
+t = (cput(()->rr_perk!(ep_one_c, epmat_cit, uks)),  gput(()->rr_perk!(ep_one_g, epmat_git, uks_g)),
      cput(()->get_eph_RR_to_kR_batched!(ep_all_c, epmat_ck, ks, uks)),
      gput(()->get_eph_RR_to_kR_batched!(ep_all_g, epmat_gk, ks, uks_g)))
 @printf "RR_to_kR (%d k)   per-k:  CPU %6.2f  GPU %6.2f ms  |  batched:  CPU %6.2f  GPU %6.2f ms\n" nk (t.*1e3)...
 
 # ---- kR_to_kq over nq q-points (fixed k = ks[1]) ----
-obj_k1_c = WannierObject(model.epmat.irvec_next, ep_all_c[:, :, 1])
-obj_k1_g = to_device(ElectronPhonon.gpu_backend(), WannierObject(model.epmat.irvec_next, Array(ep_all_g[:, :, 1])))
-itp_c_perq = get_interpolator(obj_k1_c; fourier_mode="batched")          # per-q Fourier
-itp_g_perq = get_interpolator(obj_k1_g; fourier_mode="batched")
+obj_k1_c = WannierObject(model.epmat.irvec_next, ep_all_c[:, 1, :])
+obj_k1_g = to_device(ElectronPhonon.gpu_backend(), WannierObject(model.epmat.irvec_next, Array(ep_all_g)[:, 1, :]))
+itp_c_perq = get_interpolator(obj_k1_c; fourier_mode="batched", batch_size=1)   # per-q Fourier
+itp_g_perq = get_interpolator(obj_k1_g; fourier_mode="batched", batch_size=1)
 itp_c1 = get_interpolator(obj_k1_c; fourier_mode="batched", batch_size=nq)
 itp_g1 = get_interpolator(obj_k1_g; fourier_mode="batched", batch_size=nq)
 uphs_g = CuArray(uphs); ukqs_g = CuArray(ukqs)
@@ -63,7 +68,8 @@ ep4c = zeros(ComplexF64, nw, nw, nmodes, nq); ep4g = CUDA.zeros(ComplexF64, nw, 
 
 # All interpolators are built once, outside the timed closures (matching the RR_to_kR section).
 kq_perq!(itp, EP, UPH, UKQ) = for iq in 1:nq
-    get_eph_kR_to_kq_batched!(view(EP, :, :, :, iq), itp, qs[iq], @view(UPH[:, :, iq]), @view(UKQ[:, :, iq]))
+    get_eph_kR_to_kq_batched!(view(EP, :, :, :, iq:iq), itp, view(qs, iq:iq),
+                              @view(UPH[:, :, iq:iq]), @view(UKQ[:, :, iq:iq]))
 end
 
 t = (cput(()->kq_perq!(itp_c_perq, ep4c, uphs, ukqs)),

--- a/benchmark/bench_eph_gpu.jl
+++ b/benchmark/bench_eph_gpu.jl
@@ -41,11 +41,11 @@ epmat_git = get_interpolator(epmat_g; fourier_mode="batched", batch_size=1)
 epmat_gk  = get_interpolator(epmat_g; fourier_mode="batched", batch_size=nk)
 uks_g = CuArray(uks)
 
-# `ep_ekpR_all` is (ndata, nk, nr_ep) — k in the MIDDLE axis (see get_eph_RR_to_kR_batched!).
-ep_all_c = zeros(ComplexF64, nw*nband*nmodes, nk, nr_ep)
-ep_all_g = CUDA.zeros(ComplexF64, nw*nband*nmodes, nk, nr_ep)
-ep_one_c = zeros(ComplexF64, nw*nband*nmodes, 1, nr_ep)
-ep_one_g = CUDA.zeros(ComplexF64, nw*nband*nmodes, 1, nr_ep)
+# `ep_ekpR_all` is (ndata, nr_ep, nk) — one k per trailing slice (see get_eph_RR_to_kR_batched!).
+ep_all_c = zeros(ComplexF64, nw*nband*nmodes, nr_ep, nk)
+ep_all_g = CUDA.zeros(ComplexF64, nw*nband*nmodes, nr_ep, nk)
+ep_one_c = zeros(ComplexF64, nw*nband*nmodes, nr_ep, 1)
+ep_one_g = CUDA.zeros(ComplexF64, nw*nband*nmodes, nr_ep, 1)
 
 rr_perk!(out, itp, U) = for ik in 1:nk
     get_eph_RR_to_kR_batched!(out, itp, view(ks, ik:ik), @view U[:, :, ik:ik])
@@ -57,8 +57,8 @@ t = (cput(()->rr_perk!(ep_one_c, epmat_cit, uks)),  gput(()->rr_perk!(ep_one_g, 
 @printf "RR_to_kR (%d k)   per-k:  CPU %6.2f  GPU %6.2f ms  |  batched:  CPU %6.2f  GPU %6.2f ms\n" nk (t.*1e3)...
 
 # ---- kR_to_kq over nq q-points (fixed k = ks[1]) ----
-obj_k1_c = WannierObject(model.epmat.irvec_next, ep_all_c[:, 1, :])
-obj_k1_g = to_device(ElectronPhonon.gpu_backend(), WannierObject(model.epmat.irvec_next, Array(ep_all_g)[:, 1, :]))
+obj_k1_c = WannierObject(model.epmat.irvec_next, ep_all_c[:, :, 1])
+obj_k1_g = to_device(ElectronPhonon.gpu_backend(), WannierObject(model.epmat.irvec_next, Array(ep_all_g)[:, :, 1]))
 itp_c_perq = get_interpolator(obj_k1_c; fourier_mode="batched", batch_size=1)   # per-q Fourier
 itp_g_perq = get_interpolator(obj_k1_g; fourier_mode="batched", batch_size=1)
 itp_c1 = get_interpolator(obj_k1_c; fourier_mode="batched", batch_size=nq)

--- a/docs/writing_a_calculator.md
+++ b/docs/writing_a_calculator.md
@@ -26,8 +26,9 @@ A calculator must implement:
   payload it does not declare.
 
 Optionally, `calculator_begin!(calc, scope, ctx)` / `calculator_end!(calc, scope, ctx)` bracket one
-outer iteration (`OuterIteration()`) or one batch of outer iterations (`OuterIterationBatch()`);
-their defaults are no-ops.
+outer iteration (`OuterIteration()`) or one batch of outer iterations (`OuterIterationBatch()`).
+There is no default: define a method for every (scope, loop-mode) combination the loops you support
+fire, even as an explicit no-op — see the table under "Adding a GPU path" for which those are.
 
 Which loop shape? `OuterKLoop` calculators run under `run_eph_over_k_and_q` /
 `run_eph_over_k_and_kq` (outer loop over k); `OuterQLoop` calculators run under
@@ -159,16 +160,27 @@ To add a GPU path to an existing CPU calculator:
 3. Manage device buffers. `setup_calculator!` is passed the run's `backend`, so build whole-run
    device buffers (index maps, band energies, weights — anything intrinsic to the state sets) there
    with `alloc(backend, …)` / `to_device(backend, …)` (only when `backend isa GPUBackend`). Use the
-   brackets only for per-iteration state: allocate/zero the per-iteration device accumulator in
-   `calculator_begin!(calc, OuterIteration(), ctx)` (or `OuterIterationBatch()` for outer-k
-   per-batch buffers) using `ctx.backend`, and copy the result device→host in the matching
-   `calculator_end!`. Declare per-point device scratch via
-   `eph_batched_bytes_per_point(calc, PayloadType; nw, nmodes)` so the loop's memory-adaptive batch
-   sizing accounts for it.
+   brackets only for per-iteration state, and mind **which brackets the loop you are targeting
+   actually fires**:
 
-   If a bracket is shared between the CPU and GPU loop shapes (e.g. the `OuterIteration` bracket,
-   which the batched outer-k loop fires per k in addition to the CPU per-point loop), select the
-   batched behavior from the loop **mode** carried in `ctx`, never the backend: either dispatch on
+   | loop | brackets fired |
+   |---|---|
+   | CPU outer-k / outer-q (`SingleMode`) | `OuterIteration` per k / per q |
+   | GPU outer-q (`BatchedMode`) | `OuterIteration` per q |
+   | **GPU outer-k (`BatchedMode`)** | **`OuterIterationBatch` only — no per-k bracket** |
+
+   The GPU outer-k loop runs its q-tile loop *outside* the k loop (one Fourier phase tile is reused
+   by every k of the batch), so a single k's work is spread over the whole batch and has no
+   begin/end point. A per-k device reduction there must move to `OuterIterationBatch`; a
+   `calculator_begin!(calc, OuterIteration(), ctx)` method written for that loop would simply never
+   run. Allocate/zero the per-iteration device accumulator in the bracket the loop does fire, using
+   `ctx.backend`, and copy the result device→host in the matching `calculator_end!`. Declare
+   per-point device scratch via `eph_batched_bytes_per_point(calc, PayloadType; nw, nmodes)` so the
+   loop's memory-adaptive batch sizing accounts for it.
+
+   If a bracket is shared between loop shapes (e.g. the `OuterIteration` bracket, fired by the CPU
+   loops in `SingleMode` and by the GPU outer-q loop in `BatchedMode`), select the batched behavior
+   from the loop **mode** carried in `ctx`, never the backend: either dispatch on
    `ctx::LoopContext{<:AbstractBackend, SingleMode}` vs `{<:AbstractBackend, BatchedMode}`, or branch
    on `ctx.mode isa ElectronPhonon.BatchedMode`. `ctx.backend` is only for allocation
    (`alloc(ctx.backend, …)`) / `free_bytes` / `synchronize`, not for telling the loop shapes apart.

--- a/ext/ElectronPhononCUDAExt.jl
+++ b/ext/ElectronPhononCUDAExt.jl
@@ -134,7 +134,7 @@ end
 # Per-thread work grows ~nw³·nmodes², so we gate on the single product nw·nmodes (nmodes = 3·N_atoms
 # ≥ 3, so the product bounds the aspect ratio — no separate per-dim cap needed). Assumes nbandk,
 # nbandkq ≤ nw (true in the full-band loop). The threshold itself is
-# `ElectronPhonon._FUSED_ROT_MAX_NWNM`, in `src` because the outer-k loop also reads it.
+# `ElectronPhonon._FUSED_ROT_MAX_NWNM`, in `src` next to the generic method it selects against.
 
 # g : (nw, nbandk, nmodes, nq) ; ukq : (nw, nbandkq, nq) ; uph : (nmodes, nmodes, nq)
 # ep : (nbandkq, nbandk, nmodes, nq) ; g2 / ωq optional (g2 : same as ep ; ωq : (nmodes, nq)).
@@ -172,9 +172,8 @@ end
 # `DenseCuArray` (not `CuArray`): the GPU e-ph loop passes contiguous device VIEWS
 # (e.g. `view(epkq_dev, :,:,:, 1:nq_batch)`) for a partial final q-batch. The fused kernel takes
 # them through `@cuda` (cudaconvert handles strided views) and the cuBLAS path takes their
-# reshapes (strided), so no padding to a fixed batch width is needed. `g` alone may also be strided
-# in `q` (one k of a kR→kq strip); only the fused branch accepts that, which is why the loop caps
-# the strip width at 1 above `_FUSED_ROT_MAX_NWNM`.
+# reshapes (strided), so no padding to a fixed batch width is needed. `g` alone may be any strided
+# device array: only the fused branch accepts that, hence the density assert on the cuBLAS branch.
 function ElectronPhonon.eph_apply_rotations!(ep_kq_all::DenseCuArray{Complex{T},4},
         g::AnyCuArray{Complex{T},4},
         ukqs::DenseCuArray, u_phs::DenseCuArray, tmp; g2_out=nothing, ωq=nothing) where {T}

--- a/ext/ElectronPhononCUDAExt.jl
+++ b/ext/ElectronPhononCUDAExt.jl
@@ -133,9 +133,8 @@ end
 # Above a threshold the matmuls are large enough that cuBLAS wins, so we fall back to the two GEMMs.
 # Per-thread work grows ~nw³·nmodes², so we gate on the single product nw·nmodes (nmodes = 3·N_atoms
 # ≥ 3, so the product bounds the aspect ratio — no separate per-dim cap needed). Assumes nbandk,
-# nbandkq ≤ nw (true in the full-band loop). The crossover is hardware-dependent: the value below
-# was tuned on one GPU and should be retuned elsewhere.
-const _FUSED_ROT_MAX_NWNM = 24
+# nbandkq ≤ nw (true in the full-band loop). The threshold itself is
+# `ElectronPhonon._FUSED_ROT_MAX_NWNM`, in `src` because the outer-k loop also reads it.
 
 # g : (nw, nbandk, nmodes, nq) ; ukq : (nw, nbandkq, nq) ; uph : (nmodes, nmodes, nq)
 # ep : (nbandkq, nbandk, nmodes, nq) ; g2 / ωq optional (g2 : same as ep ; ωq : (nmodes, nq)).
@@ -173,19 +172,23 @@ end
 # `DenseCuArray` (not `CuArray`): the GPU e-ph loop passes contiguous device VIEWS
 # (e.g. `view(epkq_dev, :,:,:, 1:nq_batch)`) for a partial final q-batch. The fused kernel takes
 # them through `@cuda` (cudaconvert handles strided views) and the cuBLAS path takes their
-# reshapes (strided), so no padding to a fixed batch width is needed.
-function ElectronPhonon.eph_apply_rotations!(ep_kq_all::DenseCuArray{Complex{T},4}, g,
+# reshapes (strided), so no padding to a fixed batch width is needed. `g` alone may also be strided
+# in `q` (one k of a kR→kq strip); only the fused branch accepts that, which is why the loop caps
+# the strip width at 1 above `_FUSED_ROT_MAX_NWNM`.
+function ElectronPhonon.eph_apply_rotations!(ep_kq_all::DenseCuArray{Complex{T},4},
+        g::AnyCuArray{Complex{T},4},
         ukqs::DenseCuArray, u_phs::DenseCuArray, tmp; g2_out=nothing, ωq=nothing) where {T}
     nbandkq, nbandk, nmodes, nq = size(ep_kq_all)
     nw = size(ukqs, 1)
-    if nw * nmodes <= _FUSED_ROT_MAX_NWNM
-        g4 = reshape(g, nw, nbandk, nmodes, nq)
+    @assert size(g) == (nw, nbandk, nmodes, nq)
+    if nw * nmodes <= ElectronPhonon._FUSED_ROT_MAX_NWNM
         threads = 256
         blocks = cld(nbandkq * nbandk * nq, threads)
         @cuda threads=threads blocks=blocks _fused_eph_rot_kernel!(
-            ep_kq_all, g2_out, g4, ukqs, u_phs, ωq, nw, nbandkq, nbandk, nmodes, nq)
+            ep_kq_all, g2_out, g, ukqs, u_phs, ωq, nw, nbandkq, nbandk, nmodes, nq)
     else
         # Large nw/nmodes: cuBLAS strided-batched is efficient; keep the two-GEMM path.
+        @assert ElectronPhonon._is_dense(g)
         gemm_strided_batched!('C', 'N', one(Complex{T}), ukqs,
                               reshape(g, nw, nbandk * nmodes, nq), zero(Complex{T}), tmp)
         gemm_strided_batched!('N', 'N', one(Complex{T}),

--- a/src/EPData.jl
+++ b/src/EPData.jl
@@ -56,7 +56,9 @@ Fields:
   fused kernel (separate type param `AT4R` from `eps`'s `AT4C`: complex vs real element type).
 - `ωqs`           :: `(nmodes, nq)` — phonon frequencies of this batch.
 - `ik`            :: outer k index.
-- `ikqs`          :: `(nq,)` k+q indices of this batch (device).
+- `ikqs`          :: `(nq,)` k+q indices of this batch. The loop tiles k+q contiguously, so this is
+  the `UnitRange` `qstart:qend` — `isbits`, hence passed in the kernel launch parameters rather than
+  read from device memory. Consumers must index it, not assume a device array.
 - `ibandk_offset` :: k-side window-projection band offset (0-based; 0 for full-band). `eps`'s
   band-of-k axis `n` (1-based) is PHYSICAL band `ibandk_offset + n`.
 """

--- a/src/boltzmann/QMEStates.jl
+++ b/src/boltzmann/QMEStates.jl
@@ -66,8 +66,10 @@ Base.iterate(s::QMEStates, state=1) = state > s.n ? nothing : (s[state], state+1
 end
 
 function dump_BTData(f, obj::AbstractKpoints{T}) where T
+    # Underscore-prefixed fields are private caches derived from the other fields (the xk->ik
+    # indices); they are not written and are rebuilt by the constructor on load.
     for name in fieldnames(typeof(obj))
-        if name !== :_xk_hash_to_ik
+        if !startswith(String(name), "_")
             f[String(name)] = _data_julia_to_hdf5(getfield(obj, name))
         end
     end

--- a/src/boltzmann/boltzmann_calculator.jl
+++ b/src/boltzmann/boltzmann_calculator.jl
@@ -190,9 +190,8 @@ end
 # --- CPU (non-batched, EPData) path --------------------------------------------------
 
 # CPU path: zero the per-chunk thread buffers for the new outer k (the buffers are allocated in
-# `setup_calculator!`). Dispatched on `SingleMode`; in the batched loop (`BatchedMode`) the explicit
-# no-op below runs (the batched loop fires per-k OuterIteration brackets too, but the device buffers
-# live in OuterIterationBatch).
+# `setup_calculator!`). Dispatched on `SingleMode`; the batched outer-k loop fires no per-k
+# `OuterIteration` bracket at all — its device lifecycle lives in the OuterIterationBatch brackets.
 function calculator_begin!(calc::BoltzmannCalculator{FT}, ::OuterIteration,
         ctx::LoopContext{CPUBackend, SingleMode}) where {FT}
     for c in eachindex(calc.Sₒ_buffer)
@@ -259,12 +258,6 @@ function calculator_end!(calc::BoltzmannCalculator, ::OuterIteration,
     end
     calc
 end
-
-# GPU per-k OuterIteration bracket: no-op. The batched outer-k loop fires the per-k `OuterIteration`
-# brackets too (BatchedMode), but this calculator's per-k device work is none — its device buffers
-# are set up once and the per-batch tile lifecycle lives in the OuterIterationBatch brackets below.
-calculator_begin!(::BoltzmannCalculator, ::OuterIteration, ::LoopContext{<:AbstractBackend, BatchedMode}) = nothing
-calculator_end!(::BoltzmannCalculator,   ::OuterIteration, ::LoopContext{<:AbstractBackend, BatchedMode}) = nothing
 
 # --- GPU batched path (EPDataQBatched) -----------------------------------------------
 

--- a/src/boltzmann/boltzmann_calculator.jl
+++ b/src/boltzmann/boltzmann_calculator.jl
@@ -263,8 +263,9 @@ end
 
 # Batched path: called by the GPU e-ph loop once per outer-k batch, before its k iterations. The
 # run's device buffers (`calc.dev`) were built once in `setup_calculator!`; here it only records this
-# batch's Sᵢ tile range and zeros the tile's active region (via `calc.tiled`). Dispatched on
-# `BatchedMode`; the per-point (`SingleMode`) path runs the default no-op.
+# batch's Sᵢ tile range and zeros the tile's active region (via `calc.tiled`). The `BatchedMode`
+# annotation records the only mode this scope is ever fired in (`OuterIterationBatch`/`SingleMode`
+# does not occur); brackets have no default, so this method is required rather than an override.
 function calculator_begin!(calc::BoltzmannCalculator{FT}, ::OuterIterationBatch,
         ctx::LoopContext{<:AbstractBackend, BatchedMode}) where {FT}
     # Sᵢ tile for this batch (block mode: zeroed and its range recorded by the helper).

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -18,7 +18,8 @@ Users subtype `AbstractCalculator` and implement:
   around one outer iteration (`OuterIteration()`) or one batch of outer iterations
   (`OuterIterationBatch()`). There is NO default: a calculator must define these for every
   (scope, loop-mode) combination its supported loops fire, even as an explicit no-op (`= nothing`);
-  a missing method is a loud error, not a silent skip.
+  a missing method is a loud error, not a silent skip. The GPU outer-k loop fires only
+  `OuterIterationBatch` (see the bracket comment below).
 
 Optionally:
 * `eph_batched_bytes_per_point(calc, PayloadType; nw, nmodes)` — per-point device scratch (bytes)
@@ -168,9 +169,12 @@ struct OuterIterationBatch end   # one batch of consecutive outer iterations (GP
 # (scope, loop-mode) combination the drivers fire on it, even when it wants a no-op — a missing
 # method is a loud error, never a silent skip (a silently-skipped bracket is a hard-to-find bug). The
 # combinations follow what the calculator `supports`: OuterIteration/SingleMode (CPU loops),
-# OuterIteration/BatchedMode (GPU outer-k per-k bracket; GPU outer-q per-q accumulator), and
-# OuterIterationBatch/BatchedMode (GPU outer-k per-batch). OuterIterationBatch/SingleMode is never
-# fired. A calculator that does nothing at a scope defines an explicit no-op (`= nothing`).
+# OuterIteration/BatchedMode (GPU outer-q per-q accumulator), and OuterIterationBatch/BatchedMode
+# (GPU outer-k per-batch). OuterIterationBatch/SingleMode is never fired, and neither is
+# OuterIteration/BatchedMode in the GPU OUTER-K loop: there the q-tile loop runs outside the k loop,
+# so a single k's work is spread over the whole batch and has no per-k begin/end point — a
+# calculator needing a per-k device reduction there must do it at OuterIterationBatch scope.
+# A calculator that does nothing at a scope defines an explicit no-op (`= nothing`).
 function calculator_begin!(calc::AbstractCalculator, scope, ctx)
     error("calculator_begin!($(typeof(calc)), ::$(typeof(scope)), ::$(typeof(ctx))) is not " *
           "defined. Every calculator must define the begin/end brackets for the (scope, loop-mode) " *

--- a/src/calculator/eph_device_staging.jl
+++ b/src/calculator/eph_device_staging.jl
@@ -56,6 +56,8 @@ end
 # built at `batch_size = nk_batch_max`, was omitted from the original hand-count — validated against a
 # direct pool-stat measurement of `BatchedWannierInterpolator(epmat_dev)`) PLUS the k+q-convention
 # terms `24·(nk + nkq) + 8·nkq + 16·nr_ep·nk_batch_max`. All transition-pinned by test/test_gpu.jl.
+# Not counted: the loop's `irvecp_mat` (`24·nr_ep`, 20 kB at Cu shapes), matching how the
+# `BatchedFourierCore.irvec_mat` of the same shape has never been counted.
 function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_grid, nk_batch_max,
         calculators, ndata_epmat, nr_epmat, FT = Float64)
     cx = sizeof(Complex{FT})    # 16

--- a/src/calculator/eph_device_staging.jl
+++ b/src/calculator/eph_device_staging.jl
@@ -12,7 +12,8 @@
 # the batch-sizing check are centralized here.
 
 """
-    plan_batch(backend, per_point, committed, cap; headroom_num = 7, headroom_den = 10, what = "") -> nbatch
+    plan_batch(backend, per_point, committed, cap; headroom_num = 7, headroom_den = 10, what = "",
+               warn = true) -> nbatch
 
 Size a batched GPU e-ph loop's batch to free device memory:
 `nbatch = min(cap, (free - committed) · headroom ÷ per_point)`, clamped to at least 1, where
@@ -21,10 +22,13 @@ CPU backend `free_bytes` is `typemax(Int)`, so `nbatch = cap`. Errors if the who
 alone exceed free device memory (a clear early failure instead of an OOM mid-loop); `what` names the
 loop in that message. `headroom_num / headroom_den` is the usable fraction of free memory (default
 `7/10`, i.e. a 30% headroom for the batched drivers' recycled temporaries), applied as
-`x ÷ den * num` to match the integer arithmetic of the formulas this replaces.
+`x ÷ den * num` to match the integer arithmetic of the formulas this replaces. Pass `warn = false`
+for a counterfactual query ("how wide would the batch be at a different `per_point`?"), which must
+not tell the user their batch was reduced.
 """
 function plan_batch(backend::AbstractBackend, per_point::Integer, committed::Integer, cap::Integer;
-        headroom_num::Integer = 7, headroom_den::Integer = 10, what::AbstractString = "")
+        headroom_num::Integer = 7, headroom_den::Integer = 10, what::AbstractString = "",
+        warn::Bool = true)
     free = free_bytes(backend)
     if free != typemax(Int) && committed > free
         error("GPU $(what): committed device memory ($(round(committed / 1e9, digits = 2)) GB, " *
@@ -34,7 +38,7 @@ function plan_batch(backend::AbstractBackend, per_point::Integer, committed::Int
     nb_mem = free == typemax(Int) ? Int(cap) :
         max(1, ((free - committed) ÷ headroom_den * headroom_num) ÷ per_point)
     nbatch = min(Int(cap), nb_mem)
-    if free != typemax(Int) && nb_mem < cap
+    if warn && free != typemax(Int) && nb_mem < cap
         @warn "WARNING : GPU batch width reduced from the requested cap $(Int(cap)) to $nbatch to fit " *
             "free device memory in plan_batch$(isempty(what) ? "" : " ($what)"). GPU performance may " *
             "degrade compared to smaller calculations."

--- a/src/calculator/eph_device_staging.jl
+++ b/src/calculator/eph_device_staging.jl
@@ -49,9 +49,11 @@ end
 # e-ph data size (`= nw²·nmodes` full-band); `nr_ep` = number of R-vectors of g(k, R_ep); `nkq` /
 # `nq_grid` = k+q / q grid sizes; `nk_batch_max` = the fixed outer-k batch width; `ndata_epmat` /
 # `nr_epmat` = the parent e-ph object's (`epmat_dev`) data size / R-vector count, for the RR→kR
-# interpolator's scratch. The per-q term sums to `56·nw·nbandk_max·nmodes + 16·nr_ep + 16·nmodes² +
-# 8·nmodes + 8 + Σcalc`; the committed to the old hand-counted `16·nw²·nkq + (16·nmodes²+8·nmodes)·
-# nq_grid + 16·nw·nbandk_max·(nmodes·nr_ep+1)·nk_batch_max` PLUS the `itp_epmat` Fourier scratch
+# interpolator's scratch. `nk_b` is the kR→kq GEMM strip width (`_krkq_strip_width`), which widens
+# `kRkq_ws.g` and nothing else. The per-q term sums to `(40 + 16·nk_b)·nw·nbandk_max·nmodes +
+# 16·nr_ep + 16·nmodes² + 8·nmodes + 8 + Σcalc`; the committed to the old hand-counted
+# `16·nw²·nkq + (16·nmodes²+8·nmodes)·nq_grid +
+# 16·nw·nbandk_max·(nmodes·nr_ep+1)·nk_batch_max` PLUS the `itp_epmat` Fourier scratch
 # `(16·ndata_epmat + 16·nr_epmat + 24)·nk_batch_max` (added 2026-07-18; the parent RR→kR interpolator,
 # built at `batch_size = nk_batch_max`, was omitted from the original hand-count — validated against a
 # direct pool-stat measurement of `BatchedWannierInterpolator(epmat_dev)`) PLUS the k+q-convention
@@ -59,7 +61,7 @@ end
 # Not counted: the loop's `irvecp_mat` (`24·nr_ep`, 20 kB at Cu shapes), matching how the
 # `BatchedFourierCore.irvec_mat` of the same shape has never been counted.
 function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_grid, nk_batch_max,
-        calculators, ndata_epmat, nr_epmat, FT = Float64)
+        calculators, ndata_epmat, nr_epmat, nk_b = 1, FT = Float64)
     cx = sizeof(Complex{FT})    # 16
     rl = sizeof(FT)             # 8
     iz = sizeof(Int)            # 8
@@ -69,7 +71,7 @@ function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_gri
     per_point =
         cx * ndata +                       # epkq_dev
         rl * ndata +                       # g2_dev
-        cx * ndata +                       # kRkq_ws.g   (ndata_ekpR)
+        cx * ndata * nk_b +                # kRkq_ws.g   (ndata_ekpR × the GEMM strip width)
         cx * nw * (nbandk_max * nmodes) +  # kRkq_ws.tmp (nbandkq=nw, nbandk·nmodes)
         cx * nr_ep +                       # P_kq (kR→kq phase tile)
         cx * nmodes * nmodes +             # uphs_dev

--- a/src/calculator/eph_device_staging.jl
+++ b/src/calculator/eph_device_staging.jl
@@ -53,9 +53,8 @@ end
 # e-ph data size (`= nw²·nmodes` full-band); `nr_ep` = number of R-vectors of g(k, R_ep); `nkq` /
 # `nq_grid` = k+q / q grid sizes; `nk_batch_max` = the fixed outer-k batch width; `ndata_epmat` /
 # `nr_epmat` = the parent e-ph object's (`epmat_dev`) data size / R-vector count, for the RR→kR
-# interpolator's scratch. `nk_b` is the kR→kq GEMM strip width (`_krkq_strip_width`), which widens
-# `kRkq_ws.g` and nothing else. The per-q term sums to `(40 + 16·nk_b)·nw·nbandk_max·nmodes +
-# 16·nr_ep + 16·nmodes² + 8·nmodes + 8 + Σcalc`; the committed to the old hand-counted
+# interpolator's scratch. The per-q term sums to `56·nw·nbandk_max·nmodes + 16·nr_ep + 16·nmodes² +
+# 8·nmodes + 8 + Σcalc`; the committed to the old hand-counted
 # `16·nw²·nkq + (16·nmodes²+8·nmodes)·nq_grid +
 # 16·nw·nbandk_max·(nmodes·nr_ep+1)·nk_batch_max` PLUS the `itp_epmat` Fourier scratch
 # `(16·ndata_epmat + 16·nr_epmat + 24)·nk_batch_max` (added 2026-07-18; the parent RR→kR interpolator,
@@ -65,7 +64,7 @@ end
 # Not counted: the loop's `irvecp_mat` (`24·nr_ep`, 20 kB at Cu shapes), matching how the
 # `BatchedFourierCore.irvec_mat` of the same shape has never been counted.
 function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_grid, nk_batch_max,
-        calculators, ndata_epmat, nr_epmat, nk_b = 1, FT = Float64)
+        calculators, ndata_epmat, nr_epmat, FT = Float64)
     cx = sizeof(Complex{FT})    # 16
     rl = sizeof(FT)             # 8
     iz = sizeof(Int)            # 8
@@ -75,7 +74,7 @@ function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_gri
     per_point =
         cx * ndata +                       # epkq_dev
         rl * ndata +                       # g2_dev
-        cx * ndata * nk_b +                # kRkq_ws.g   (ndata_ekpR × the GEMM strip width)
+        cx * ndata +                       # kRkq_ws.g   (ndata_ekpR)
         cx * nw * (nbandk_max * nmodes) +  # kRkq_ws.tmp (nbandkq=nw, nbandk·nmodes)
         cx * nr_ep +                       # P_kq (kR→kq phase tile)
         cx * nmodes * nmodes +             # uphs_dev

--- a/src/calculator/eph_device_staging.jl
+++ b/src/calculator/eph_device_staging.jl
@@ -49,49 +49,47 @@ end
 # e-ph data size (`= nw²·nmodes` full-band); `nr_ep` = number of R-vectors of g(k, R_ep); `nkq` /
 # `nq_grid` = k+q / q grid sizes; `nk_batch_max` = the fixed outer-k batch width; `ndata_epmat` /
 # `nr_epmat` = the parent e-ph object's (`epmat_dev`) data size / R-vector count, for the RR→kR
-# interpolator's scratch. The per-q term sums to `72·nw·nbandk_max·nmodes + 24·nr_ep + 16·nmodes² +
-# 8·nmodes + 40 + Σcalc`; the committed to the old hand-counted `16·nw²·nkq + (16·nmodes²+8·nmodes)·
+# interpolator's scratch. The per-q term sums to `56·nw·nbandk_max·nmodes + 16·nr_ep + 16·nmodes² +
+# 8·nmodes + 8 + Σcalc`; the committed to the old hand-counted `16·nw²·nkq + (16·nmodes²+8·nmodes)·
 # nq_grid + 16·nw·nbandk_max·(nmodes·nr_ep+1)·nk_batch_max` PLUS the `itp_epmat` Fourier scratch
-# `(16·ndata_epmat + 24·nr_epmat + 24)·nk_batch_max` (added 2026-07-18; the parent RR→kR interpolator,
+# `(16·ndata_epmat + 16·nr_epmat + 24)·nk_batch_max` (added 2026-07-18; the parent RR→kR interpolator,
 # built at `batch_size = nk_batch_max`, was omitted from the original hand-count — validated against a
-# direct pool-stat measurement of `BatchedWannierInterpolator(epmat_dev)`). Both transition-pinned by
-# test/test_gpu.jl.
-function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nkq, nq_grid, nk_batch_max,
+# direct pool-stat measurement of `BatchedWannierInterpolator(epmat_dev)`) PLUS the k+q-convention
+# terms `24·(nk + nkq) + 8·nkq + 16·nr_ep·nk_batch_max`. All transition-pinned by test/test_gpu.jl.
+function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_grid, nk_batch_max,
         calculators, ndata_epmat, nr_epmat, FT = Float64)
     cx = sizeof(Complex{FT})    # 16
     rl = sizeof(FT)             # 8
     iz = sizeof(Int)            # 8
     ndata = nw * nbandk_max * nmodes
-    # Per-q device buffers (batched-inner axis = q): epkq/g2/uphs/ωq/iqs/ikqs are the loop's own
-    # staging; kRkq_ws.{g,tmp} + the itp_ep_ekpR Fourier scratch (cached_results / phase / rdotk /
-    # xkmat) scale with the q-batch too.
+    # Per-q device buffers (batched-inner axis = q): epkq/g2/uphs/ωq/iqs are the loop's own staging;
+    # kRkq_ws.{g,tmp} and the kR→kq phase tile P_kq scale with the q-tile too.
     per_point =
         cx * ndata +                       # epkq_dev
         rl * ndata +                       # g2_dev
         cx * ndata +                       # kRkq_ws.g   (ndata_ekpR)
         cx * nw * (nbandk_max * nmodes) +  # kRkq_ws.tmp (nbandkq=nw, nbandk·nmodes)
-        cx * ndata +                       # itp_ep_ekpR.cached_results (ndata_ekpR)
-        cx * nr_ep +                       # itp_ep_ekpR.core.phase
-        rl * nr_ep +                       # itp_ep_ekpR.core.rdotk
-        rl * 3 +                           # itp_ep_ekpR.core.xkmat (3 rows)
+        cx * nr_ep +                       # P_kq (kR→kq phase tile)
         cx * nmodes * nmodes +             # uphs_dev
         rl * nmodes +                      # ωq_dev
-        iz + iz                            # iqs_batch_dev + ikqs_dev
+        iz                                 # iqs_batch_dev
     for c in calculators
         per_point += eph_batched_bytes_per_point(c, EPDataQBatched; nw, nmodes)
     end
     # Whole-run + per-k-batch commitments (allocated after the sizing point; subtracted from free).
     # The `itp_epmat` term uses `nk_batch_max` (the outer-k batch width, a SEPARATE fixed cap from the
-    # sized q-batch), so it belongs here in `committed`, not in the per-q term. Its layout mirrors how
-    # the child `itp_ep_ekpR` scratch is counted in `per_point`: cached_results (16·ndata_epmat) +
-    # phase (16·nr_epmat) + rdotk (8·nr_epmat) + xkmat (24), all × nk_batch_max.
+    # sized q-tile), so it belongs here in `committed`, not in the per-q term: cached_results
+    # (16·ndata_epmat) + phase (16·nr_epmat) + xkmat (24), all × nk_batch_max.
     committed =
         cx * nw * nw * nkq +                                  # ukqs_all_dev
         cx * nmodes * nmodes * nq_grid +                      # uph_all_dev
         rl * nmodes * nq_grid +                               # ωq_all_dev
         cx * ndata * nr_ep * nk_batch_max +                   # ep_ekpR_all
         cx * nw * nbandk_max * nk_batch_max +                 # uks_dev
-        (cx * ndata_epmat + (cx + rl) * nr_epmat + rl * 3) * nk_batch_max  # itp_epmat Fourier scratch
+        (cx * ndata_epmat + cx * nr_epmat + rl * 3) * nk_batch_max + # itp_epmat Fourier scratch
+        rl * 3 * (nk + nkq) +                                 # xk_dev + xkq_dev
+        iz * nkq +                                            # ikqs_all_dev (1:nkq)
+        cx * nr_ep * nk_batch_max                             # P_k (k+q-convention phase)
     (per_point, committed)
 end
 
@@ -110,7 +108,7 @@ function _outer_q_staging_bytes(; nw, nmodes, nr_el_ham, nr_ep_eRpq, use_polar_e
         cx * nw^2 * 8 +                       # Hkq_flat + Uk_batch + Ukq_batch + itp_el_ham.cached_results
                                              #   + eigen_batched (E,U) & rotation transients (historical margin)
         (use_polar_eph ? cx * nw^2 : 0) +    # mmats_batch (polar only)
-        (cx + rl) * (nr_el_ham + nr_ep_eRpq) # interpolator core phase (cx) + rdotk (rl) = 24·nr, both interpolators
+        cx * (nr_el_ham + nr_ep_eRpq)        # interpolator core phase, both interpolators
     for c in calculators
         per_point += eph_batched_bytes_per_point(c, EPDataKBatched; nw, nmodes)
     end

--- a/src/calculator/eph_device_staging.jl
+++ b/src/calculator/eph_device_staging.jl
@@ -70,13 +70,13 @@ function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_gri
     iz = sizeof(Int)            # 8
     ndata = nw * nbandk_max * nmodes
     # Per-q device buffers (batched-inner axis = q): epkq/g2/uphs/ωq/iqs are the loop's own staging;
-    # kRkq_ws.{g,tmp} and the kR→kq phase tile P_mkq scale with the q-tile too.
+    # kRkq_ws.{g,tmp} and the kR→kq phase tile P_kq scale with the q-tile too.
     per_point =
         cx * ndata +                       # epkq_dev
         rl * ndata +                       # g2_dev
         cx * ndata +                       # kRkq_ws.g   (ndata_ekpR)
         cx * nw * (nbandk_max * nmodes) +  # kRkq_ws.tmp (nbandkq=nw, nbandk·nmodes)
-        cx * nr_ep +                       # P_mkq (kR→kq phase tile)
+        cx * nr_ep +                       # P_kq (kR→kq phase tile)
         cx * nmodes * nmodes +             # uphs_dev
         rl * nmodes +                      # ωq_dev
         iz                                 # iqs_batch_dev
@@ -94,7 +94,7 @@ function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_gri
         cx * ndata * nr_ep * nk_batch_max +                   # ep_ekpR_all
         cx * nw * nbandk_max * nk_batch_max +                 # uks_dev
         (cx * ndata_epmat + cx * nr_epmat + rl * 3) * nk_batch_max + # itp_epmat Fourier scratch
-        rl * 3 * (nk + nkq) +                                 # xk_dev + xkq_dev
+        rl * 3 * (nk + nkq) +                                 # mxk_dev + xkq_dev
         cx * nr_ep * nk_batch_max                             # P_mk (k+q-convention phase)
     (per_point, committed)
 end

--- a/src/calculator/eph_device_staging.jl
+++ b/src/calculator/eph_device_staging.jl
@@ -70,13 +70,13 @@ function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_gri
     iz = sizeof(Int)            # 8
     ndata = nw * nbandk_max * nmodes
     # Per-q device buffers (batched-inner axis = q): epkq/g2/uphs/ωq/iqs are the loop's own staging;
-    # kRkq_ws.{g,tmp} and the kR→kq phase tile P_kq scale with the q-tile too.
+    # kRkq_ws.{g,tmp} and the kR→kq phase tile P_mkq scale with the q-tile too.
     per_point =
         cx * ndata +                       # epkq_dev
         rl * ndata +                       # g2_dev
         cx * ndata +                       # kRkq_ws.g   (ndata_ekpR)
         cx * nw * (nbandk_max * nmodes) +  # kRkq_ws.tmp (nbandkq=nw, nbandk·nmodes)
-        cx * nr_ep +                       # P_kq (kR→kq phase tile)
+        cx * nr_ep +                       # P_mkq (kR→kq phase tile)
         cx * nmodes * nmodes +             # uphs_dev
         rl * nmodes +                      # ωq_dev
         iz                                 # iqs_batch_dev
@@ -95,7 +95,7 @@ function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_gri
         cx * nw * nbandk_max * nk_batch_max +                 # uks_dev
         (cx * ndata_epmat + cx * nr_epmat + rl * 3) * nk_batch_max + # itp_epmat Fourier scratch
         rl * 3 * (nk + nkq) +                                 # xk_dev + xkq_dev
-        cx * nr_ep * nk_batch_max                             # P_k (k+q-convention phase)
+        cx * nr_ep * nk_batch_max                             # P_mk (k+q-convention phase)
     (per_point, committed)
 end
 

--- a/src/calculator/eph_device_staging.jl
+++ b/src/calculator/eph_device_staging.jl
@@ -54,9 +54,8 @@ end
 # `nq_grid` = k+q / q grid sizes; `nk_batch_max` = the fixed outer-k batch width; `ndata_epmat` /
 # `nr_epmat` = the parent e-ph object's (`epmat_dev`) data size / R-vector count, for the RR→kR
 # interpolator's scratch. `nk_b` is the kR→kq GEMM strip width (`_krkq_strip_width`), which widens
-# `kRkq_ws.g` and the `iq` index staging. The per-q term sums to
-# `(40 + 16·nk_b)·nw·nbandk_max·nmodes + 16·nr_ep + 16·nmodes² + 8·nmodes + 8·nk_b + Σcalc`;
-# the committed to the old hand-counted
+# `kRkq_ws.g` and nothing else. The per-q term sums to `(40 + 16·nk_b)·nw·nbandk_max·nmodes +
+# 16·nr_ep + 16·nmodes² + 8·nmodes + 8 + Σcalc`; the committed to the old hand-counted
 # `16·nw²·nkq + (16·nmodes²+8·nmodes)·nq_grid +
 # 16·nw·nbandk_max·(nmodes·nr_ep+1)·nk_batch_max` PLUS the `itp_epmat` Fourier scratch
 # `(16·ndata_epmat + 16·nr_epmat + 24)·nk_batch_max` (added 2026-07-18; the parent RR→kR interpolator,
@@ -81,7 +80,7 @@ function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_gri
         cx * nr_ep +                       # P_kq (kR→kq phase tile)
         cx * nmodes * nmodes +             # uphs_dev
         rl * nmodes +                      # ωq_dev
-        iz * nk_b                          # iqs_strip_dev (staged one kR->kq strip wide)
+        iz                                 # iqs_batch_dev
     for c in calculators
         per_point += eph_batched_bytes_per_point(c, EPDataQBatched; nw, nmodes)
     end

--- a/src/calculator/eph_device_staging.jl
+++ b/src/calculator/eph_device_staging.jl
@@ -54,14 +54,15 @@ end
 # `nq_grid` = k+q / q grid sizes; `nk_batch_max` = the fixed outer-k batch width; `ndata_epmat` /
 # `nr_epmat` = the parent e-ph object's (`epmat_dev`) data size / R-vector count, for the RR→kR
 # interpolator's scratch. `nk_b` is the kR→kq GEMM strip width (`_krkq_strip_width`), which widens
-# `kRkq_ws.g` and nothing else. The per-q term sums to `(40 + 16·nk_b)·nw·nbandk_max·nmodes +
-# 16·nr_ep + 16·nmodes² + 8·nmodes + 8 + Σcalc`; the committed to the old hand-counted
+# `kRkq_ws.g` and the `iq` index staging. The per-q term sums to
+# `(40 + 16·nk_b)·nw·nbandk_max·nmodes + 16·nr_ep + 16·nmodes² + 8·nmodes + 8·nk_b + Σcalc`;
+# the committed to the old hand-counted
 # `16·nw²·nkq + (16·nmodes²+8·nmodes)·nq_grid +
 # 16·nw·nbandk_max·(nmodes·nr_ep+1)·nk_batch_max` PLUS the `itp_epmat` Fourier scratch
 # `(16·ndata_epmat + 16·nr_epmat + 24)·nk_batch_max` (added 2026-07-18; the parent RR→kR interpolator,
 # built at `batch_size = nk_batch_max`, was omitted from the original hand-count — validated against a
 # direct pool-stat measurement of `BatchedWannierInterpolator(epmat_dev)`) PLUS the k+q-convention
-# terms `24·(nk + nkq) + 8·nkq + 16·nr_ep·nk_batch_max`. All transition-pinned by test/test_gpu.jl.
+# terms `24·(nk + nkq) + 16·nr_ep·nk_batch_max`. All transition-pinned by test/test_gpu.jl.
 # Not counted: the loop's `irvecp_mat` (`24·nr_ep`, 20 kB at Cu shapes), matching how the
 # `BatchedFourierCore.irvec_mat` of the same shape has never been counted.
 function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_grid, nk_batch_max,
@@ -80,7 +81,7 @@ function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_gri
         cx * nr_ep +                       # P_kq (kR→kq phase tile)
         cx * nmodes * nmodes +             # uphs_dev
         rl * nmodes +                      # ωq_dev
-        iz                                 # iqs_batch_dev
+        iz * nk_b                          # iqs_strip_dev (staged one kR->kq strip wide)
     for c in calculators
         per_point += eph_batched_bytes_per_point(c, EPDataQBatched; nw, nmodes)
     end
@@ -96,7 +97,6 @@ function _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_gri
         cx * nw * nbandk_max * nk_batch_max +                 # uks_dev
         (cx * ndata_epmat + cx * nr_epmat + rl * 3) * nk_batch_max + # itp_epmat Fourier scratch
         rl * 3 * (nk + nkq) +                                 # xk_dev + xkq_dev
-        iz * nkq +                                            # ikqs_all_dev (1:nkq)
         cx * nr_ep * nk_batch_max                             # P_k (k+q-convention phase)
     (per_point, committed)
 end

--- a/src/calculator/eph_setup_common.jl
+++ b/src/calculator/eph_setup_common.jl
@@ -37,18 +37,20 @@ end
 # directly on `kqpts`. `kqpts_irr` / `ik_to_ikirr_isym_kq` are only read on the unfolding path.
 function _compute_electron_states_kq(
         model, kqpts, kqpts_irr, ik_to_ikirr_isym_kq, symmetry, el_kq_from_unfolding, window_kq;
-        quantities, fourier_mode, use_gpu = false,
+        quantities, fourier_mode, use_gpu = false, verbosity = 1,
     )
-    if el_kq_from_unfolding
-        symmetry !== nothing || throw(ArgumentError("el_kq_from_unfolding = true requires symmetry"))
-        el_kq_save_irr = compute_electron_states(model, kqpts_irr, quantities, window_kq; fourier_mode, use_gpu)
-        el_kq_save = unfold_ElectronStates(model, el_kq_save_irr, kqpts_irr, kqpts, ik_to_ikirr_isym_kq, symmetry; fourier_mode)
-        # el_kq_save_irr is not used anymore.
-        el_kq_save_irr !== el_kq_save && empty!(el_kq_save_irr)
-    else
-        el_kq_save = compute_electron_states(model, kqpts, quantities, window_kq; fourier_mode, use_gpu)
+    maybe_time(verbosity) do
+        if el_kq_from_unfolding
+            symmetry !== nothing || throw(ArgumentError("el_kq_from_unfolding = true requires symmetry"))
+            el_kq_save_irr = compute_electron_states(model, kqpts_irr, quantities, window_kq; fourier_mode, use_gpu)
+            el_kq_save = unfold_ElectronStates(model, el_kq_save_irr, kqpts_irr, kqpts, ik_to_ikirr_isym_kq, symmetry; fourier_mode)
+            # el_kq_save_irr is not used anymore.
+            el_kq_save_irr !== el_kq_save && empty!(el_kq_save_irr)
+        else
+            el_kq_save = compute_electron_states(model, kqpts, quantities, window_kq; fourier_mode, use_gpu)
+        end
+        el_kq_save
     end
-    el_kq_save
 end
 
 
@@ -97,7 +99,8 @@ function _setup_electron_kq(model, kqpts_input;
 
     # (3) states: direct, or gauge-consistent IBZ→full unfolding (the one genuinely special path)
     el_kq_save = _compute_electron_states_kq(model, kqpts, kqpts_irr, ik_to_ikirr_isym_kq,
-        symmetry, el_kq_from_unfolding, window_kq; quantities=el_kq_quantities, fourier_mode, use_gpu)
+        symmetry, el_kq_from_unfolding, window_kq;
+        quantities=el_kq_quantities, fourier_mode, use_gpu, verbosity)
     sel_kq = electron_states_to_FilteredStates(kqpts, el_kq_save, nelec_kq; nw)
     return (; kqpts, el_kq_save, sel_kq)
 end

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -661,6 +661,10 @@ function _loop_eph_over_k_and_kq_gpu(
     # Phonon eigenvectors `u` and frequencies `e` depend only on iq, so (like ukqs_all_dev above)
     # collect the full q-grid stacks on the host and copy to the device once, then gather per
     # batch on the device by index (below).
+    # TODO: these two are the only fields of `ph_save` this loop ever reads, and
+    # `_compute_phonon_states_gpu!` built them on the device before scattering them into per-q
+    # `PhononState`s — so this gather + H2D undoes a D2H. Have the setup hand `use_gpu` the device
+    # stacks directly and drop this block; see the TODO at `_scatter_phonon_states!`.
     uph_all_dev = similar(epmat_dev.op_r, Complex{FT}, nmodes, nmodes, qpts.n)
     ωq_all_dev  = similar(epmat_dev.op_r, FT, nmodes, qpts.n)
     let uph_all_host = Array{Complex{FT}}(undef, nmodes, nmodes, qpts.n),

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -621,15 +621,22 @@ function _loop_eph_over_k_and_kq_gpu(
               "$(round(per_point / 1e3, digits = 1)) kB/q; q-batch size = $nq_batch_max, " *
               "kR->kq strip nk_b = $nk_b"
     end
-    # The strip's extra `ws.g` rows are spent out of the same per-q budget as the phase tile. At the
-    # shapes where the strip switches on they are a small share of it, but a model with a large
-    # `ndata` and a small `nr_ep` inverts that; say so rather than silently starving the q-tile.
-    strip_bytes = sizeof(Complex{FT}) * ndata_ekpR * (nk_b - 1)
-    if nk_b > 1 && nq_batch_max < nq_batch_cap && strip_bytes * 4 > per_point
-        @warn "GPU outer-k: the kR->kq strip (nk_b = $nk_b) takes " *
-              "$(round(Int, 100 * strip_bytes / per_point))% of the per-q device budget while the " *
-              "q-tile is memory-limited ($nq_batch_max of $nq_batch_cap). Lower _KRKQ_GEMM_M_TARGET if this " *
-              "run is slower than one with nk_b = 1."
+    # The strip widens `ws.g`, which is spent out of the same per-q budget as the phase tile. At the
+    # shapes where the strip switches on it is a small share of that budget, but a model with a large
+    # `ndata` and a small `nr_ep` inverts the ratio. Report the quantity that actually matters — how
+    # much q-tile the strip cost — by re-asking the accountant at `nk_b = 1`, so this stays right if
+    # another buffer ever becomes strip-sized. Only when the tile is memory-bound (`< nq_batch_cap`):
+    # a user-supplied `nq_batch_max` is not the strip's fault.
+    if nk_b > 1 && nq_batch_max < nq_batch_cap && mpi_isroot()
+        per_point_1, _ = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
+            nq_grid = qpts.n, nk_batch_max, calculators,
+            ndata_epmat = epmat_dev.ndata, nr_epmat = epmat_dev.nr, nk_b = 1, FT)
+        nq_batch_1 = plan_batch(backend, per_point_1, committed, nq_batch_cap; warn = false)
+        if nq_batch_max * 2 < nq_batch_1
+            @warn "GPU outer-k: the kR->kq strip (nk_b = $nk_b) more than halved the q-tile " *
+                  "($nq_batch_1 -> $nq_batch_max of $nkq k+q). Lower `nk_outer_batch_max` (it " *
+                  "clamps nk_b) if this run is slower than one with nk_b = 1."
+        end
     end
 
     # ----- persistent workspace (allocated once, reused across all (k, q)) -----
@@ -796,6 +803,9 @@ function _loop_eph_over_k_and_kq_gpu(
             # (unit stride down the rows, `lda = ndata_ekpR*nk_batch_max` across) - a plain view,
             # no copy. A partial final strip just uses a shorter row range: `M` is a runtime GEMM
             # dimension, so nothing needs padding. Everything below the GEMM stays strictly per-k.
+            # NOT an invitation to overlap the k of a strip: `g` is the only strip-wide buffer.
+            # `epkq_dev`, `g2_dev`, `uphs_dev`, `ωq_dev` and `kRkq_ws.tmp` are all single-k and are
+            # overwritten by each k below, correct only because the k are serialized on one stream.
             for sstart in 1:nk_b:nk_batch
                 nks  = min(nk_b, nk_batch - sstart + 1)
                 rows = ndata_ekpR * (sstart - 1) + 1 : ndata_ekpR * (sstart - 1 + nks)

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -693,7 +693,7 @@ function _loop_eph_over_k_and_kq_gpu(
     # exact, and `cispi` is exactly symmetric). This is the only consumer of the k coordinates.
     # Out-of-place on purpose: on `CPUBackend` `_kpoints_to_device_matrix` returns a view onto
     # `kpts.vectors`, so negating in place would corrupt the k-points.
-    mxk_dev = -1 .* _kpoints_to_device_matrix(backend, kpts)
+    mxk_dev = _kpoints_to_device_matrix(backend, kpts) .* -1
     xkq_dev = _kpoints_to_device_matrix(backend, kqpts)
 
     # The two Fourier phase matrices of the k+q convention (see `get_eph_RR_to_kR_batched!`):

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -513,6 +513,57 @@ end
 #  small-`nw` regime; a full-band large-`nw` run gets `nk_b = 1` and the loop as it was. k are
 #  visited in the same order and everything below the GEMM is per-k, so the payload stream and the
 #  bracket order are unchanged.
+# ---- per-(k-strip, q-tile) `iq` index build ------------------------------------------------------
+#
+# `prepare_iqs!(builder, iqs_dev, iks, kloc0, qstart, nq)` fills `iqs_dev[1:nq, kloc0 + i - 1]` with
+# the index into `qpts` of `x_{k+q} - x_k` for the `i`-th outer k of `iks` and every k+q of the tile
+# `qstart .+ (0:nq-1)`, leaving the device buffer ready for the phonon gather. The builder owns its
+# host staging matrix and ends with the H2D.
+#
+# The staging is per k-STRIP (`nk_b` columns), not per k: one stream drain per strip instead of
+# `nk_b` of them, for `nk_b * nq_batch_max * 8` B of host and device staging (12.7 MB at Cu nk=150).
+# That drain count is most of what this block costs — see `plans/qindex_build_threaded_vs_device.md`.
+# At `nk_b == 1` it degenerates to per-k staging exactly.
+struct SerialHostIqBuilder{GK}
+    qpts     :: GK
+    xkqs_int :: Matrix{Int}   # (3, nkq), reduced into 0:ngrid[d]-1
+    xks_int  :: Matrix{Int}   # (3, nk),  reduced into 0:ngrid[d]-1
+    iqs_host :: Matrix{Int}   # (nq_batch_max, nk_b) host staging
+end
+
+function prepare_iqs!(b::SerialHostIqBuilder, iqs_dev, iks, kloc0::Int, qstart::Int, nq::Int)
+    _fill_iqs_serial!(b.iqs_host, b.qpts, b.xkqs_int, b.xks_int, iks, kloc0, qstart, nq)
+    # One contiguous 5-arg H2D of the columns just written (a host↔device SubArray copy would fall
+    # back to scalar indexing). Full columns: the rows past `nq` are never read by the gather.
+    copyto!(iqs_dev, size(b.iqs_host, 1) * (kloc0 - 1) + 1,
+            b.iqs_host, size(b.iqs_host, 1) * (kloc0 - 1) + 1, size(b.iqs_host, 1) * length(iks))
+    iqs_dev
+end
+
+# The build itself, as a standalone function so the `iks`/`qstart`/`nq` it closes over are typed
+# arguments rather than `Core.Box`-wrapped captures of the enclosing loop bodies.
+function _fill_iqs_serial!(iqs, qpts, xkqs_int, xks_int, iks, kloc0, qstart, nq)
+    ng1, ng2, ng3 = qpts.ngrid
+    for (i, ik) in enumerate(iks)
+        kloc = kloc0 + i - 1
+        k1, k2, k3 = xks_int[1, ik], xks_int[2, ik], xks_int[3, ik]
+        for j in 1:nq
+            ikq = qstart + j - 1
+            # Integer grid-coord hash for iq (no Float64 normalize/_hash_xk per pair). Both operands
+            # are pre-reduced into 0:ng-1 at setup, so the fold is a compare-and-add.
+            h1 = _wrap_reduced(xkqs_int[1, ikq] - k1, ng1)
+            h2 = _wrap_reduced(xkqs_int[2, ikq] - k2, ng2)
+            h3 = _wrap_reduced(xkqs_int[3, ikq] - k3, ng3)
+            hash = (h1 * ng2 + h2) * ng3 + h3
+            iq = _ik_from_hash(qpts, hash)
+            # 0 = miss on either index.
+            (iq < 1 || iq > qpts.n) && throw(ArgumentError("kq - k = q point not found in precomputed qpts"))
+            iqs[j, kloc] = iq
+        end
+    end
+    iqs
+end
+
 function _loop_eph_over_k_and_kq_gpu(
         model       :: Model{FT},
         kpts, qpts, kqpts,
@@ -708,30 +759,33 @@ function _loop_eph_over_k_and_kq_gpu(
     # convention multiply and keeps a padded (never-read) slice of ep_ekpR_all meaningful.
     fill!(P_k, 1)
 
-    iqs_batch  = Vector{Int}(undef, nq_batch_max)
-    iqs_batch_dev    = similar(epmat_dev.op_r, Int, nq_batch_max)
+    # `iq` index staging, one k-STRIP wide (see `prepare_iqs!`). Filled to 1 so that the rows past a
+    # partial q-tile's width — copied along with the rest, never read by the gather — are a valid
+    # index rather than garbage.
+    iqs_strip     = fill(1, nq_batch_max, nk_b)
+    iqs_strip_dev = similar(epmat_dev.op_r, Int, nq_batch_max, nk_b)
 
     # Integer grid-coord hash for iq, replacing the per-(k,q) float normalize + `_hash_xk`:
-    #   hc_i = mod(xkqs_int[i,ikq] - xks_int[i,ik], ng_i),  hash = (hc1*ng2 + hc2)*ng3 + hc3,
+    #   hc_i = fold(xkqs_int[i,ikq] - xks_int[i,ik], ng_i),  hash = (hc1*ng2 + hc2)*ng3 + hc3,
     # reproducing `_hash_xk` bit-identically with no Float64 in the hot loop. Requires every k and
     # k+q to lie exactly on the q-grid (ngrid a multiple of both meshes) — guaranteed by precompute_ph,
     # asserted above. Only `iq` is needed: the q-VECTOR no longer enters the interpolation (the
     # kR->kq phase is built from x_{k+q}), so this loop gathers phonon data by index only.
-    ng1, ng2, ng3 = qpts.ngrid
+    # Both coordinate lists are reduced into `0:ng-1` here, once, so the per-pair fold is
+    # `_wrap_reduced` (a compare-and-add) instead of `mod` (a runtime integer division). The q-grid
+    # shift is subtracted on the k+q side only: q = x_{k+q} - x_k - shift, and folding it into one
+    # operand keeps it out of the pair loop.
     shq = qpts.shift
     xkqs_int = Matrix{Int}(undef, 3, nkq)
     xks_int  = Matrix{Int}(undef, 3, nk)
-    for ikq in 1:nkq, d in 1:3
-        xkqs_int[d, ikq] = round(Int, (kqpts.vectors[ikq][d] - shq[d]) * qpts.ngrid[d])
+    for ikq in 1:nkq
+        xkqs_int[:, ikq] .= _grid_coords_reduced(kqpts.vectors[ikq], qpts.ngrid, shq)
     end
-    for ik in 1:nk, d in 1:3
-        xks_int[d, ik] = round(Int, kpts.vectors[ik][d] * qpts.ngrid[d])
+    for ik in 1:nk
+        xks_int[:, ik] .= _grid_coords_reduced(kpts.vectors[ik], qpts.ngrid, zero(Vec3{FT}))
     end
 
-    # The payload's k+q index list is the plain range `qstart:qend` of the current q-tile, so hold
-    # 1:nkq on the device once and slice it instead of refilling and re-uploading it per (k, tile).
-    ikqs_all_dev = similar(epmat_dev.op_r, Int, nkq)
-    copyto!(ikqs_all_dev, collect(1:nkq))
+    iq_builder = SerialHostIqBuilder(qpts, xkqs_int, xks_int, iqs_strip)
 
     ωq_dev    = similar(epmat_dev.op_r, FT, nmodes, nq_batch_max)
     g2_dev    = similar(epmat_dev.op_r, FT, nw, nbandk_max, nmodes, nq_batch_max)
@@ -783,9 +837,11 @@ function _loop_eph_over_k_and_kq_gpu(
             # the reason the q-tile loop sits outside the k loop. In the k+q convention it reads
             # x_{k+q} directly, so it is a contiguous slice of the fixed k+q list.
             @views fourier_phase!(P_kq[:, rng_q], irvecp_mat, xkq_dev[:, qstart:qend])
-            # k+q rotations and k+q indices: contiguous slices of prebuilt device stacks (no copy).
+            # k+q rotations: a contiguous slice of the prebuilt device stack (no copy). The payload's
+            # k+q index list is the plain range of this tile — `isbits`, so it rides in the kernel
+            # launch parameters instead of costing a device buffer and a global load per thread.
             ukqs_used = view(ukqs_all_dev, :, :, qstart:qend)
-            ikqs_used = view(ikqs_all_dev, qstart:qend)
+            ikqs_used = qstart:qend
 
             # Strip-mine the k loop for the kR->kq Fourier: one tall GEMM stacks `nks` outer-k
             # into a single left operand, so the k-invariant phase tile is read once per strip
@@ -802,41 +858,31 @@ function _loop_eph_over_k_and_kq_gpu(
                 eph_kR_to_kq_fourier!(view(kRkq_ws.g, 1:ndata_ekpR*nks, rng_q),
                     view(ep_ekpR_2d, rows, :), view(P_kq, :, rng_q))
 
+                # Build this (strip, tile)'s q-index lists; the phonon eigenvectors `u` and
+                # frequencies `e` are gathered on the device by iq below. One entry and one stream
+                # drain for the whole strip.
+                prepare_iqs!(iq_builder, iqs_strip_dev,
+                    iks_batch[sstart:(sstart + nks - 1)], 1, qstart, nq_batch)
+
                 for ik_ind in sstart:(sstart + nks - 1)
                     ik = iks_batch[ik_ind]
-                    # Build this (k, tile)'s q-index list (host-side integers only); the phonon
-                    # eigenvectors `u` and frequencies `e` are gathered on the device by iq below.
-                    for j in 1:nq_batch
-                        ikq = qstart + j - 1
-                        # Integer grid-coord hash for iq (no Float64 normalize/_hash_xk per pair).
-                        h1 = mod(xkqs_int[1, ikq] - xks_int[1, ik], ng1)
-                        h2 = mod(xkqs_int[2, ikq] - xks_int[2, ik], ng2)
-                        h3 = mod(xkqs_int[3, ikq] - xks_int[3, ik], ng3)
-                        hash = (h1 * ng2 + h2) * ng3 + h3
-                        iq = _ik_from_hash(qpts, hash)
-                        # 0 = miss on either index.
-                        (iq < 1 || iq > qpts.n) && throw(ArgumentError("kq - k = q point not found in precomputed qpts"))
-                        iqs_batch[j] = iq
-                    end
+                    kloc = ik_ind - sstart + 1
 
                     # Gather this tile's phonon eigenvectors/frequencies on the device by iq
                     # (uphs_dev[:,:,j] = uph_all_dev[:,:,iq[j]]); ωq gathered here too so the fused kernel
                     # can fold g2 = |ep|²/(2ω) in the same pass. Everything below runs at width nq_batch
-                    # via views into the nq_batch_max-sized buffers, so there is no padded tail.
-                    # H2D copy of just the first nq_batch indices (5-arg contiguous copy — copying a host↔
-                    # device SubArray view instead would fall back to scalar indexing); the device gather
-                    # then reads only `view(iqs_batch_dev, rng_q)`, so the untouched tail is never used.
+                    # via views into the nq_batch_max-sized buffers, so there is no padded tail. This k's
+                    # indices are column `kloc` of the strip staging — contiguous, so no strided read.
                     # `@inbounds`: bounds-checking a device INDEX ARRAY costs a Bool map+reduce kernel and
-                    # a D2H round trip of the result per (k, tile); `iq` is already validated on the host
-                    # (the guard above), so the device-side re-check is pure overhead.
-                    copyto!(iqs_batch_dev, 1, iqs_batch, 1, nq_batch)
-                    @inbounds @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, view(iqs_batch_dev, rng_q)]
-                    @inbounds @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, view(iqs_batch_dev, rng_q)]
+                    # a D2H round trip of the result per (k, tile); `iq` is already validated where it is
+                    # built (the guard in `_fill_iqs_serial!`), so the device-side re-check is pure overhead.
+                    iqs_used = view(iqs_strip_dev, rng_q, kloc)
+                    @inbounds @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, iqs_used]
+                    @inbounds @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, iqs_used]
 
                     # Gauge rotations for this k, folding g2 = |ep|²/(2ω) into the same fused kernel
                     # pass. This k's Fourier output is the strip's `kloc`-th slice, strided in q when
                     # nk_b > 1 - which only the fused kernel reads, hence the `_krkq_strip_width` gate.
-                    kloc = ik_ind - sstart + 1
                     eph_apply_rotations!(view(epkq_dev, :, :, :, rng_q),
                         _strip_g_slice(kRkq_ws.g, g_strip5, kloc, rng_q), ukqs_used,
                         view(uphs_dev, :, :, rng_q), view(kRkq_ws.tmp, :, :, rng_q);

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -679,8 +679,9 @@ function _loop_eph_over_k_and_kq_gpu(
     irvecp_mat = _irvec_matrix(model.epmat.irvec_next, epmat_dev, FT)
     P_k  = similar(epmat_dev.op_r, Complex{FT}, nr_ep, nk_batch_max)
     P_kq = similar(epmat_dev.op_r, Complex{FT}, nr_ep, nq_batch_max)
-    # A partial k-batch leaves P_k's padded tail columns unwritten; 1 keeps the padded (discarded)
-    # slices of ep_ekpR_all finite.
+    # Defensive: only columns 1:nk_batch are rewritten per batch. `nk_batch_max = min(…, nk)` makes
+    # the first batch full, so the tail is in practice always written, but 1 is the identity of the
+    # convention multiply and keeps a padded (never-read) slice of ep_ekpR_all meaningful.
     fill!(P_k, 1)
 
     iqs_batch  = Vector{Int}(undef, nq_batch_max)

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -478,15 +478,12 @@ end
 #  GPU calculator loop (see README_GPU.md).
 #
 #  This mirrors `_loop_eph_over_k_and_kq` but moves the e-ph Wannier->Bloch interpolation
-#  onto the device using the batched drivers from `wannier_to_bloch_batched.jl`. No CUDA code lives
-#  in the base package: the loop only calls `to_device` and the generic batched drivers, and the
-#  device methods are provided by the CUDA extension. That is not the same as running on any
-#  backend — at `nk_b > 1` the per-k `g` slice handed to `eph_apply_rotations!` is strided in q, and
-#  only the extension's fused kernel reads such an operand (the generic two-GEMM method asserts a
-#  dense `g`). The loop has one call site, inside the `use_gpu` branch, so a CPU backend never
-#  reaches that assert. It is a separate function from the CPU `_loop_eph_over_k_and_kq` because its
-#  control flow — batched over k-batches and q-batches with device staging — differs from the
-#  per-(k,q) CPU loop.
+#  onto the device using the batched drivers from `wannier_to_bloch_batched.jl`. The code here is
+#  backend-generic: it only calls `to_device` and the generic batched drivers, so no CUDA
+#  code lives in the base package (the device methods are provided by the CUDA extension). It
+#  is a separate function from the CPU `_loop_eph_over_k_and_kq` because its control flow —
+#  batched over k-batches and q-batches with device staging — differs from the per-(k,q) CPU loop,
+#  not because it holds any device-specific code.
 #
 #  Supported (all handled upstream in the shared `_setup`, so this loop itself is agnostic to them):
 #    * energy windows (window_k / window_kq): the k side carries only its in-window bands, the
@@ -504,18 +501,12 @@ end
 #  Buffer reuse: device buffers are allocated once before the k loop and reused for every
 #  (k, q), so the loop itself allocates almost nothing.
 #
-#  Loop shape: `k-batch -> q-tile -> k-strip -> k -> q(device)`. The q-tile loop sits OUTSIDE the
-#  per-k loop because the kR->kq Fourier phase is built from the fixed k+q list (the k+q convention,
-#  see `get_eph_RR_to_kR_batched!`) and is therefore the same for every k of the batch: one built
-#  tile is reused `nk_batch` times. Consequence for calculators: a k's work no longer finishes at a
+#  Loop shape: `k-batch -> q-tile -> k -> q(device)`. The q-tile loop sits OUTSIDE the per-k loop
+#  because the kR->kq Fourier phase is built from the fixed k+q list (the k+q convention, see
+#  `get_eph_RR_to_kR_batched!`) and is therefore the same for every k of the batch: one built tile
+#  is reused `nk_batch` times. Consequence for calculators: a k's work no longer finishes at a
 #  single point in the loop, so this loop fires only the `OuterIterationBatch` bracket — there is
 #  no per-k `OuterIteration` bracket in the batched outer-k loop.
-#  The k-strip level runs the kR->kq Fourier for `nk_b` k at once (`_krkq_strip_width`), so that
-#  phase tile is also READ once per strip rather than once per k and the GEMM's M dimension fills a
-#  cuBLAS tile. It helps only where `ndata = nw·nbandk_max·nmodes` is small — a narrow-window,
-#  small-`nw` regime; a full-band large-`nw` run gets `nk_b = 1` and the loop as it was. k are
-#  visited in the same order and everything below the GEMM is per-k, so the payload stream and the
-#  bracket order are unchanged.
 # ---- per-(k, q-tile) `iq` index build ------------------------------------------------------------
 #
 # Fill `iqs[1:nq]` with the index into `qpts` of `x_{k+q} - x_k` for outer k `ik` and every k+q of
@@ -626,14 +617,6 @@ function _loop_eph_over_k_and_kq_gpu(
     ndata_ekpR = nw * nbandk_max * nmodes
     nr_ep = length(model.epmat.irvec_next)
 
-    # ----- kR->kq GEMM strip width -----
-    # `nk_b` consecutive outer-k are stacked into one tall kR->kq GEMM, so the k-invariant phase tile
-    # is read nk_b times less and the GEMM's M dimension fills a cuBLAS tile. Shape-derived; it is 1
-    # (no strip, nothing changes) at large ndata or when the fused rotation kernel is not used. The
-    # M-target rule bounds the extra per-q staging (a wider `kRkq_ws.g`) at
-    # `16·(_KRKQ_GEMM_M_TARGET - ndata)` bytes for any model, so the q-tile below cannot collapse.
-    nk_b = _krkq_strip_width(; nw, nbandk_max, nmodes, nk_batch_max)
-
     # ----- memory-adaptive q-batch size (§7) -----
     # Every per-q staging buffer scales with the q-batch width, so cap it at what free device memory
     # allows (30% headroom for the batched drivers' recycled temporaries). The whole-run + per-k-batch
@@ -643,13 +626,12 @@ function _loop_eph_over_k_and_kq_gpu(
     # (Int, or nkq when nothing) stays a hard cap.
     per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
         nq_grid = qpts.n, nk_batch_max, calculators,
-        ndata_epmat = epmat_dev.ndata, nr_epmat = epmat_dev.nr, nk_b, FT)
+        ndata_epmat = epmat_dev.ndata, nr_epmat = epmat_dev.nr, FT)
     nq_batch_cap = nq_batch_user === nothing ? nkq : min(nq_batch_user, nkq)
     nq_batch_max = plan_batch(backend, per_point, committed, nq_batch_cap; what = "outer-k")
     if verbosity > 0 && mpi_isroot()
         @info "GPU outer-k device memory: committed = $(round(committed / 1e9, digits = 2)) GB, " *
-              "$(round(per_point / 1e3, digits = 1)) kB/q; q-batch size = $nq_batch_max, " *
-              "kR->kq strip nk_b = $nk_b"
+              "$(round(per_point / 1e3, digits = 1)) kB/q; q-batch size = $nq_batch_max"
     end
 
     # ----- persistent workspace (allocated once, reused across all (k, q)) -----
@@ -657,25 +639,20 @@ function _loop_eph_over_k_and_kq_gpu(
     # batch-sliced views), so the batched drivers' reshape/cuBLAS calls stay on dense arrays.
 
     # RR->kR over a batch of `nk_batch_max` outer-k at once: one batched kernel per batch instead of one
-    # launch-bound single-k call per k. `ep_ekpR_all` holds g(k, R_ep) for the whole batch, k in the
-    # MIDDLE axis so that a strip of `nk_b` consecutive k is the plain row range
-    # `ep_ekpR_2d[ndata*(s-1)+1 : ndata*(s-1+nk_b), :]` — an `lda` view, no copy.
+    # launch-bound single-k call per k. `ep_ekpR_all` holds g(k, R_ep) for the whole batch; the inner
+    # kR->kq driver reads each k's slice `ep_ekpR_all[:, :, ik_ind]` directly.
     uks_dev     = similar(epmat_dev.op_r, Complex{FT}, nw, nbandk_max, nk_batch_max)
     uks_host    = Array{Complex{FT}}(undef, nw, nbandk_max, nk_batch_max)
-    ep_ekpR_all = similar(epmat_dev.op_r, Complex{FT}, ndata_ekpR, nk_batch_max, nr_ep)
-    ep_ekpR_2d  = reshape(ep_ekpR_all, ndata_ekpR * nk_batch_max, nr_ep)
+    ep_ekpR_all = similar(epmat_dev.op_r, Complex{FT}, ndata_ekpR, nr_ep, nk_batch_max)
     ks_batch     = Vector{Vec3{FT}}(undef, nk_batch_max)
 
     uphs_dev = similar(epmat_dev.op_r, Complex{FT}, nmodes, nmodes, nq_batch_max)
     epkq_dev = similar(epmat_dev.op_r, Complex{FT}, nw, nbandk_max, nmodes, nq_batch_max)
 
-    # In-place scratch for the kR->kq step (g / tmp), reused across all (k, q) so nothing is
-    # allocated per call. Sized for the max batch width `nq_batch_max`; only the first `nq_batch`
-    # columns are used for a partial final batch. `g` holds a whole strip of `nk_b` k; `g_strip5`
-    # is its (nw, nbandk, nmodes, nk_b, nq) view, from which each k takes a q-strided 4-D slice.
-    # Only at `nk_b > 1`: see `_strip_g_slice` for why `nk_b = 1` slices the 2-D buffer instead.
-    kRkq_ws = KRtoKQWorkspace(epmat_dev.op_r, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max; nk_b)
-    g_strip5 = reshape(kRkq_ws.g, nw, nbandk_max, nmodes, nk_b, nq_batch_max)
+    # In-place scratch for the per-k kR->kq driver (g / tmp), reused across all (k, q) so the
+    # driver allocates nothing per call. Sized for the max batch width `nq_batch_max`; the driver
+    # uses the first `nq_batch` columns for a partial final batch.
+    kRkq_ws = KRtoKQWorkspace(epmat_dev.op_r, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max)
 
     # Collect the k+q electron eigenvectors on the host and copy to the device once (they do not
     # depend on the outer k), reused across all k. Each q-batch reads a contiguous slice directly.
@@ -732,8 +709,8 @@ function _loop_eph_over_k_and_kq_gpu(
     P_k  = similar(epmat_dev.op_r, Complex{FT}, nr_ep, nk_batch_max)
     P_kq = similar(epmat_dev.op_r, Complex{FT}, nr_ep, nq_batch_max)
     # Defensive: only columns 1:nk_batch are rewritten per batch, so a partial final batch leaves the
-    # tail columns holding whatever the previous batch wrote. Nothing reads them — the strip loop runs
-    # `1:nk_b:nk_batch` — and 1 is the identity of the convention multiply, so the padded (never-read)
+    # tail columns holding whatever the previous batch wrote. Nothing reads them — the k loop runs
+    # `1:nk_batch` — and 1 is the identity of the convention multiply, so the padded (never-read)
     # slice of ep_ekpR_all stays meaningful whether or not it has been written yet.
     fill!(P_k, 1)
 
@@ -817,59 +794,39 @@ function _loop_eph_over_k_and_kq_gpu(
             ukqs_used = view(ukqs_all_dev, :, :, qstart:qend)
             ikqs_used = qstart:qend
 
-            # Strip-mine the k loop for the kR->kq Fourier: one tall GEMM stacks `nks` outer-k
-            # into a single left operand, so the k-invariant phase tile is read once per strip
-            # instead of once per k. The left operand is the strip's row range of `ep_ekpR_2d`
-            # (unit stride down the rows, `lda = ndata_ekpR*nk_batch_max` across) - a plain view,
-            # no copy. A partial final strip just uses a shorter row range: `M` is a runtime GEMM
-            # dimension, so nothing needs padding. Everything below the GEMM stays strictly per-k.
-            # NOT an invitation to overlap the k of a strip: `g` is the only strip-wide buffer.
-            # `epkq_dev`, `g2_dev`, `uphs_dev`, `ωq_dev` and `kRkq_ws.tmp` are all single-k and are
-            # overwritten by each k below, correct only because the k are serialized on one stream.
-            for sstart in 1:nk_b:nk_batch
-                nks  = min(nk_b, nk_batch - sstart + 1)
-                rows = ndata_ekpR * (sstart - 1) + 1 : ndata_ekpR * (sstart - 1 + nks)
-                eph_kR_to_kq_fourier!(view(kRkq_ws.g, 1:ndata_ekpR*nks, rng_q),
-                    view(ep_ekpR_2d, rows, :), view(P_kq, :, rng_q))
+            for (ik_ind, ik) in enumerate(iks_batch)
+                # Build this (k, tile)'s q-index list (host-side integers only), then gather this
+                # tile's phonon eigenvectors/frequencies on the device by iq
+                # (uphs_dev[:,:,j] = uph_all_dev[:,:,iq[j]]); ωq gathered here too so the fused kernel
+                # can fold g2 = |ep|²/(2ω) in the same pass. Everything below runs at width nq_batch
+                # via views into the nq_batch_max-sized buffers, so there is no padded tail.
+                # H2D copy of just the first nq_batch indices (5-arg contiguous copy — copying a host↔
+                # device SubArray view instead would fall back to scalar indexing); the device gather
+                # then reads only `view(iqs_batch_dev, rng_q)`, so the untouched tail is never used.
+                # `@inbounds`: bounds-checking a device INDEX ARRAY costs a Bool map+reduce kernel and
+                # a D2H round trip of the result per (k, tile); `iq` is already validated on the host
+                # (the guard in `_fill_iqs!`), so the device-side re-check is pure overhead.
+                _fill_iqs!(iqs_batch, qpts, xkqs_int, xks_int, ik, qstart, nq_batch)
+                copyto!(iqs_batch_dev, 1, iqs_batch, 1, nq_batch)
+                iqs_used = view(iqs_batch_dev, rng_q)
+                @inbounds @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, iqs_used]
+                @inbounds @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, iqs_used]
 
-                for ik_ind in sstart:(sstart + nks - 1)
-                    ik = iks_batch[ik_ind]
-                    kloc = ik_ind - sstart + 1
+                # One batched Wannier->Bloch over this tile's q: ep_kq(q) (nw, nbandk_max, nmodes),
+                # folding g2 = |ep|²/(2ω) into the same fused kernel pass.
+                get_eph_kR_to_kq_batched!(view(epkq_dev, :, :, :, rng_q),
+                    view(ep_ekpR_all, :, :, ik_ind), view(P_kq, :, rng_q),
+                    view(uphs_dev, :, :, rng_q), ukqs_used; ws = kRkq_ws,
+                    g2_out = view(g2_dev, :, :, :, rng_q), ωq = view(ωq_dev, :, rng_q))
 
-                    # Build this (k, tile)'s q-index list (host-side integers only), then gather this
-                    # tile's phonon eigenvectors/frequencies on the device by iq
-                    # (uphs_dev[:,:,j] = uph_all_dev[:,:,iq[j]]); ωq gathered here too so the fused kernel
-                    # can fold g2 = |ep|²/(2ω) in the same pass. Everything below runs at width nq_batch
-                    # via views into the nq_batch_max-sized buffers, so there is no padded tail.
-                    # H2D copy of just the first nq_batch indices (5-arg contiguous copy — copying a host↔
-                    # device SubArray view instead would fall back to scalar indexing); the device gather
-                    # then reads only `view(iqs_batch_dev, rng_q)`, so the untouched tail is never used.
-                    # `@inbounds`: bounds-checking a device INDEX ARRAY costs a Bool map+reduce kernel and
-                    # a D2H round trip of the result per (k, tile); `iq` is already validated on the host
-                    # (the guard in `_fill_iqs!`), so the device-side re-check is pure overhead.
-                    _fill_iqs!(iqs_batch, qpts, xkqs_int, xks_int, ik, qstart, nq_batch)
-                    copyto!(iqs_batch_dev, 1, iqs_batch, 1, nq_batch)
-                    iqs_used = view(iqs_batch_dev, rng_q)
-                    @inbounds @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, iqs_used]
-                    @inbounds @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, iqs_used]
-
-                    # Gauge rotations for this k, folding g2 = |ep|²/(2ω) into the same fused kernel
-                    # pass. This k's Fourier output is the strip's `kloc`-th slice, strided in q when
-                    # nk_b > 1 - which only the fused kernel reads, hence the `_krkq_strip_width` gate.
-                    eph_apply_rotations!(view(epkq_dev, :, :, :, rng_q),
-                        _strip_g_slice(kRkq_ws.g, g_strip5, kloc, rng_q), ukqs_used,
-                        view(uphs_dev, :, :, rng_q), view(kRkq_ws.tmp, :, :, rng_q);
-                        g2_out = view(g2_dev, :, :, :, rng_q), ωq = view(ωq_dev, :, rng_q))
-
-                    # Hand the tile's e-ph matrix (still on the device) to each calculator, which forms
-                    # g2 / scatters it on the device; no D2H of the e-ph matrix here.
-                    ctx_k = LoopContext(backend, BatchedMode(), ik, iks_batch, nk_batch_max)
-                    payload = EPDataQBatched(
-                        view(epkq_dev, :, :, :, rng_q), view(g2_dev, :, :, :, rng_q),
-                        view(ωq_dev, :, rng_q), ik, ikqs_used, ibandk_offsets[ik])
-                    foreach(c -> run_calculator!(c, payload, ctx_k), calculators)
-                end # ik within strip
-            end # strip
+                # Hand the tile's e-ph matrix (still on the device) to each calculator, which forms
+                # g2 / scatters it on the device; no D2H of the e-ph matrix here.
+                ctx_k = LoopContext(backend, BatchedMode(), ik, iks_batch, nk_batch_max)
+                payload = EPDataQBatched(
+                    view(epkq_dev, :, :, :, rng_q), view(g2_dev, :, :, :, rng_q),
+                    view(ωq_dev, :, rng_q), ik, ikqs_used, ibandk_offsets[ik])
+                foreach(c -> run_calculator!(c, payload, ctx_k), calculators)
+            end # ik
 
             qstart = qend + 1
         end # q tile

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -652,12 +652,6 @@ function _loop_eph_over_k_and_kq_gpu(
     iqs_batch  = Vector{Int}(undef, nq_batch_max)
     iqs_batch_dev    = similar(epmat_dev.op_r, Int, nq_batch_max)
 
-    # q-index lookup without an O(prod(ngrid)) dense table (ngrid can be ~1e6/dim with few points).
-    # `combine_kpoint_grids` sorts `qpts` by hash, so a FULL grid has iq == hash+1 (pure arithmetic);
-    # otherwise fall back to the O(n) hash Dict `GridKpoints` carries. Decide once:
-    qpts_is_full = qpts.n == prod(qpts.ngrid) &&
-        all(_hash_xk(qpts.vectors[iq], qpts) == iq - 1 for iq in 1:qpts.n)
-
     # Integer grid-coord hash for iq, replacing the per-(k,q) float normalize + `_hash_xk`:
     #   hc_i = mod(xkqs_int[i,ikq] - xks_int[i,ik], ng_i),  hash = (hc1*ng2 + hc2)*ng3 + hc3,
     # reproducing `_hash_xk` bit-identically with no Float64 in the hot loop. Requires every k and
@@ -738,9 +732,8 @@ function _loop_eph_over_k_and_kq_gpu(
                 h2 = mod(xkqs_int[2, ikq] - xks_int[2, ik], ng2)
                 h3 = mod(xkqs_int[3, ikq] - xks_int[3, ik], ng3)
                 hash = (h1 * ng2 + h2) * ng3 + h3
-                # Full sorted grid → iq = hash+1 (no table); else O(n) Dict (no ngrid³ array).
-                iq = qpts_is_full ? hash + 1 : get(qpts._xk_hash_to_ik, hash, 0)
-                # Guard both paths: Dict miss → iq==0; full-grid fast path → iq>qpts.n if off-grid.
+                iq = _ik_from_hash(qpts, hash)
+                # 0 = miss on either index.
                 (iq < 1 || iq > qpts.n) && throw(ArgumentError("kq - k = q point not found in precomputed qpts"))
                 # q-vector from the O(n) qpts.vectors (a cached gather — cheaper than recomputing it
                 # with 3 float divisions; qpts.vectors is O(n), never ngrid³). ≡ (xkq-xk) mod G.

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -691,7 +691,9 @@ function _loop_eph_over_k_and_kq_gpu(
     # Negated once here rather than conjugating the phase tile every batch: the convention needs
     # conj(exp(2πi R_p·x_k)) = exp(2πi R_p·(−x_k)), and the two are bitwise identical (FP negation is
     # exact, and `cispi` is exactly symmetric). This is the only consumer of the k coordinates.
-    mxk_dev = -_kpoints_to_device_matrix(backend, kpts)
+    # Out-of-place on purpose: on `CPUBackend` `_kpoints_to_device_matrix` returns a view onto
+    # `kpts.vectors`, so negating in place would corrupt the k-points.
+    mxk_dev = -1 .* _kpoints_to_device_matrix(backend, kpts)
     xkq_dev = _kpoints_to_device_matrix(backend, kqpts)
 
     # The two Fourier phase matrices of the k+q convention (see `get_eph_RR_to_kR_batched!`):

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -498,15 +498,17 @@ end
 #    * el_kq_from_unfolding (directly-computed k+q only)
 #    * energy_conservation other than (:None, 0.0)
 #
+#  Calculator brackets: only `OuterIterationBatch` fires, never `OuterIteration` — a k's work is
+#  spread over the q-tiles, so it does not finish at a single point in the loop.
+#
 #  Buffer reuse: device buffers are allocated once before the k loop and reused for every
 #  (k, q), so the loop itself allocates almost nothing.
 #
 #  Loop shape: `k-batch -> q-tile -> k -> q(device)`. The q-tile loop sits OUTSIDE the per-k loop
 #  because the kR->kq Fourier phase is built from the fixed k+q list (the k+q convention, see
 #  `get_eph_RR_to_kR_batched!`) and is therefore the same for every k of the batch: one built tile
-#  is reused `nk_batch` times. Consequence for calculators: a k's work no longer finishes at a
-#  single point in the loop, so this loop fires only the `OuterIterationBatch` bracket — there is
-#  no per-k `OuterIteration` bracket in the batched outer-k loop.
+#  is reused `nk_batch` times.
+
 # ---- per-(k, q-tile) `iq` index build ------------------------------------------------------------
 #
 # Fill `iqs[1:nq]` with the index into `qpts` of `x_{k+q} - x_k` for outer k `ik` and every k+q of
@@ -637,26 +639,28 @@ function _loop_eph_over_k_and_kq_gpu(
     # ----- persistent workspace (allocated once, reused across all (k, q)) -----
     # All device staging is sized to the full batch and used as plain CuArrays (not
     # batch-sliced views), so the batched drivers' reshape/cuBLAS calls stay on dense arrays.
+    # `proto` is the `similar` template every device buffer below is allocated from.
+    proto = epmat_dev.op_r
 
     # RR->kR over a batch of `nk_batch_max` outer-k at once: one batched kernel per batch instead of one
     # launch-bound single-k call per k. `ep_ekpR_all` holds g(k, R_ep) for the whole batch; the inner
     # kR->kq driver reads each k's slice `ep_ekpR_all[:, :, ik_ind]` directly.
-    uks_dev     = similar(epmat_dev.op_r, Complex{FT}, nw, nbandk_max, nk_batch_max)
+    uks_dev     = similar(proto, Complex{FT}, nw, nbandk_max, nk_batch_max)
     uks_host    = Array{Complex{FT}}(undef, nw, nbandk_max, nk_batch_max)
-    ep_ekpR_all = similar(epmat_dev.op_r, Complex{FT}, ndata_ekpR, nr_ep, nk_batch_max)
+    ep_ekpR_all = similar(proto, Complex{FT}, ndata_ekpR, nr_ep, nk_batch_max)
     ks_batch     = Vector{Vec3{FT}}(undef, nk_batch_max)
 
-    uphs_dev = similar(epmat_dev.op_r, Complex{FT}, nmodes, nmodes, nq_batch_max)
-    epkq_dev = similar(epmat_dev.op_r, Complex{FT}, nw, nbandk_max, nmodes, nq_batch_max)
+    uphs_dev = similar(proto, Complex{FT}, nmodes, nmodes, nq_batch_max)
+    epkq_dev = similar(proto, Complex{FT}, nw, nbandk_max, nmodes, nq_batch_max)
 
     # In-place scratch for the per-k kR->kq driver (g / tmp), reused across all (k, q) so the
     # driver allocates nothing per call. Sized for the max batch width `nq_batch_max`; the driver
     # uses the first `nq_batch` columns for a partial final batch.
-    kRkq_ws = KRtoKQWorkspace(epmat_dev.op_r, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max)
+    kRkq_ws = KRtoKQWorkspace(proto, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max)
 
     # Collect the k+q electron eigenvectors on the host and copy to the device once (they do not
     # depend on the outer k), reused across all k. Each q-batch reads a contiguous slice directly.
-    ukqs_all_dev = similar(epmat_dev.op_r, Complex{FT}, nw, nw, nkq)
+    ukqs_all_dev = similar(proto, Complex{FT}, nw, nw, nkq)
     let ukqs_all_host = Array{Complex{FT}}(undef, nw, nw, nkq)
         for ikq in 1:nkq
             @views ukqs_all_host[:, :, ikq] .= el_kq_save[ikq].u_full
@@ -670,8 +674,8 @@ function _loop_eph_over_k_and_kq_gpu(
     # `_compute_phonon_states_gpu!` built them on the device before scattering them into per-q
     # `PhononState`s — so this gather + H2D undoes a D2H. Have the setup hand `use_gpu` the device
     # stacks directly and drop this block; see the TODO at `_scatter_phonon_states!`.
-    uph_all_dev = similar(epmat_dev.op_r, Complex{FT}, nmodes, nmodes, qpts.n)
-    ωq_all_dev  = similar(epmat_dev.op_r, FT, nmodes, qpts.n)
+    uph_all_dev = similar(proto, Complex{FT}, nmodes, nmodes, qpts.n)
+    ωq_all_dev  = similar(proto, FT, nmodes, qpts.n)
     let uph_all_host = Array{Complex{FT}}(undef, nmodes, nmodes, qpts.n),
         ωq_all_host  = Array{FT}(undef, nmodes, qpts.n)
         for iq in 1:qpts.n
@@ -684,18 +688,8 @@ function _loop_eph_over_k_and_kq_gpu(
 
     # Grid coordinates as (3 × n) real device matrices, uploaded once. Both phase builds below read
     # them directly, so nothing on the phase path is staged on the host or copied H2D inside the loop.
-    xk_dev  = similar(epmat_dev.op_r, FT, 3, nk)
-    xkq_dev = similar(epmat_dev.op_r, FT, 3, nkq)
-    let xk_host = Matrix{FT}(undef, 3, nk), xkq_host = Matrix{FT}(undef, 3, nkq)
-        for ik in 1:nk, d in 1:3
-            xk_host[d, ik] = kpts.vectors[ik][d]
-        end
-        for ikq in 1:nkq, d in 1:3
-            xkq_host[d, ikq] = kqpts.vectors[ikq][d]
-        end
-        copyto!(xk_dev, xk_host)
-        copyto!(xkq_dev, xkq_host)
-    end
+    xk_dev  = _kpoint_vectors_to_device(backend, kpts)
+    xkq_dev = _kpoint_vectors_to_device(backend, kqpts)
 
     # The two Fourier phase matrices of the k+q convention (see `get_eph_RR_to_kR_batched!`):
     #   P_k [ip, k] = exp(2πi R_p · x_k)      — conjugated into g(k, R_ep) once per outer-k batch
@@ -705,9 +699,9 @@ function _loop_eph_over_k_and_kq_gpu(
     # Not a `TiledDeviceOutput`: that tiles the OUTPUT side over the outer-state axis and owns a
     # host mirror plus a per-batch D2H, whereas P_kq is an input-side, q-indexed,
     # write-once-read-many device buffer with no host side and no D2H at all.
-    irvecp_mat = _irvec_matrix(model.epmat.irvec_next, epmat_dev, FT)
-    P_k  = similar(epmat_dev.op_r, Complex{FT}, nr_ep, nk_batch_max)
-    P_kq = similar(epmat_dev.op_r, Complex{FT}, nr_ep, nq_batch_max)
+    irvecp_mat = _irvec_matrix_to_device(model.epmat.irvec_next, epmat_dev, FT)
+    P_k  = similar(proto, Complex{FT}, nr_ep, nk_batch_max)
+    P_kq = similar(proto, Complex{FT}, nr_ep, nq_batch_max)
     # Defensive: only columns 1:nk_batch are rewritten per batch, so a partial final batch leaves the
     # tail columns holding whatever the previous batch wrote. Nothing reads them — the k loop runs
     # `1:nk_batch` — and 1 is the identity of the convention multiply, so the padded (never-read)
@@ -716,7 +710,7 @@ function _loop_eph_over_k_and_kq_gpu(
 
     # `iq` index staging for one (k, q-tile).
     iqs_batch     = Vector{Int}(undef, nq_batch_max)
-    iqs_batch_dev = similar(epmat_dev.op_r, Int, nq_batch_max)
+    iqs_batch_dev = similar(proto, Int, nq_batch_max)
 
     # Integer grid-coord hash for iq, replacing the per-(k,q) float normalize + `_hash_xk`:
     #   hc_i = fold(xkqs_int[i,ikq] - xks_int[i,ik], ng_i),  hash = (hc1*ng2 + hc2)*ng3 + hc3,
@@ -738,8 +732,8 @@ function _loop_eph_over_k_and_kq_gpu(
         xks_int[:, ik] .= _grid_coords_reduced(kpts.vectors[ik], qpts.ngrid, zero(Vec3{FT}))
     end
 
-    ωq_dev    = similar(epmat_dev.op_r, FT, nmodes, nq_batch_max)
-    g2_dev    = similar(epmat_dev.op_r, FT, nw, nbandk_max, nmodes, nq_batch_max)
+    ωq_dev    = similar(proto, FT, nmodes, nq_batch_max)
+    g2_dev    = similar(proto, FT, nw, nbandk_max, nmodes, nq_batch_max)
 
     for kstart in 1:nk_batch_max:nk
         kend = min(kstart + nk_batch_max - 1, nk)
@@ -771,7 +765,7 @@ function _loop_eph_over_k_and_kq_gpu(
         # k+q convention (multiplied by conj(P_k)) so the kR->kq phase below is k-independent.
         @views fourier_phase!(P_k[:, 1:nk_batch], irvecp_mat, xk_dev[:, iks_batch])
         get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat, ks_batch, uks_dev;
-            kq_convention_phase = P_k)
+            additional_phase = P_k)
 
         # Outer-batch-resident calculators (re)point/zero their per-batch device buffer here, before
         # this batch's scatters; no-op (default hooks) for calculators that hold their whole output.

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -688,8 +688,8 @@ function _loop_eph_over_k_and_kq_gpu(
 
     # Grid coordinates as (3 × n) real device matrices, uploaded once. Both phase builds below read
     # them directly, so nothing on the phase path is staged on the host or copied H2D inside the loop.
-    xk_dev  = _kpoint_vectors_to_device(backend, kpts)
-    xkq_dev = _kpoint_vectors_to_device(backend, kqpts)
+    xk_dev  = _kpoints_to_device_matrix(backend, kpts)
+    xkq_dev = _kpoints_to_device_matrix(backend, kqpts)
 
     # The two Fourier phase matrices of the k+q convention (see `get_eph_RR_to_kR_batched!`):
     #   P_k [ip, k] = exp(2πi R_p · x_k)      — conjugated into g(k, R_ep) once per outer-k batch
@@ -699,7 +699,7 @@ function _loop_eph_over_k_and_kq_gpu(
     # Not a `TiledDeviceOutput`: that tiles the OUTPUT side over the outer-state axis and owns a
     # host mirror plus a per-batch D2H, whereas P_kq is an input-side, q-indexed,
     # write-once-read-many device buffer with no host side and no D2H at all.
-    irvecp_mat = _irvec_matrix_to_device(model.epmat.irvec_next, epmat_dev, FT)
+    irvecp_mat = _irvec_to_device_matrix(model.epmat.irvec_next, epmat_dev, FT)
     P_k  = similar(proto, Complex{FT}, nr_ep, nk_batch_max)
     P_kq = similar(proto, Complex{FT}, nr_ep, nq_batch_max)
     # Defensive: only columns 1:nk_batch are rewritten per batch, so a partial final batch leaves the
@@ -763,7 +763,11 @@ function _loop_eph_over_k_and_kq_gpu(
 
         # One batched RR->kR over the whole batch: g(k, R_ep) for all k in the batch, stored in the
         # k+q convention (multiplied by conj(P_k)) so the kR->kq phase below is k-independent.
-        @views fourier_phase!(P_k[:, 1:nk_batch], irvecp_mat, xk_dev[:, iks_batch])
+        # `get_eph_RR_to_kR_batched!` multiplies by whatever it is handed, so conjugate here.
+        @views begin
+            fourier_phase!(P_k[:, 1:nk_batch], irvecp_mat, xk_dev[:, iks_batch])
+            P_k[:, 1:nk_batch] .= conj.(P_k[:, 1:nk_batch])
+        end
         get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat, ks_batch, uks_dev;
             additional_phase = P_k)
 

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -20,8 +20,9 @@ function run_eph_over_k_and_kq(
         use_gpu = false,   # Run the e-ph Wannier->Bloch interpolation on the GPU
         nq_batch_max = nothing,  # GPU: k+q points per batched kR->kq kernel (nothing = all k+q in one batch)
         # GPU: number of outer k points per batched RR->kR kernel + D2H tile extent. Calculators still
-        # see outer k SERIALLY (one `OuterIteration` bracket + payload per k); this only sets the
-        # interpolation-staging width. No deprecated alias for the former name `nk_batch_max`.
+        # see one payload per outer k, but a k's q-tiles are no longer contiguous (the q-tile loop is
+        # outside the k loop) and only the `OuterIterationBatch` bracket is fired; this also sets how
+        # many outer k reuse one kR->kq phase tile. No deprecated alias for the former `nk_batch_max`.
         nk_outer_batch_max = 256,
         verbosity::Int = 1,
     ) where {FT}
@@ -499,6 +500,13 @@ end
 #
 #  Buffer reuse: device buffers are allocated once before the k loop and reused for every
 #  (k, q), so the loop itself allocates almost nothing.
+#
+#  Loop shape: `k-batch -> q-tile -> k -> q(device)`. The q-tile loop sits OUTSIDE the per-k loop
+#  because the kR->kq Fourier phase is built from the fixed k+q list (the k+q convention, see
+#  `get_eph_RR_to_kR_batched!`) and is therefore the same for every k of the batch: one built tile
+#  is reused `nk_batch` times. Consequence for calculators: a k's work no longer finishes at a
+#  single point in the loop, so this loop fires only the `OuterIterationBatch` bracket — there is
+#  no per-k `OuterIteration` bracket in the batched outer-k loop.
 function _loop_eph_over_k_and_kq_gpu(
         model       :: Model{FT},
         kpts, qpts, kqpts,
@@ -531,11 +539,12 @@ function _loop_eph_over_k_and_kq_gpu(
     # symmetry-agnostic — `symmetry` is only passed through to `postprocess_calculator!`. The
     # dispatcher gates the unsupported el_kq_from_unfolding = true case.
 
-    # Default (nq_batch_max === nothing): size the q-batch to the free device memory (below), which
-    # for small nw/nmodes lands on all k+q in a single batch. Fewer, larger kR->kq / calculator
-    # kernels — the GPU e-ph path is launch-bound for small nw/nmodes, so one big batch is ~1.8×
-    # faster than the old 1024 default at 16³. Passing an Int caps the batch harder; the
-    # memory-adaptive cap (§7) then takes the smaller of the two so a large-nw run cannot OOM.
+    # Default (nq_batch_max === nothing): size the q-tile to the free device memory (below), which
+    # for small nw/nmodes lands on all k+q in a single tile. Fewer, larger kR->kq / calculator
+    # kernels — the GPU e-ph path is launch-bound for small nw/nmodes, so one big tile is ~1.8×
+    # faster than the old 1024 default at 16³, and one tile also means one kR->kq phase build for
+    # the whole outer-k batch. Passing an Int caps the tile harder; the memory-adaptive cap (§7)
+    # then takes the smaller of the two so a large-nw run cannot OOM.
     nq_batch_user = nq_batch_max   # nothing = size to memory (capped at nkq); Int = hard upper cap
     nk_batch_max = min(nk_outer_batch_max, nk)
 
@@ -577,22 +586,20 @@ function _loop_eph_over_k_and_kq_gpu(
     # `epmat_dev` (device e-ph object) was uploaded ONCE in the shared setup and threaded here through
     # `backend`; the loop reuses it rather than re-uploading. `backend` is carried in LoopContext below.
     itp_epmat = BatchedWannierInterpolator(epmat_dev; batch_size = nk_batch_max)
-    # Device child object for g(k, R_ep), born partial-width: under the k-side eigenvector-window
-    # projection only the first nw·nbandk_max·nmodes rows of op_r are filled/read, so `ndata` (which
-    # sizes the interpolator's Fourier cache) is set at construction, not mutated afterward. `op_r`
-    # itself is full-band-sized.
+    # g(k, R_ep) is born partial-width: under the k-side eigenvector-window projection only the
+    # first nw·nbandk_max·nmodes rows carry data. It is consumed directly out of `ep_ekpR_all`
+    # (below), so there is no child WannierObject and no second interpolator here.
     ndata_ekpR = nw * nbandk_max * nmodes
-    ep_ekpR_dev = to_device(backend, get_next_wannier_object(model.epmat; ndata_child = ndata_ekpR))
-    nr_ep = ep_ekpR_dev.nr
+    nr_ep = length(model.epmat.irvec_next)
 
     # ----- memory-adaptive q-batch size (§7) -----
     # Every per-q staging buffer scales with the q-batch width, so cap it at what free device memory
     # allows (30% headroom for the batched drivers' recycled temporaries). The whole-run + per-k-batch
-    # commitments allocated after this point are subtracted first; `epmat_dev` / `ep_ekpR_dev` /
-    # `itp_epmat` are already live, so `free_bytes` reflects them. All buffer byte accounting lives in
+    # commitments allocated after this point are subtracted first; `epmat_dev` / `itp_epmat` are
+    # already live, so `free_bytes` reflects them. All buffer byte accounting lives in
     # `_outer_k_staging_bytes` (shared with `estimate_device_memory`); `nq_batch_user`
     # (Int, or nkq when nothing) stays a hard cap.
-    per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nkq,
+    per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
         nq_grid = qpts.n, nk_batch_max, calculators,
         ndata_epmat = epmat_dev.ndata, nr_epmat = epmat_dev.nr, FT)
     nq_batch_cap = nq_batch_user === nothing ? nkq : min(nq_batch_user, nkq)
@@ -602,15 +609,13 @@ function _loop_eph_over_k_and_kq_gpu(
               "$(round(per_point / 1e3, digits = 1)) kB/q; q-batch size = $nq_batch_max"
     end
 
-    itp_ep_ekpR = BatchedWannierInterpolator(ep_ekpR_dev; batch_size = nq_batch_max)
-
     # ----- persistent workspace (allocated once, reused across all (k, q)) -----
     # All device staging is sized to the full batch and used as plain CuArrays (not
     # batch-sliced views), so the batched drivers' reshape/cuBLAS calls stay on dense arrays.
 
     # RR->kR over a batch of `nk_batch_max` outer-k at once: one batched kernel per batch instead of one
-    # launch-bound single-k call per k. `ep_ekpR_all` holds g(k, R_ep) for the whole batch; each
-    # k's slice is then copied into `ep_ekpR_dev` (device→device) for the inner kR->kq driver.
+    # launch-bound single-k call per k. `ep_ekpR_all` holds g(k, R_ep) for the whole batch; the inner
+    # kR->kq driver reads each k's slice `ep_ekpR_all[:, :, ik_ind]` directly.
     uks_dev     = similar(epmat_dev.op_r, Complex{FT}, nw, nbandk_max, nk_batch_max)
     uks_host    = Array{Complex{FT}}(undef, nw, nbandk_max, nk_batch_max)
     ep_ekpR_all = similar(epmat_dev.op_r, Complex{FT}, ndata_ekpR, nr_ep, nk_batch_max)
@@ -622,7 +627,7 @@ function _loop_eph_over_k_and_kq_gpu(
     # In-place scratch for the per-k kR->kq driver (g / tmp), reused across all (k, q) so the
     # driver allocates nothing per call. Sized for the max batch width `nq_batch_max`; the driver
     # uses the first `nq_batch` columns for a partial final batch.
-    kRkq_ws = KRtoKQWorkspace(ep_ekpR_dev.op_r, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max)
+    kRkq_ws = KRtoKQWorkspace(epmat_dev.op_r, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max)
 
     # Collect the k+q electron eigenvectors on the host and copy to the device once (they do not
     # depend on the outer k), reused across all k. Each q-batch reads a contiguous slice directly.
@@ -648,7 +653,36 @@ function _loop_eph_over_k_and_kq_gpu(
         copyto!(ωq_all_dev, ωq_all_host)
     end
 
-    qs_batch  = Vector{Vec3{FT}}(undef, nq_batch_max)
+    # Grid coordinates as (3 × n) real device matrices, uploaded once. Both phase builds below read
+    # them directly, so nothing on the phase path is staged on the host or copied H2D inside the loop.
+    xk_dev  = similar(epmat_dev.op_r, FT, 3, nk)
+    xkq_dev = similar(epmat_dev.op_r, FT, 3, nkq)
+    let xk_host = Matrix{FT}(undef, 3, nk), xkq_host = Matrix{FT}(undef, 3, nkq)
+        for ik in 1:nk, d in 1:3
+            xk_host[d, ik] = kpts.vectors[ik][d]
+        end
+        for ikq in 1:nkq, d in 1:3
+            xkq_host[d, ikq] = kqpts.vectors[ikq][d]
+        end
+        copyto!(xk_dev, xk_host)
+        copyto!(xkq_dev, xkq_host)
+    end
+
+    # The two Fourier phase matrices of the k+q convention (see `get_eph_RR_to_kR_batched!`):
+    #   P_k [ip, k] = exp(2πi R_p · x_k)      — conjugated into g(k, R_ep) once per outer-k batch
+    #   P_kq[ip, j] = exp(2πi R_p · x_{k+q_j}) — the kR->kq phase, INDEPENDENT of the outer k
+    # so one built P_kq tile serves every k of the batch. That reuse factor is `nk_batch`, i.e.
+    # `nk_outer_batch_max`: lowering that cap shrinks this saving proportionally.
+    # Not a `TiledDeviceOutput`: that tiles the OUTPUT side over the outer-state axis and owns a
+    # host mirror plus a per-batch D2H, whereas P_kq is an input-side, q-indexed,
+    # write-once-read-many device buffer with no host side and no D2H at all.
+    irvecp_mat = _irvec_matrix(model.epmat.irvec_next, epmat_dev, FT)
+    P_k  = similar(epmat_dev.op_r, Complex{FT}, nr_ep, nk_batch_max)
+    P_kq = similar(epmat_dev.op_r, Complex{FT}, nr_ep, nq_batch_max)
+    # A partial k-batch leaves P_k's padded tail columns unwritten; 1 keeps the padded (discarded)
+    # slices of ep_ekpR_all finite.
+    fill!(P_k, 1)
+
     iqs_batch  = Vector{Int}(undef, nq_batch_max)
     iqs_batch_dev    = similar(epmat_dev.op_r, Int, nq_batch_max)
 
@@ -656,8 +690,8 @@ function _loop_eph_over_k_and_kq_gpu(
     #   hc_i = mod(xkqs_int[i,ikq] - xks_int[i,ik], ng_i),  hash = (hc1*ng2 + hc2)*ng3 + hc3,
     # reproducing `_hash_xk` bit-identically with no Float64 in the hot loop. Requires every k and
     # k+q to lie exactly on the q-grid (ngrid a multiple of both meshes) — guaranteed by precompute_ph,
-    # asserted above. `qs_batch` reads qpts.vectors[iq] ≡ (xkq-xk) mod G; the Fourier phase is periodic
-    # in q→q+G, so the interpolated e-ph matrix is unchanged.
+    # asserted above. Only `iq` is needed: the q-VECTOR no longer enters the interpolation (the
+    # kR->kq phase is built from x_{k+q}), so this loop gathers phonon data by index only.
     ng1, ng2, ng3 = qpts.ngrid
     shq = qpts.shift
     xkqs_int = Matrix{Int}(undef, 3, nkq)
@@ -669,9 +703,12 @@ function _loop_eph_over_k_and_kq_gpu(
         xks_int[d, ik] = round(Int, kpts.vectors[ik][d] * qpts.ngrid[d])
     end
 
-    ikqs_host = Vector{Int}(undef, nq_batch_max)
+    # The payload's k+q index list is the plain range `qstart:qend` of the current q-tile, so hold
+    # 1:nkq on the device once and slice it instead of refilling and re-uploading it per (k, tile).
+    ikqs_all_dev = similar(epmat_dev.op_r, Int, nkq)
+    copyto!(ikqs_all_dev, collect(1:nkq))
+
     ωq_dev    = similar(epmat_dev.op_r, FT, nmodes, nq_batch_max)
-    ikqs_dev  = similar(epmat_dev.op_r, Int, nq_batch_max)
     g2_dev    = similar(epmat_dev.op_r, FT, nw, nbandk_max, nmodes, nq_batch_max)
 
     for kstart in 1:nk_batch_max:nk
@@ -695,100 +732,94 @@ function _loop_eph_over_k_and_kq_gpu(
         end
         copyto!(uks_dev, uks_host)
 
-        # One batched RR->kR over the whole batch: g(k, R_ep) for all k in the batch.
-        get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat, ks_batch, uks_dev)
+        if mpi_isroot() && div(kend, progress_print_step) > div(kstart - 1, progress_print_step)
+            @info "$(now()) ik = $kstart:$kend / $nk"
+            flush(stdout); flush(stderr)
+        end
+
+        # One batched RR->kR over the whole batch: g(k, R_ep) for all k in the batch, stored in the
+        # k+q convention (multiplied by conj(P_k)) so the kR->kq phase below is k-independent.
+        @views fourier_phase!(P_k[:, 1:nk_batch], irvecp_mat, xk_dev[:, iks_batch])
+        get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat, ks_batch, uks_dev;
+            kq_convention_phase = P_k)
 
         # Outer-batch-resident calculators (re)point/zero their per-batch device buffer here, before
         # this batch's scatters; no-op (default hooks) for calculators that hold their whole output.
         ctx_batch = LoopContext(backend, BatchedMode(), iks_batch, nk_batch_max)
         foreach(c -> calculator_begin!(c, OuterIterationBatch(), ctx_batch), calculators)
 
-    for (ik_ind, ik) in enumerate(iks_batch)
-        if mod(ik, progress_print_step) == 0 && mpi_isroot()
-            @info "$(now()) ik = $ik / $nk"
-            flush(stdout); flush(stderr)
-        end
-
-        # Load this k's g(k, R_ep) into the interpolator's parent (cheap device→device copy);
-        # the inner kR->kq driver reads `ep_ekpR_dev.op_r` fresh. Under the k-side projection only
-        # the first ndata_ekpR rows are used (op_r itself is full-band-sized). `update_op_r!` writes
-        # the leading rows and bumps `_id` (the single invalidation entry point).
-        @views update_op_r!(ep_ekpR_dev, ep_ekpR_all[:, :, ik_ind]; rows = 1:ndata_ekpR)
-
-        ctx_k = LoopContext(backend, BatchedMode(), ik, iks_batch, nk_batch_max)
-        foreach(c -> calculator_begin!(c, OuterIteration(), ctx_k), calculators)
-
         qstart = 1
         while qstart <= nkq
             qend = min(qstart + nq_batch_max - 1, nkq)
             nq_batch = qend - qstart + 1
+            rng_q = 1:nq_batch   # this tile's columns within the nq_batch_max-sized device buffers
 
-            # Build the per-q index list for this batch (host-side integers only); the phonon
-            # eigenvectors `u` and frequencies `e` are gathered on the device by iq below.
-            for j in 1:nq_batch
-                ikq = qstart + j - 1
-                # Integer grid-coord hash for iq (no Float64 normalize/_hash_xk per pair).
-                h1 = mod(xkqs_int[1, ikq] - xks_int[1, ik], ng1)
-                h2 = mod(xkqs_int[2, ikq] - xks_int[2, ik], ng2)
-                h3 = mod(xkqs_int[3, ikq] - xks_int[3, ik], ng3)
-                hash = (h1 * ng2 + h2) * ng3 + h3
-                iq = _ik_from_hash(qpts, hash)
-                # 0 = miss on either index.
-                (iq < 1 || iq > qpts.n) && throw(ArgumentError("kq - k = q point not found in precomputed qpts"))
-                # q-vector from the O(n) qpts.vectors (a cached gather — cheaper than recomputing it
-                # with 3 float divisions; qpts.vectors is O(n), never ngrid³). ≡ (xkq-xk) mod G.
-                qs_batch[j] = qpts.vectors[iq]
-                iqs_batch[j] = iq
-                ikqs_host[j] = ikq
-            end
-            rng_q = 1:nq_batch   # this batch's columns within the nq_batch_max-sized device buffers
-
-            # Gather this batch's phonon eigenvectors/frequencies on the device by iq
-            # (uphs_dev[:,:,j] = uph_all_dev[:,:,iq[j]]); ωq gathered here too so the fused kernel
-            # can fold g2 = |ep|²/(2ω) in the same pass. Everything below runs at width nq_batch
-            # via views into the nq_batch_max-sized buffers, so there is no padded tail.
-            # H2D copy of just the first nq_batch indices (5-arg contiguous copy — copying a host↔
-            # device SubArray view instead would fall back to scalar indexing); the device gather
-            # then reads only `view(iqs_batch_dev, rng_q)`, so the untouched tail is never used.
-            # `@inbounds`: bounds-checking a device INDEX ARRAY costs a Bool map+reduce kernel and
-            # a D2H round trip of the result per (k, batch); `iq` is already validated on the host
-            # (the guard above), so the device-side re-check is pure overhead.
-            copyto!(iqs_batch_dev, 1, iqs_batch, 1, nq_batch)
-            @inbounds @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, view(iqs_batch_dev, rng_q)]
-            @inbounds @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, view(iqs_batch_dev, rng_q)]
-            # k+q rotations: a contiguous slice of the prebuilt device stack (no copy).
+            # kR->kq phase for this q-tile, built ONCE and reused by every k of the outer-k batch —
+            # the reason the q-tile loop sits outside the k loop. In the k+q convention it reads
+            # x_{k+q} directly, so it is a contiguous slice of the fixed k+q list.
+            @views fourier_phase!(P_kq[:, rng_q], irvecp_mat, xkq_dev[:, qstart:qend])
+            # k+q rotations and k+q indices: contiguous slices of prebuilt device stacks (no copy).
             ukqs_used = view(ukqs_all_dev, :, :, qstart:qend)
+            ikqs_used = view(ikqs_all_dev, qstart:qend)
 
-            # One batched Wannier->Bloch over this batch's q: ep_kq(q) (nw, nw, nmodes), folding
-            # g2 = |ep|²/(2ω) into the same fused kernel pass.
-            get_eph_kR_to_kq_batched!(view(epkq_dev, :, :, :, rng_q), itp_ep_ekpR, view(qs_batch, rng_q),
-                view(uphs_dev, :, :, rng_q), ukqs_used; ws=kRkq_ws,
-                g2_out = view(g2_dev, :, :, :, rng_q), ωq = view(ωq_dev, :, rng_q))
+            for (ik_ind, ik) in enumerate(iks_batch)
+                # Build this (k, tile)'s q-index list (host-side integers only); the phonon
+                # eigenvectors `u` and frequencies `e` are gathered on the device by iq below.
+                for j in 1:nq_batch
+                    ikq = qstart + j - 1
+                    # Integer grid-coord hash for iq (no Float64 normalize/_hash_xk per pair).
+                    h1 = mod(xkqs_int[1, ikq] - xks_int[1, ik], ng1)
+                    h2 = mod(xkqs_int[2, ikq] - xks_int[2, ik], ng2)
+                    h3 = mod(xkqs_int[3, ikq] - xks_int[3, ik], ng3)
+                    hash = (h1 * ng2 + h2) * ng3 + h3
+                    iq = _ik_from_hash(qpts, hash)
+                    # 0 = miss on either index.
+                    (iq < 1 || iq > qpts.n) && throw(ArgumentError("kq - k = q point not found in precomputed qpts"))
+                    iqs_batch[j] = iq
+                end
 
-            # Hand the batch's e-ph matrix (still on the device) to each calculator, which forms
-            # g2 / scatters it on the device; no D2H of the e-ph matrix here. 5-arg contiguous H2D
-            # copy of the first nq_batch k+q indices (a SubArray-view copy would go scalar).
-            copyto!(ikqs_dev, 1, ikqs_host, 1, nq_batch)
-            payload = EPDataQBatched(
-                view(epkq_dev, :, :, :, rng_q), view(g2_dev, :, :, :, rng_q),
-                view(ωq_dev, :, rng_q), ik, view(ikqs_dev, rng_q), ibandk_offsets[ik])
-            foreach(c -> run_calculator!(c, payload, ctx_k), calculators)
+                # Gather this tile's phonon eigenvectors/frequencies on the device by iq
+                # (uphs_dev[:,:,j] = uph_all_dev[:,:,iq[j]]); ωq gathered here too so the fused kernel
+                # can fold g2 = |ep|²/(2ω) in the same pass. Everything below runs at width nq_batch
+                # via views into the nq_batch_max-sized buffers, so there is no padded tail.
+                # H2D copy of just the first nq_batch indices (5-arg contiguous copy — copying a host↔
+                # device SubArray view instead would fall back to scalar indexing); the device gather
+                # then reads only `view(iqs_batch_dev, rng_q)`, so the untouched tail is never used.
+                # `@inbounds`: bounds-checking a device INDEX ARRAY costs a Bool map+reduce kernel and
+                # a D2H round trip of the result per (k, tile); `iq` is already validated on the host
+                # (the guard above), so the device-side re-check is pure overhead.
+                copyto!(iqs_batch_dev, 1, iqs_batch, 1, nq_batch)
+                @inbounds @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, view(iqs_batch_dev, rng_q)]
+                @inbounds @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, view(iqs_batch_dev, rng_q)]
+
+                # One batched Wannier->Bloch over this tile's q: ep_kq(q) (nw, nw, nmodes), folding
+                # g2 = |ep|²/(2ω) into the same fused kernel pass.
+                get_eph_kR_to_kq_batched!(view(epkq_dev, :, :, :, rng_q),
+                    view(ep_ekpR_all, :, :, ik_ind), view(P_kq, :, rng_q),
+                    view(uphs_dev, :, :, rng_q), ukqs_used; ws=kRkq_ws,
+                    g2_out = view(g2_dev, :, :, :, rng_q), ωq = view(ωq_dev, :, rng_q))
+
+                # Hand the tile's e-ph matrix (still on the device) to each calculator, which forms
+                # g2 / scatters it on the device; no D2H of the e-ph matrix here.
+                ctx_k = LoopContext(backend, BatchedMode(), ik, iks_batch, nk_batch_max)
+                payload = EPDataQBatched(
+                    view(epkq_dev, :, :, :, rng_q), view(g2_dev, :, :, :, rng_q),
+                    view(ωq_dev, :, rng_q), ik, ikqs_used, ibandk_offsets[ik])
+                foreach(c -> run_calculator!(c, payload, ctx_k), calculators)
+            end # ik within batch
 
             qstart = qend + 1
-        end # q batch
+        end # q tile
 
-        foreach(c -> calculator_end!(c, OuterIteration(), ctx_k), calculators)
-    end # ik within batch
+        # Outer-batch-resident calculators D2H this batch's device buffer into their host output here
+        # (one contiguous copy per batch, not per k); no-op (default hooks) for full-resident calculators.
+        foreach(c -> calculator_end!(c, OuterIterationBatch(), ctx_batch), calculators)
 
-    # Outer-batch-resident calculators D2H this batch's device buffer into their host output here
-    # (one contiguous copy per batch, not per k); no-op (default hooks) for full-resident calculators.
-    foreach(c -> calculator_end!(c, OuterIterationBatch(), ctx_batch), calculators)
-
-    # Bound the host look-ahead to one k-batch: a device-resident calculator never D2H-syncs per k,
-    # so without this the host can race across all batches, keeping every batch's RR->kR scratch +
-    # per-k transients live in the memory pool at once. Draining at each batch boundary caps the
-    # transient working set with negligible utilization cost. No-op on the CPU backend.
-    synchronize(backend)
+        # Bound the host look-ahead to one k-batch: a device-resident calculator never D2H-syncs per k,
+        # so without this the host can race across all batches, keeping every batch's RR->kR scratch +
+        # per-k transients live in the memory pool at once. Draining at each batch boundary caps the
+        # transient working set with negligible utilization cost. No-op on the CPU backend.
+        synchronize(backend)
     end # k batch
 
     foreach(c -> postprocess_calculator!(c; qpts, symmetry), calculators)

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -692,21 +692,21 @@ function _loop_eph_over_k_and_kq_gpu(
     xkq_dev = _kpoints_to_device_matrix(backend, kqpts)
 
     # The two Fourier phase matrices of the k+q convention (see `get_eph_RR_to_kR_batched!`):
-    #   P_k [ip, k] = exp(2πi R_p · x_k)      — conjugated into g(k, R_ep) once per outer-k batch
-    #   P_kq[ip, j] = exp(2πi R_p · x_{k+q_j}) — the kR->kq phase, INDEPENDENT of the outer k
-    # so one built P_kq tile serves every k of the batch. That reuse factor is `nk_batch`, i.e.
+    #   P_mk [ip, k] = exp(2πi R_p · x_k)      — conjugated into g(k, R_ep) once per outer-k batch
+    #   P_mkq[ip, j] = exp(2πi R_p · x_{k+q_j}) — the kR->kq phase, INDEPENDENT of the outer k
+    # so one built P_mkq tile serves every k of the batch. That reuse factor is `nk_batch`, i.e.
     # `nk_outer_batch_max`: lowering that cap shrinks this saving proportionally.
     # Not a `TiledDeviceOutput`: that tiles the OUTPUT side over the outer-state axis and owns a
-    # host mirror plus a per-batch D2H, whereas P_kq is an input-side, q-indexed,
+    # host mirror plus a per-batch D2H, whereas P_mkq is an input-side, q-indexed,
     # write-once-read-many device buffer with no host side and no D2H at all.
     irvecp_mat = _irvec_to_device_matrix(model.epmat.irvec_next, epmat_dev, FT)
-    P_k  = alloc(backend, Complex{FT}, nr_ep, nk_batch_max)
-    P_kq = alloc(backend, Complex{FT}, nr_ep, nq_batch_max)
+    P_mk  = alloc(backend, Complex{FT}, nr_ep, nk_batch_max)
+    P_mkq = alloc(backend, Complex{FT}, nr_ep, nq_batch_max)
     # Defensive: only columns 1:nk_batch are rewritten per batch, so a partial final batch leaves the
     # tail columns holding whatever the previous batch wrote. Nothing reads them — the k loop runs
     # `1:nk_batch` — and 1 is the identity of the convention multiply, so the padded (never-read)
     # slice of ep_ekpR_all stays meaningful whether or not it has been written yet.
-    fill!(P_k, 1)
+    fill!(P_mk, 1)
 
     # `iq` index staging for one (k, q-tile).
     iqs_batch     = Vector{Int}(undef, nq_batch_max)
@@ -762,14 +762,14 @@ function _loop_eph_over_k_and_kq_gpu(
         end
 
         # One batched RR->kR over the whole batch: g(k, R_ep) for all k in the batch, stored in the
-        # k+q convention (multiplied by conj(P_k)) so the kR->kq phase below is k-independent.
+        # k+q convention (multiplied by conj(P_mk)) so the kR->kq phase below is k-independent.
         # `get_eph_RR_to_kR_batched!` multiplies by whatever it is handed, so conjugate here.
         @views begin
-            fourier_phase!(P_k[:, 1:nk_batch], irvecp_mat, xk_dev[:, iks_batch])
-            P_k[:, 1:nk_batch] .= conj.(P_k[:, 1:nk_batch])
+            fourier_phase!(P_mk[:, 1:nk_batch], irvecp_mat, xk_dev[:, iks_batch])
+            P_mk[:, 1:nk_batch] .= conj.(P_mk[:, 1:nk_batch])
         end
         get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat, ks_batch, uks_dev;
-            additional_phase = P_k)
+            additional_phase = P_mk)
 
         # Outer-batch-resident calculators (re)point/zero their per-batch device buffer here, before
         # this batch's scatters; no-op (default hooks) for calculators that hold their whole output.
@@ -785,7 +785,7 @@ function _loop_eph_over_k_and_kq_gpu(
             # kR->kq phase for this q-tile, built ONCE and reused by every k of the outer-k batch —
             # the reason the q-tile loop sits outside the k loop. In the k+q convention it reads
             # x_{k+q} directly, so it is a contiguous slice of the fixed k+q list.
-            @views fourier_phase!(P_kq[:, rng_q], irvecp_mat, xkq_dev[:, qstart:qend])
+            @views fourier_phase!(P_mkq[:, rng_q], irvecp_mat, xkq_dev[:, qstart:qend])
             # k+q rotations: a contiguous slice of the prebuilt device stack (no copy). The payload's
             # k+q index list is the plain range of this tile — `isbits`, so it rides in the kernel
             # launch parameters instead of costing a device buffer and a global load per thread.
@@ -813,7 +813,7 @@ function _loop_eph_over_k_and_kq_gpu(
                 # One batched Wannier->Bloch over this tile's q: ep_kq(q) (nw, nbandk_max, nmodes),
                 # folding g2 = |ep|²/(2ω) into the same fused kernel pass.
                 get_eph_kR_to_kq_batched!(view(epkq_dev, :, :, :, rng_q),
-                    view(ep_ekpR_all, :, :, ik_ind), view(P_kq, :, rng_q),
+                    view(ep_ekpR_all, :, :, ik_ind), view(P_mkq, :, rng_q),
                     view(uphs_dev, :, :, rng_q), ukqs_used; ws = kRkq_ws,
                     g2_out = view(g2_dev, :, :, :, rng_q), ωq = view(ωq_dev, :, rng_q))
 

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -501,12 +501,18 @@ end
 #  Buffer reuse: device buffers are allocated once before the k loop and reused for every
 #  (k, q), so the loop itself allocates almost nothing.
 #
-#  Loop shape: `k-batch -> q-tile -> k -> q(device)`. The q-tile loop sits OUTSIDE the per-k loop
-#  because the kR->kq Fourier phase is built from the fixed k+q list (the k+q convention, see
-#  `get_eph_RR_to_kR_batched!`) and is therefore the same for every k of the batch: one built tile
-#  is reused `nk_batch` times. Consequence for calculators: a k's work no longer finishes at a
+#  Loop shape: `k-batch -> q-tile -> k-strip -> k -> q(device)`. The q-tile loop sits OUTSIDE the
+#  per-k loop because the kR->kq Fourier phase is built from the fixed k+q list (the k+q convention,
+#  see `get_eph_RR_to_kR_batched!`) and is therefore the same for every k of the batch: one built
+#  tile is reused `nk_batch` times. Consequence for calculators: a k's work no longer finishes at a
 #  single point in the loop, so this loop fires only the `OuterIterationBatch` bracket — there is
 #  no per-k `OuterIteration` bracket in the batched outer-k loop.
+#  The k-strip level runs the kR->kq Fourier for `nk_b` k at once (`_krkq_strip_width`), so that
+#  phase tile is also READ once per strip rather than once per k and the GEMM's M dimension fills a
+#  cuBLAS tile. It helps only where `ndata = nw·nbandk_max·nmodes` is small — a narrow-window,
+#  small-`nw` regime; a full-band large-`nw` run gets `nk_b = 1` and the loop as it was. k are
+#  visited in the same order and everything below the GEMM is per-k, so the payload stream and the
+#  bracket order are unchanged.
 function _loop_eph_over_k_and_kq_gpu(
         model       :: Model{FT},
         kpts, qpts, kqpts,
@@ -592,6 +598,12 @@ function _loop_eph_over_k_and_kq_gpu(
     ndata_ekpR = nw * nbandk_max * nmodes
     nr_ep = length(model.epmat.irvec_next)
 
+    # ----- kR->kq GEMM strip width -----
+    # `nk_b` consecutive outer-k are stacked into one tall kR->kq GEMM, so the k-invariant phase tile
+    # is read nk_b times less and the GEMM's M dimension fills a cuBLAS tile. Shape-derived; it is 1
+    # (no strip, nothing changes) at large ndata or when the fused rotation kernel is not used.
+    nk_b = _krkq_strip_width(; nw, nbandk_max, nmodes, nk_batch_max)
+
     # ----- memory-adaptive q-batch size (§7) -----
     # Every per-q staging buffer scales with the q-batch width, so cap it at what free device memory
     # allows (30% headroom for the batched drivers' recycled temporaries). The whole-run + per-k-batch
@@ -601,12 +613,23 @@ function _loop_eph_over_k_and_kq_gpu(
     # (Int, or nkq when nothing) stays a hard cap.
     per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
         nq_grid = qpts.n, nk_batch_max, calculators,
-        ndata_epmat = epmat_dev.ndata, nr_epmat = epmat_dev.nr, FT)
+        ndata_epmat = epmat_dev.ndata, nr_epmat = epmat_dev.nr, nk_b, FT)
     nq_batch_cap = nq_batch_user === nothing ? nkq : min(nq_batch_user, nkq)
     nq_batch_max = plan_batch(backend, per_point, committed, nq_batch_cap; what = "outer-k")
     if verbosity > 0 && mpi_isroot()
         @info "GPU outer-k device memory: committed = $(round(committed / 1e9, digits = 2)) GB, " *
-              "$(round(per_point / 1e3, digits = 1)) kB/q; q-batch size = $nq_batch_max"
+              "$(round(per_point / 1e3, digits = 1)) kB/q; q-batch size = $nq_batch_max, " *
+              "kR->kq strip nk_b = $nk_b"
+    end
+    # The strip's extra `ws.g` rows are spent out of the same per-q budget as the phase tile. At the
+    # shapes where the strip switches on they are a small share of it, but a model with a large
+    # `ndata` and a small `nr_ep` inverts that; say so rather than silently starving the q-tile.
+    strip_bytes = sizeof(Complex{FT}) * ndata_ekpR * (nk_b - 1)
+    if nk_b > 1 && nq_batch_max < nq_batch_cap && strip_bytes * 4 > per_point
+        @warn "GPU outer-k: the kR->kq strip (nk_b = $nk_b) takes " *
+              "$(round(Int, 100 * strip_bytes / per_point))% of the per-q device budget while the " *
+              "q-tile is memory-limited ($nq_batch_max of $nq_batch_cap). Lower _KRKQ_GEMM_M_TARGET if this " *
+              "run is slower than one with nk_b = 1."
     end
 
     # ----- persistent workspace (allocated once, reused across all (k, q)) -----
@@ -614,20 +637,24 @@ function _loop_eph_over_k_and_kq_gpu(
     # batch-sliced views), so the batched drivers' reshape/cuBLAS calls stay on dense arrays.
 
     # RR->kR over a batch of `nk_batch_max` outer-k at once: one batched kernel per batch instead of one
-    # launch-bound single-k call per k. `ep_ekpR_all` holds g(k, R_ep) for the whole batch; the inner
-    # kR->kq driver reads each k's slice `ep_ekpR_all[:, :, ik_ind]` directly.
+    # launch-bound single-k call per k. `ep_ekpR_all` holds g(k, R_ep) for the whole batch, k in the
+    # MIDDLE axis so that a strip of `nk_b` consecutive k is the plain row range
+    # `ep_ekpR_2d[ndata*(s-1)+1 : ndata*(s-1+nk_b), :]` — an `lda` view, no copy.
     uks_dev     = similar(epmat_dev.op_r, Complex{FT}, nw, nbandk_max, nk_batch_max)
     uks_host    = Array{Complex{FT}}(undef, nw, nbandk_max, nk_batch_max)
-    ep_ekpR_all = similar(epmat_dev.op_r, Complex{FT}, ndata_ekpR, nr_ep, nk_batch_max)
+    ep_ekpR_all = similar(epmat_dev.op_r, Complex{FT}, ndata_ekpR, nk_batch_max, nr_ep)
+    ep_ekpR_2d  = reshape(ep_ekpR_all, ndata_ekpR * nk_batch_max, nr_ep)
     ks_batch     = Vector{Vec3{FT}}(undef, nk_batch_max)
 
     uphs_dev = similar(epmat_dev.op_r, Complex{FT}, nmodes, nmodes, nq_batch_max)
     epkq_dev = similar(epmat_dev.op_r, Complex{FT}, nw, nbandk_max, nmodes, nq_batch_max)
 
-    # In-place scratch for the per-k kR->kq driver (g / tmp), reused across all (k, q) so the
-    # driver allocates nothing per call. Sized for the max batch width `nq_batch_max`; the driver
-    # uses the first `nq_batch` columns for a partial final batch.
-    kRkq_ws = KRtoKQWorkspace(epmat_dev.op_r, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max)
+    # In-place scratch for the kR->kq step (g / tmp), reused across all (k, q) so nothing is
+    # allocated per call. Sized for the max batch width `nq_batch_max`; only the first `nq_batch`
+    # columns are used for a partial final batch. `g` holds a whole strip of `nk_b` k; `g_strip5`
+    # is its (nw, nbandk, nmodes, nk_b, nq) view, from which each k takes a q-strided 4-D slice.
+    kRkq_ws = KRtoKQWorkspace(epmat_dev.op_r, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max; nk_b)
+    g_strip5 = reshape(kRkq_ws.g, nw, nbandk_max, nmodes, nk_b, nq_batch_max)
 
     # Collect the k+q electron eigenvectors on the host and copy to the device once (they do not
     # depend on the outer k), reused across all k. Each q-batch reads a contiguous slice directly.
@@ -763,51 +790,67 @@ function _loop_eph_over_k_and_kq_gpu(
             ukqs_used = view(ukqs_all_dev, :, :, qstart:qend)
             ikqs_used = view(ikqs_all_dev, qstart:qend)
 
-            for (ik_ind, ik) in enumerate(iks_batch)
-                # Build this (k, tile)'s q-index list (host-side integers only); the phonon
-                # eigenvectors `u` and frequencies `e` are gathered on the device by iq below.
-                for j in 1:nq_batch
-                    ikq = qstart + j - 1
-                    # Integer grid-coord hash for iq (no Float64 normalize/_hash_xk per pair).
-                    h1 = mod(xkqs_int[1, ikq] - xks_int[1, ik], ng1)
-                    h2 = mod(xkqs_int[2, ikq] - xks_int[2, ik], ng2)
-                    h3 = mod(xkqs_int[3, ikq] - xks_int[3, ik], ng3)
-                    hash = (h1 * ng2 + h2) * ng3 + h3
-                    iq = _ik_from_hash(qpts, hash)
-                    # 0 = miss on either index.
-                    (iq < 1 || iq > qpts.n) && throw(ArgumentError("kq - k = q point not found in precomputed qpts"))
-                    iqs_batch[j] = iq
-                end
+            # Strip-mine the k loop for the kR->kq Fourier: one tall GEMM stacks `nks` outer-k
+            # into a single left operand, so the k-invariant phase tile is read once per strip
+            # instead of once per k. The left operand is the strip's row range of `ep_ekpR_2d`
+            # (unit stride down the rows, `lda = ndata_ekpR*nk_batch_max` across) - a plain view,
+            # no copy. A partial final strip just uses a shorter row range: `M` is a runtime GEMM
+            # dimension, so nothing needs padding. Everything below the GEMM stays strictly per-k.
+            for sstart in 1:nk_b:nk_batch
+                nks  = min(nk_b, nk_batch - sstart + 1)
+                rows = ndata_ekpR * (sstart - 1) + 1 : ndata_ekpR * (sstart - 1 + nks)
+                eph_kR_to_kq_fourier!(view(kRkq_ws.g, 1:ndata_ekpR*nks, rng_q),
+                    view(ep_ekpR_2d, rows, :), view(P_kq, :, rng_q))
 
-                # Gather this tile's phonon eigenvectors/frequencies on the device by iq
-                # (uphs_dev[:,:,j] = uph_all_dev[:,:,iq[j]]); ωq gathered here too so the fused kernel
-                # can fold g2 = |ep|²/(2ω) in the same pass. Everything below runs at width nq_batch
-                # via views into the nq_batch_max-sized buffers, so there is no padded tail.
-                # H2D copy of just the first nq_batch indices (5-arg contiguous copy — copying a host↔
-                # device SubArray view instead would fall back to scalar indexing); the device gather
-                # then reads only `view(iqs_batch_dev, rng_q)`, so the untouched tail is never used.
-                # `@inbounds`: bounds-checking a device INDEX ARRAY costs a Bool map+reduce kernel and
-                # a D2H round trip of the result per (k, tile); `iq` is already validated on the host
-                # (the guard above), so the device-side re-check is pure overhead.
-                copyto!(iqs_batch_dev, 1, iqs_batch, 1, nq_batch)
-                @inbounds @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, view(iqs_batch_dev, rng_q)]
-                @inbounds @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, view(iqs_batch_dev, rng_q)]
+                for ik_ind in sstart:(sstart + nks - 1)
+                    ik = iks_batch[ik_ind]
+                    # Build this (k, tile)'s q-index list (host-side integers only); the phonon
+                    # eigenvectors `u` and frequencies `e` are gathered on the device by iq below.
+                    for j in 1:nq_batch
+                        ikq = qstart + j - 1
+                        # Integer grid-coord hash for iq (no Float64 normalize/_hash_xk per pair).
+                        h1 = mod(xkqs_int[1, ikq] - xks_int[1, ik], ng1)
+                        h2 = mod(xkqs_int[2, ikq] - xks_int[2, ik], ng2)
+                        h3 = mod(xkqs_int[3, ikq] - xks_int[3, ik], ng3)
+                        hash = (h1 * ng2 + h2) * ng3 + h3
+                        iq = _ik_from_hash(qpts, hash)
+                        # 0 = miss on either index.
+                        (iq < 1 || iq > qpts.n) && throw(ArgumentError("kq - k = q point not found in precomputed qpts"))
+                        iqs_batch[j] = iq
+                    end
 
-                # One batched Wannier->Bloch over this tile's q: ep_kq(q) (nw, nw, nmodes), folding
-                # g2 = |ep|²/(2ω) into the same fused kernel pass.
-                get_eph_kR_to_kq_batched!(view(epkq_dev, :, :, :, rng_q),
-                    view(ep_ekpR_all, :, :, ik_ind), view(P_kq, :, rng_q),
-                    view(uphs_dev, :, :, rng_q), ukqs_used; ws=kRkq_ws,
-                    g2_out = view(g2_dev, :, :, :, rng_q), ωq = view(ωq_dev, :, rng_q))
+                    # Gather this tile's phonon eigenvectors/frequencies on the device by iq
+                    # (uphs_dev[:,:,j] = uph_all_dev[:,:,iq[j]]); ωq gathered here too so the fused kernel
+                    # can fold g2 = |ep|²/(2ω) in the same pass. Everything below runs at width nq_batch
+                    # via views into the nq_batch_max-sized buffers, so there is no padded tail.
+                    # H2D copy of just the first nq_batch indices (5-arg contiguous copy — copying a host↔
+                    # device SubArray view instead would fall back to scalar indexing); the device gather
+                    # then reads only `view(iqs_batch_dev, rng_q)`, so the untouched tail is never used.
+                    # `@inbounds`: bounds-checking a device INDEX ARRAY costs a Bool map+reduce kernel and
+                    # a D2H round trip of the result per (k, tile); `iq` is already validated on the host
+                    # (the guard above), so the device-side re-check is pure overhead.
+                    copyto!(iqs_batch_dev, 1, iqs_batch, 1, nq_batch)
+                    @inbounds @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, view(iqs_batch_dev, rng_q)]
+                    @inbounds @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, view(iqs_batch_dev, rng_q)]
 
-                # Hand the tile's e-ph matrix (still on the device) to each calculator, which forms
-                # g2 / scatters it on the device; no D2H of the e-ph matrix here.
-                ctx_k = LoopContext(backend, BatchedMode(), ik, iks_batch, nk_batch_max)
-                payload = EPDataQBatched(
-                    view(epkq_dev, :, :, :, rng_q), view(g2_dev, :, :, :, rng_q),
-                    view(ωq_dev, :, rng_q), ik, ikqs_used, ibandk_offsets[ik])
-                foreach(c -> run_calculator!(c, payload, ctx_k), calculators)
-            end # ik within batch
+                    # Gauge rotations for this k, folding g2 = |ep|²/(2ω) into the same fused kernel
+                    # pass. This k's Fourier output is the strip's `kloc`-th slice, strided in q when
+                    # nk_b > 1 - which only the fused kernel reads, hence the `_krkq_strip_width` gate.
+                    kloc = ik_ind - sstart + 1
+                    eph_apply_rotations!(view(epkq_dev, :, :, :, rng_q),
+                        view(g_strip5, :, :, :, kloc, rng_q), ukqs_used,
+                        view(uphs_dev, :, :, rng_q), view(kRkq_ws.tmp, :, :, rng_q);
+                        g2_out = view(g2_dev, :, :, :, rng_q), ωq = view(ωq_dev, :, rng_q))
+
+                    # Hand the tile's e-ph matrix (still on the device) to each calculator, which forms
+                    # g2 / scatters it on the device; no D2H of the e-ph matrix here.
+                    ctx_k = LoopContext(backend, BatchedMode(), ik, iks_batch, nk_batch_max)
+                    payload = EPDataQBatched(
+                        view(epkq_dev, :, :, :, rng_q), view(g2_dev, :, :, :, rng_q),
+                        view(ωq_dev, :, rng_q), ik, ikqs_used, ibandk_offsets[ik])
+                    foreach(c -> run_calculator!(c, payload, ctx_k), calculators)
+                end # ik within strip
+            end # strip
 
             qstart = qend + 1
         end # q tile

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -601,7 +601,9 @@ function _loop_eph_over_k_and_kq_gpu(
     # ----- kR->kq GEMM strip width -----
     # `nk_b` consecutive outer-k are stacked into one tall kR->kq GEMM, so the k-invariant phase tile
     # is read nk_b times less and the GEMM's M dimension fills a cuBLAS tile. Shape-derived; it is 1
-    # (no strip, nothing changes) at large ndata or when the fused rotation kernel is not used.
+    # (no strip, nothing changes) at large ndata or when the fused rotation kernel is not used. The
+    # M-target rule bounds the extra per-q staging (a wider `kRkq_ws.g`) at
+    # `16·(_KRKQ_GEMM_M_TARGET - ndata)` bytes for any model, so the q-tile below cannot collapse.
     nk_b = _krkq_strip_width(; nw, nbandk_max, nmodes, nk_batch_max)
 
     # ----- memory-adaptive q-batch size (§7) -----
@@ -620,23 +622,6 @@ function _loop_eph_over_k_and_kq_gpu(
         @info "GPU outer-k device memory: committed = $(round(committed / 1e9, digits = 2)) GB, " *
               "$(round(per_point / 1e3, digits = 1)) kB/q; q-batch size = $nq_batch_max, " *
               "kR->kq strip nk_b = $nk_b"
-    end
-    # The strip widens `ws.g`, which is spent out of the same per-q budget as the phase tile. At the
-    # shapes where the strip switches on it is a small share of that budget, but a model with a large
-    # `ndata` and a small `nr_ep` inverts the ratio. Report the quantity that actually matters — how
-    # much q-tile the strip cost — by re-asking the accountant at `nk_b = 1`, so this stays right if
-    # another buffer ever becomes strip-sized. Only when the tile is memory-bound (`< nq_batch_cap`):
-    # a user-supplied `nq_batch_max` is not the strip's fault.
-    if nk_b > 1 && nq_batch_max < nq_batch_cap && mpi_isroot()
-        per_point_1, _ = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
-            nq_grid = qpts.n, nk_batch_max, calculators,
-            ndata_epmat = epmat_dev.ndata, nr_epmat = epmat_dev.nr, nk_b = 1, FT)
-        nq_batch_1 = plan_batch(backend, per_point_1, committed, nq_batch_cap; warn = false)
-        if nq_batch_max * 2 < nq_batch_1
-            @warn "GPU outer-k: the kR->kq strip (nk_b = $nk_b) more than halved the q-tile " *
-                  "($nq_batch_1 -> $nq_batch_max of $nkq k+q). Lower `nk_outer_batch_max` (it " *
-                  "clamps nk_b) if this run is slower than one with nk_b = 1."
-        end
     end
 
     # ----- persistent workspace (allocated once, reused across all (k, q)) -----
@@ -660,6 +645,7 @@ function _loop_eph_over_k_and_kq_gpu(
     # allocated per call. Sized for the max batch width `nq_batch_max`; only the first `nq_batch`
     # columns are used for a partial final batch. `g` holds a whole strip of `nk_b` k; `g_strip5`
     # is its (nw, nbandk, nmodes, nk_b, nq) view, from which each k takes a q-strided 4-D slice.
+    # Only at `nk_b > 1`: see `_strip_g_slice` for why `nk_b = 1` slices the 2-D buffer instead.
     kRkq_ws = KRtoKQWorkspace(epmat_dev.op_r, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max; nk_b)
     g_strip5 = reshape(kRkq_ws.g, nw, nbandk_max, nmodes, nk_b, nq_batch_max)
 
@@ -848,7 +834,7 @@ function _loop_eph_over_k_and_kq_gpu(
                     # nk_b > 1 - which only the fused kernel reads, hence the `_krkq_strip_width` gate.
                     kloc = ik_ind - sstart + 1
                     eph_apply_rotations!(view(epkq_dev, :, :, :, rng_q),
-                        view(g_strip5, :, :, :, kloc, rng_q), ukqs_used,
+                        _strip_g_slice(kRkq_ws.g, g_strip5, kloc, rng_q), ukqs_used,
                         view(uphs_dev, :, :, rng_q), view(kRkq_ws.tmp, :, :, rng_q);
                         g2_out = view(g2_dev, :, :, :, rng_q), ωq = view(ωq_dev, :, rng_q))
 

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -688,20 +688,23 @@ function _loop_eph_over_k_and_kq_gpu(
 
     # Grid coordinates as (3 × n) real device matrices, uploaded once. Both phase builds below read
     # them directly, so nothing on the phase path is staged on the host or copied H2D inside the loop.
-    xk_dev  = _kpoints_to_device_matrix(backend, kpts)
+    # Negated once here rather than conjugating the phase tile every batch: the convention needs
+    # conj(exp(2πi R_p·x_k)) = exp(2πi R_p·(−x_k)), and the two are bitwise identical (FP negation is
+    # exact, and `cispi` is exactly symmetric). This is the only consumer of the k coordinates.
+    mxk_dev = -_kpoints_to_device_matrix(backend, kpts)
     xkq_dev = _kpoints_to_device_matrix(backend, kqpts)
 
     # The two Fourier phase matrices of the k+q convention (see `get_eph_RR_to_kR_batched!`):
-    #   P_mk [ip, k] = exp(2πi R_p · x_k)      — conjugated into g(k, R_ep) once per outer-k batch
-    #   P_mkq[ip, j] = exp(2πi R_p · x_{k+q_j}) — the kR->kq phase, INDEPENDENT of the outer k
-    # so one built P_mkq tile serves every k of the batch. That reuse factor is `nk_batch`, i.e.
+    #   P_mk[ip, k] = exp(2πi R_p · (−x_k))    — folded into g(k, R_ep) once per outer-k batch
+    #   P_kq[ip, j] = exp(2πi R_p · x_{k+q_j}) — the kR->kq phase, INDEPENDENT of the outer k
+    # so one built P_kq tile serves every k of the batch. That reuse factor is `nk_batch`, i.e.
     # `nk_outer_batch_max`: lowering that cap shrinks this saving proportionally.
     # Not a `TiledDeviceOutput`: that tiles the OUTPUT side over the outer-state axis and owns a
-    # host mirror plus a per-batch D2H, whereas P_mkq is an input-side, q-indexed,
+    # host mirror plus a per-batch D2H, whereas P_kq is an input-side, q-indexed,
     # write-once-read-many device buffer with no host side and no D2H at all.
     irvecp_mat = _irvec_to_device_matrix(model.epmat.irvec_next, epmat_dev, FT)
     P_mk  = alloc(backend, Complex{FT}, nr_ep, nk_batch_max)
-    P_mkq = alloc(backend, Complex{FT}, nr_ep, nq_batch_max)
+    P_kq = alloc(backend, Complex{FT}, nr_ep, nq_batch_max)
     # Defensive: only columns 1:nk_batch are rewritten per batch, so a partial final batch leaves the
     # tail columns holding whatever the previous batch wrote. Nothing reads them — the k loop runs
     # `1:nk_batch` — and 1 is the identity of the convention multiply, so the padded (never-read)
@@ -762,12 +765,9 @@ function _loop_eph_over_k_and_kq_gpu(
         end
 
         # One batched RR->kR over the whole batch: g(k, R_ep) for all k in the batch, stored in the
-        # k+q convention (multiplied by conj(P_mk)) so the kR->kq phase below is k-independent.
-        # `get_eph_RR_to_kR_batched!` multiplies by whatever it is handed, so conjugate here.
-        @views begin
-            fourier_phase!(P_mk[:, 1:nk_batch], irvecp_mat, xk_dev[:, iks_batch])
-            P_mk[:, 1:nk_batch] .= conj.(P_mk[:, 1:nk_batch])
-        end
+        # k+q convention (multiplied by P_mk, the phase at −x_k) so the kR->kq phase below is
+        # k-independent.
+        @views fourier_phase!(P_mk[:, 1:nk_batch], irvecp_mat, mxk_dev[:, iks_batch])
         get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat, ks_batch, uks_dev;
             additional_phase = P_mk)
 
@@ -785,7 +785,7 @@ function _loop_eph_over_k_and_kq_gpu(
             # kR->kq phase for this q-tile, built ONCE and reused by every k of the outer-k batch —
             # the reason the q-tile loop sits outside the k loop. In the k+q convention it reads
             # x_{k+q} directly, so it is a contiguous slice of the fixed k+q list.
-            @views fourier_phase!(P_mkq[:, rng_q], irvecp_mat, xkq_dev[:, qstart:qend])
+            @views fourier_phase!(P_kq[:, rng_q], irvecp_mat, xkq_dev[:, qstart:qend])
             # k+q rotations: a contiguous slice of the prebuilt device stack (no copy). The payload's
             # k+q index list is the plain range of this tile — `isbits`, so it rides in the kernel
             # launch parameters instead of costing a device buffer and a global load per thread.
@@ -813,7 +813,7 @@ function _loop_eph_over_k_and_kq_gpu(
                 # One batched Wannier->Bloch over this tile's q: ep_kq(q) (nw, nbandk_max, nmodes),
                 # folding g2 = |ep|²/(2ω) into the same fused kernel pass.
                 get_eph_kR_to_kq_batched!(view(epkq_dev, :, :, :, rng_q),
-                    view(ep_ekpR_all, :, :, ik_ind), view(P_mkq, :, rng_q),
+                    view(ep_ekpR_all, :, :, ik_ind), view(P_kq, :, rng_q),
                     view(uphs_dev, :, :, rng_q), ukqs_used; ws = kRkq_ws,
                     g2_out = view(g2_dev, :, :, :, rng_q), ωq = view(ωq_dev, :, rng_q))
 

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -478,12 +478,15 @@ end
 #  GPU calculator loop (see README_GPU.md).
 #
 #  This mirrors `_loop_eph_over_k_and_kq` but moves the e-ph Wannier->Bloch interpolation
-#  onto the device using the batched drivers from `wannier_to_bloch_batched.jl`. The code here is
-#  backend-generic: it only calls `to_device` and the generic batched drivers, so no CUDA
-#  code lives in the base package (the device methods are provided by the CUDA extension). It
-#  is a separate function from the CPU `_loop_eph_over_k_and_kq` because its control flow —
-#  batched over k-batches and q-batches with device staging — differs from the per-(k,q) CPU loop,
-#  not because it holds any device-specific code.
+#  onto the device using the batched drivers from `wannier_to_bloch_batched.jl`. No CUDA code lives
+#  in the base package: the loop only calls `to_device` and the generic batched drivers, and the
+#  device methods are provided by the CUDA extension. That is not the same as running on any
+#  backend — at `nk_b > 1` the per-k `g` slice handed to `eph_apply_rotations!` is strided in q, and
+#  only the extension's fused kernel reads such an operand (the generic two-GEMM method asserts a
+#  dense `g`). The loop has one call site, inside the `use_gpu` branch, so a CPU backend never
+#  reaches that assert. It is a separate function from the CPU `_loop_eph_over_k_and_kq` because its
+#  control flow — batched over k-batches and q-batches with device staging — differs from the
+#  per-(k,q) CPU loop.
 #
 #  Supported (all handled upstream in the shared `_setup`, so this loop itself is agnostic to them):
 #    * energy windows (window_k / window_kq): the k side carries only its in-window bands, the
@@ -513,53 +516,27 @@ end
 #  small-`nw` regime; a full-band large-`nw` run gets `nk_b = 1` and the loop as it was. k are
 #  visited in the same order and everything below the GEMM is per-k, so the payload stream and the
 #  bracket order are unchanged.
-# ---- per-(k-strip, q-tile) `iq` index build ------------------------------------------------------
+# ---- per-(k, q-tile) `iq` index build ------------------------------------------------------------
 #
-# `prepare_iqs!(builder, iqs_dev, iks, kloc0, qstart, nq)` fills `iqs_dev[1:nq, kloc0 + i - 1]` with
-# the index into `qpts` of `x_{k+q} - x_k` for the `i`-th outer k of `iks` and every k+q of the tile
-# `qstart .+ (0:nq-1)`, leaving the device buffer ready for the phonon gather. The builder owns its
-# host staging matrix and ends with the H2D.
-#
-# The staging is per k-STRIP (`nk_b` columns), not per k: one stream drain per strip instead of
-# `nk_b` of them, for `nk_b * nq_batch_max * 8` B of host and device staging (12.7 MB at Cu nk=150).
-# That drain count is most of what this block costs — see `plans/qindex_build_threaded_vs_device.md`.
-# At `nk_b == 1` it degenerates to per-k staging exactly.
-struct SerialHostIqBuilder{GK}
-    qpts     :: GK
-    xkqs_int :: Matrix{Int}   # (3, nkq), reduced into 0:ngrid[d]-1
-    xks_int  :: Matrix{Int}   # (3, nk),  reduced into 0:ngrid[d]-1
-    iqs_host :: Matrix{Int}   # (nq_batch_max, nk_b) host staging
-end
-
-function prepare_iqs!(b::SerialHostIqBuilder, iqs_dev, iks, kloc0::Int, qstart::Int, nq::Int)
-    _fill_iqs_serial!(b.iqs_host, b.qpts, b.xkqs_int, b.xks_int, iks, kloc0, qstart, nq)
-    # One contiguous 5-arg H2D of the columns just written (a host↔device SubArray copy would fall
-    # back to scalar indexing). Full columns: the rows past `nq` are never read by the gather.
-    copyto!(iqs_dev, size(b.iqs_host, 1) * (kloc0 - 1) + 1,
-            b.iqs_host, size(b.iqs_host, 1) * (kloc0 - 1) + 1, size(b.iqs_host, 1) * length(iks))
-    iqs_dev
-end
-
-# The build itself, as a standalone function so the `iks`/`qstart`/`nq` it closes over are typed
-# arguments rather than `Core.Box`-wrapped captures of the enclosing loop bodies.
-function _fill_iqs_serial!(iqs, qpts, xkqs_int, xks_int, iks, kloc0, qstart, nq)
+# Fill `iqs[1:nq]` with the index into `qpts` of `x_{k+q} - x_k` for outer k `ik` and every k+q of
+# the tile `qstart .+ (0:nq-1)`; the caller uploads it for the device phonon gather. A standalone
+# function so the `ik`/`qstart`/`nq` it works on are typed arguments rather than `Core.Box`-wrapped
+# captures of the three enclosing loop bodies.
+function _fill_iqs!(iqs, qpts, xkqs_int, xks_int, ik, qstart, nq)
     ng1, ng2, ng3 = qpts.ngrid
-    for (i, ik) in enumerate(iks)
-        kloc = kloc0 + i - 1
-        k1, k2, k3 = xks_int[1, ik], xks_int[2, ik], xks_int[3, ik]
-        for j in 1:nq
-            ikq = qstart + j - 1
-            # Integer grid-coord hash for iq (no Float64 normalize/_hash_xk per pair). Both operands
-            # are pre-reduced into 0:ng-1 at setup, so the fold is a compare-and-add.
-            h1 = _wrap_reduced(xkqs_int[1, ikq] - k1, ng1)
-            h2 = _wrap_reduced(xkqs_int[2, ikq] - k2, ng2)
-            h3 = _wrap_reduced(xkqs_int[3, ikq] - k3, ng3)
-            hash = (h1 * ng2 + h2) * ng3 + h3
-            iq = _ik_from_hash(qpts, hash)
-            # 0 = miss on either index.
-            (iq < 1 || iq > qpts.n) && throw(ArgumentError("kq - k = q point not found in precomputed qpts"))
-            iqs[j, kloc] = iq
-        end
+    k1, k2, k3 = xks_int[1, ik], xks_int[2, ik], xks_int[3, ik]
+    for j in 1:nq
+        ikq = qstart + j - 1
+        # Integer grid-coord hash for iq (no Float64 normalize/_hash_xk per pair). Both operands
+        # are pre-reduced into 0:ng-1 at setup, so the fold is a compare-and-add.
+        h1 = _wrap_reduced(xkqs_int[1, ikq] - k1, ng1)
+        h2 = _wrap_reduced(xkqs_int[2, ikq] - k2, ng2)
+        h3 = _wrap_reduced(xkqs_int[3, ikq] - k3, ng3)
+        hash = (h1 * ng2 + h2) * ng3 + h3
+        iq = _ik_from_hash(qpts, hash)
+        # 0 = miss on either index.
+        (iq < 1 || iq > qpts.n) && throw(ArgumentError("kq - k = q point not found in precomputed qpts"))
+        iqs[j] = iq
     end
     iqs
 end
@@ -754,16 +731,15 @@ function _loop_eph_over_k_and_kq_gpu(
     irvecp_mat = _irvec_matrix(model.epmat.irvec_next, epmat_dev, FT)
     P_k  = similar(epmat_dev.op_r, Complex{FT}, nr_ep, nk_batch_max)
     P_kq = similar(epmat_dev.op_r, Complex{FT}, nr_ep, nq_batch_max)
-    # Defensive: only columns 1:nk_batch are rewritten per batch. `nk_batch_max = min(…, nk)` makes
-    # the first batch full, so the tail is in practice always written, but 1 is the identity of the
-    # convention multiply and keeps a padded (never-read) slice of ep_ekpR_all meaningful.
+    # Defensive: only columns 1:nk_batch are rewritten per batch, so a partial final batch leaves the
+    # tail columns holding whatever the previous batch wrote. Nothing reads them — the strip loop runs
+    # `1:nk_b:nk_batch` — and 1 is the identity of the convention multiply, so the padded (never-read)
+    # slice of ep_ekpR_all stays meaningful whether or not it has been written yet.
     fill!(P_k, 1)
 
-    # `iq` index staging, one k-STRIP wide (see `prepare_iqs!`). Filled to 1 so that the rows past a
-    # partial q-tile's width — copied along with the rest, never read by the gather — are a valid
-    # index rather than garbage.
-    iqs_strip     = fill(1, nq_batch_max, nk_b)
-    iqs_strip_dev = similar(epmat_dev.op_r, Int, nq_batch_max, nk_b)
+    # `iq` index staging for one (k, q-tile).
+    iqs_batch     = Vector{Int}(undef, nq_batch_max)
+    iqs_batch_dev = similar(epmat_dev.op_r, Int, nq_batch_max)
 
     # Integer grid-coord hash for iq, replacing the per-(k,q) float normalize + `_hash_xk`:
     #   hc_i = fold(xkqs_int[i,ikq] - xks_int[i,ik], ng_i),  hash = (hc1*ng2 + hc2)*ng3 + hc3,
@@ -784,8 +760,6 @@ function _loop_eph_over_k_and_kq_gpu(
     for ik in 1:nk
         xks_int[:, ik] .= _grid_coords_reduced(kpts.vectors[ik], qpts.ngrid, zero(Vec3{FT}))
     end
-
-    iq_builder = SerialHostIqBuilder(qpts, xkqs_int, xks_int, iqs_strip)
 
     ωq_dev    = similar(epmat_dev.op_r, FT, nmodes, nq_batch_max)
     g2_dev    = similar(epmat_dev.op_r, FT, nw, nbandk_max, nmodes, nq_batch_max)
@@ -858,25 +832,24 @@ function _loop_eph_over_k_and_kq_gpu(
                 eph_kR_to_kq_fourier!(view(kRkq_ws.g, 1:ndata_ekpR*nks, rng_q),
                     view(ep_ekpR_2d, rows, :), view(P_kq, :, rng_q))
 
-                # Build this (strip, tile)'s q-index lists; the phonon eigenvectors `u` and
-                # frequencies `e` are gathered on the device by iq below. One entry and one stream
-                # drain for the whole strip.
-                prepare_iqs!(iq_builder, iqs_strip_dev,
-                    iks_batch[sstart:(sstart + nks - 1)], 1, qstart, nq_batch)
-
                 for ik_ind in sstart:(sstart + nks - 1)
                     ik = iks_batch[ik_ind]
                     kloc = ik_ind - sstart + 1
 
-                    # Gather this tile's phonon eigenvectors/frequencies on the device by iq
+                    # Build this (k, tile)'s q-index list (host-side integers only), then gather this
+                    # tile's phonon eigenvectors/frequencies on the device by iq
                     # (uphs_dev[:,:,j] = uph_all_dev[:,:,iq[j]]); ωq gathered here too so the fused kernel
                     # can fold g2 = |ep|²/(2ω) in the same pass. Everything below runs at width nq_batch
-                    # via views into the nq_batch_max-sized buffers, so there is no padded tail. This k's
-                    # indices are column `kloc` of the strip staging — contiguous, so no strided read.
+                    # via views into the nq_batch_max-sized buffers, so there is no padded tail.
+                    # H2D copy of just the first nq_batch indices (5-arg contiguous copy — copying a host↔
+                    # device SubArray view instead would fall back to scalar indexing); the device gather
+                    # then reads only `view(iqs_batch_dev, rng_q)`, so the untouched tail is never used.
                     # `@inbounds`: bounds-checking a device INDEX ARRAY costs a Bool map+reduce kernel and
-                    # a D2H round trip of the result per (k, tile); `iq` is already validated where it is
-                    # built (the guard in `_fill_iqs_serial!`), so the device-side re-check is pure overhead.
-                    iqs_used = view(iqs_strip_dev, rng_q, kloc)
+                    # a D2H round trip of the result per (k, tile); `iq` is already validated on the host
+                    # (the guard in `_fill_iqs!`), so the device-side re-check is pure overhead.
+                    _fill_iqs!(iqs_batch, qpts, xkqs_int, xks_int, ik, qstart, nq_batch)
+                    copyto!(iqs_batch_dev, 1, iqs_batch, 1, nq_batch)
+                    iqs_used = view(iqs_batch_dev, rng_q)
                     @inbounds @views uphs_dev[:, :, rng_q] .= uph_all_dev[:, :, iqs_used]
                     @inbounds @views ωq_dev[:, rng_q]      .= ωq_all_dev[:, iqs_used]
 

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -639,28 +639,28 @@ function _loop_eph_over_k_and_kq_gpu(
     # ----- persistent workspace (allocated once, reused across all (k, q)) -----
     # All device staging is sized to the full batch and used as plain CuArrays (not
     # batch-sliced views), so the batched drivers' reshape/cuBLAS calls stay on dense arrays.
-    # `proto` is the `similar` template every device buffer below is allocated from.
-    proto = epmat_dev.op_r
+    # Every buffer below comes from `alloc(backend, ...)`, so the backend is the single authority on
+    # where "device" is.
 
     # RR->kR over a batch of `nk_batch_max` outer-k at once: one batched kernel per batch instead of one
     # launch-bound single-k call per k. `ep_ekpR_all` holds g(k, R_ep) for the whole batch; the inner
     # kR->kq driver reads each k's slice `ep_ekpR_all[:, :, ik_ind]` directly.
-    uks_dev     = similar(proto, Complex{FT}, nw, nbandk_max, nk_batch_max)
+    uks_dev     = alloc(backend, Complex{FT}, nw, nbandk_max, nk_batch_max)
     uks_host    = Array{Complex{FT}}(undef, nw, nbandk_max, nk_batch_max)
-    ep_ekpR_all = similar(proto, Complex{FT}, ndata_ekpR, nr_ep, nk_batch_max)
+    ep_ekpR_all = alloc(backend, Complex{FT}, ndata_ekpR, nr_ep, nk_batch_max)
     ks_batch     = Vector{Vec3{FT}}(undef, nk_batch_max)
 
-    uphs_dev = similar(proto, Complex{FT}, nmodes, nmodes, nq_batch_max)
-    epkq_dev = similar(proto, Complex{FT}, nw, nbandk_max, nmodes, nq_batch_max)
+    uphs_dev = alloc(backend, Complex{FT}, nmodes, nmodes, nq_batch_max)
+    epkq_dev = alloc(backend, Complex{FT}, nw, nbandk_max, nmodes, nq_batch_max)
 
     # In-place scratch for the per-k kR->kq driver (g / tmp), reused across all (k, q) so the
     # driver allocates nothing per call. Sized for the max batch width `nq_batch_max`; the driver
     # uses the first `nq_batch` columns for a partial final batch.
-    kRkq_ws = KRtoKQWorkspace(proto, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max)
+    kRkq_ws = KRtoKQWorkspace(epmat_dev.op_r, ndata_ekpR, nw, nbandk_max, nmodes, nq_batch_max)
 
     # Collect the k+q electron eigenvectors on the host and copy to the device once (they do not
     # depend on the outer k), reused across all k. Each q-batch reads a contiguous slice directly.
-    ukqs_all_dev = similar(proto, Complex{FT}, nw, nw, nkq)
+    ukqs_all_dev = alloc(backend, Complex{FT}, nw, nw, nkq)
     let ukqs_all_host = Array{Complex{FT}}(undef, nw, nw, nkq)
         for ikq in 1:nkq
             @views ukqs_all_host[:, :, ikq] .= el_kq_save[ikq].u_full
@@ -674,8 +674,8 @@ function _loop_eph_over_k_and_kq_gpu(
     # `_compute_phonon_states_gpu!` built them on the device before scattering them into per-q
     # `PhononState`s — so this gather + H2D undoes a D2H. Have the setup hand `use_gpu` the device
     # stacks directly and drop this block; see the TODO at `_scatter_phonon_states!`.
-    uph_all_dev = similar(proto, Complex{FT}, nmodes, nmodes, qpts.n)
-    ωq_all_dev  = similar(proto, FT, nmodes, qpts.n)
+    uph_all_dev = alloc(backend, Complex{FT}, nmodes, nmodes, qpts.n)
+    ωq_all_dev  = alloc(backend, FT, nmodes, qpts.n)
     let uph_all_host = Array{Complex{FT}}(undef, nmodes, nmodes, qpts.n),
         ωq_all_host  = Array{FT}(undef, nmodes, qpts.n)
         for iq in 1:qpts.n
@@ -700,8 +700,8 @@ function _loop_eph_over_k_and_kq_gpu(
     # host mirror plus a per-batch D2H, whereas P_kq is an input-side, q-indexed,
     # write-once-read-many device buffer with no host side and no D2H at all.
     irvecp_mat = _irvec_to_device_matrix(model.epmat.irvec_next, epmat_dev, FT)
-    P_k  = similar(proto, Complex{FT}, nr_ep, nk_batch_max)
-    P_kq = similar(proto, Complex{FT}, nr_ep, nq_batch_max)
+    P_k  = alloc(backend, Complex{FT}, nr_ep, nk_batch_max)
+    P_kq = alloc(backend, Complex{FT}, nr_ep, nq_batch_max)
     # Defensive: only columns 1:nk_batch are rewritten per batch, so a partial final batch leaves the
     # tail columns holding whatever the previous batch wrote. Nothing reads them — the k loop runs
     # `1:nk_batch` — and 1 is the identity of the convention multiply, so the padded (never-read)
@@ -710,7 +710,7 @@ function _loop_eph_over_k_and_kq_gpu(
 
     # `iq` index staging for one (k, q-tile).
     iqs_batch     = Vector{Int}(undef, nq_batch_max)
-    iqs_batch_dev = similar(proto, Int, nq_batch_max)
+    iqs_batch_dev = alloc(backend, Int, nq_batch_max)
 
     # Integer grid-coord hash for iq, replacing the per-(k,q) float normalize + `_hash_xk`:
     #   hc_i = fold(xkqs_int[i,ikq] - xks_int[i,ik], ng_i),  hash = (hc1*ng2 + hc2)*ng3 + hc3,
@@ -732,8 +732,8 @@ function _loop_eph_over_k_and_kq_gpu(
         xks_int[:, ik] .= _grid_coords_reduced(kpts.vectors[ik], qpts.ngrid, zero(Vec3{FT}))
     end
 
-    ωq_dev    = similar(proto, FT, nmodes, nq_batch_max)
-    g2_dev    = similar(proto, FT, nw, nbandk_max, nmodes, nq_batch_max)
+    ωq_dev    = alloc(backend, FT, nmodes, nq_batch_max)
+    g2_dev    = alloc(backend, FT, nw, nbandk_max, nmodes, nq_batch_max)
 
     for kstart in 1:nk_batch_max:nk
         kend = min(kstart + nk_batch_max - 1, nk)

--- a/src/calculator/run_eph_over_k_and_q.jl
+++ b/src/calculator/run_eph_over_k_and_q.jl
@@ -151,7 +151,7 @@ function _setup_eph_over_k_and_q(
         end
         el_kq_save = _compute_electron_states_kq(model, kqpts, kqpts_irr, ik_to_ikirr_isym_kq,
             symmetry, el_kq_from_unfolding, window_kq;
-            quantities=["eigenvalue", "eigenvector", "velocity", "position"], fourier_mode)
+            quantities=["eigenvalue", "eigenvector", "velocity", "position"], fourier_mode, verbosity)
     else
         kqpts = nothing
         el_kq_save = nothing

--- a/src/calculator/run_eph_over_q_and_k.jl
+++ b/src/calculator/run_eph_over_q_and_k.jl
@@ -610,15 +610,9 @@ function estimate_device_memory(model::Model{FT}; nk::Integer, nkq::Integer,
     if model.epmat_outer_momentum == "el"
         nr_ep = length(get_next_wannier_object(model.epmat).irvec)
         nk_batch = min(Int(nk_outer_batch_max), Int(nk))
-        # Apply the loop's kR→kq strip rule so the two stay in step. Note this estimate is full-band
-        # by convention (`nbandk_max = nw`, see the docstring), so a WINDOWED run picks a different
-        # `nk_b` than is computed here — but the strip term is `16·ndata·nk_b`, which is
-        # `≈ 16·max(ndata, _KRKQ_GEMM_M_TARGET)` at either shape, and the full-band `ndata` is the
-        # larger of the two, so the estimate does not under-report it.
-        nk_b = _krkq_strip_width(; nw, nbandk_max = nw, nmodes, nk_batch_max = nk_batch)
         per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max = nw, nmodes, nr_ep, nk, nkq,
             nq_grid = nkq, nk_batch_max = nk_batch, calculators,
-            ndata_epmat = model.epmat.ndata, nr_epmat = model.epmat.nr, nk_b, FT)
+            ndata_epmat = model.epmat.ndata, nr_epmat = model.epmat.nr, FT)
         cap = nq_batch_max === nothing ? Int(nkq) : min(Int(nq_batch_max), Int(nkq))
         loop = :outer_k
     elseif model.epmat_outer_momentum == "ph"

--- a/src/calculator/run_eph_over_q_and_k.jl
+++ b/src/calculator/run_eph_over_q_and_k.jl
@@ -610,8 +610,11 @@ function estimate_device_memory(model::Model{FT}; nk::Integer, nkq::Integer,
     if model.epmat_outer_momentum == "el"
         nr_ep = length(get_next_wannier_object(model.epmat).irvec)
         nk_batch = min(Int(nk_outer_batch_max), Int(nk))
-        # The loop derives its kR→kq strip width from the same rule, so apply it here too or the
-        # estimate would under-report `kRkq_ws.g`.
+        # Apply the loop's kR→kq strip rule so the two stay in step. Note this estimate is full-band
+        # by convention (`nbandk_max = nw`, see the docstring), so a WINDOWED run picks a different
+        # `nk_b` than is computed here — but the strip term is `16·ndata·nk_b`, which is
+        # `≈ 16·max(ndata, _KRKQ_GEMM_M_TARGET)` at either shape, and the full-band `ndata` is the
+        # larger of the two, so the estimate does not under-report it.
         nk_b = _krkq_strip_width(; nw, nbandk_max = nw, nmodes, nk_batch_max = nk_batch)
         per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max = nw, nmodes, nr_ep, nk, nkq,
             nq_grid = nkq, nk_batch_max = nk_batch, calculators,

--- a/src/calculator/run_eph_over_q_and_k.jl
+++ b/src/calculator/run_eph_over_q_and_k.jl
@@ -610,7 +610,7 @@ function estimate_device_memory(model::Model{FT}; nk::Integer, nkq::Integer,
     if model.epmat_outer_momentum == "el"
         nr_ep = length(get_next_wannier_object(model.epmat).irvec)
         nk_batch = min(Int(nk_outer_batch_max), Int(nk))
-        per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max = nw, nmodes, nr_ep, nkq,
+        per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max = nw, nmodes, nr_ep, nk, nkq,
             nq_grid = nkq, nk_batch_max = nk_batch, calculators,
             ndata_epmat = model.epmat.ndata, nr_epmat = model.epmat.nr, FT)
         cap = nq_batch_max === nothing ? Int(nkq) : min(Int(nq_batch_max), Int(nkq))

--- a/src/calculator/run_eph_over_q_and_k.jl
+++ b/src/calculator/run_eph_over_q_and_k.jl
@@ -610,9 +610,12 @@ function estimate_device_memory(model::Model{FT}; nk::Integer, nkq::Integer,
     if model.epmat_outer_momentum == "el"
         nr_ep = length(get_next_wannier_object(model.epmat).irvec)
         nk_batch = min(Int(nk_outer_batch_max), Int(nk))
+        # The loop derives its kR→kq strip width from the same rule, so apply it here too or the
+        # estimate would under-report `kRkq_ws.g`.
+        nk_b = _krkq_strip_width(; nw, nbandk_max = nw, nmodes, nk_batch_max = nk_batch)
         per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max = nw, nmodes, nr_ep, nk, nkq,
             nq_grid = nkq, nk_batch_max = nk_batch, calculators,
-            ndata_epmat = model.epmat.ndata, nr_epmat = model.epmat.nr, FT)
+            ndata_epmat = model.epmat.ndata, nr_epmat = model.epmat.nr, nk_b, FT)
         cap = nq_batch_max === nothing ? Int(nkq) : min(Int(nq_batch_max), Int(nkq))
         loop = :outer_k
     elseif model.epmat_outer_momentum == "ph"

--- a/src/calculator/run_eph_over_q_and_k.jl
+++ b/src/calculator/run_eph_over_q_and_k.jl
@@ -199,7 +199,7 @@ function _setup_eph_over_q_and_k(
         end
         el_kq_save = _compute_electron_states_kq(model, kqpts, kqpts_irr, ik_to_ikirr_isym_kq,
             symmetry, el_kq_from_unfolding, window_kq;
-            quantities=["eigenvalue", "eigenvector", "velocity", "position"], fourier_mode)
+            quantities=["eigenvalue", "eigenvector", "velocity", "position"], fourier_mode, verbosity)
     else
         kqpts = nothing
         el_kq_save = nothing

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -252,12 +252,18 @@ end
 # more tightly. Exceeding either budget selects the Dict implementation of the same map: slower,
 # O(number of points) memory, and identical results.
 #
-# The index budget is a soft cap, not a ceiling: `_use_dense_index` waives it whenever the table
-# cannot exceed the Dict it would fall back to (`prod(ngrid) <= 4n`, which every full grid
-# satisfies at any size), so the retained index can be larger than 256 MB. It is still bounded, and
-# in the waiver regime by the Dict's own size — `8·prod <= 32n` bytes against the Dict's ~34n. A
-# `GridKpoints` keeps exactly one of the two indices, so its index cost is never worse than the
-# Dict alone would have been, and above the cap it is the Dict.
+# The index budget is a soft cap, not a ceiling. A `GridKpoints` keeps at most one of the two
+# indices, but how far the dense table can exceed the Dict it replaces depends on which clause of
+# `_use_dense_index` admitted it (table 8 B per grid node, Dict ~34 B per point):
+#   - waiver, `prod <= 4n` (includes every full grid at any size): `8·prod <= 32n` bytes against
+#     ~34n, so the table is never the bigger of the two. This is the clause that lets the retained
+#     index exceed 256 MB, and it is safe precisely because the Dict would have cost more.
+#   - density band, `4n < prod <= 8n`: up to `64n` bytes against ~34n, so up to ~1.9x the Dict —
+#     bounded in absolute terms by the 256 MB cap.
+#   - node floor, `prod <= 2^20`: the ratio is unbounded (5000 points on a (101,101,101) grid is an
+#     8.2 MB table for a ~170 kB Dict, ~48x), which is acceptable only because the floor itself
+#     bounds the table at 8 MB. That absolute bound is why this clause may ignore density at all.
+# Outside the waiver, exceeding the cap selects the Dict.
 const _DEDUP_TABLE_MAX_BYTES = 8 * 1024^3    # transient in `combine_kpoint_grids`
 const _DENSE_INDEX_MAX_BYTES = 256 * 1024^2  # retained in `GridKpoints._dense_hash_to_ik`
 
@@ -407,8 +413,8 @@ Additional arguments for `GridKpoints`:
 - `ngrid`: size of the grid
 - `shift`: shift of the grid from (0, 0, 0)
 Both of the following are derived caches of the same `_hash_xk(kpts.vectors[ik], kpts) -> ik` map,
-and exactly one of them is populated (`_use_dense_index` picks which). Read them only through
-`_ik_from_hash`.
+and at most one of them is populated — exactly one when `n > 0`, and `_use_dense_index` picks which;
+an empty `GridKpoints` has neither. Read them only through `_ik_from_hash`.
 - `_dense_hash_to_ik`: a flat `prod(ngrid)` vector indexed by `hash + 1`, where `0` marks a grid
     node that is not a k point. Empty when the grid is too sparse or too large for it.
 - `_xk_hash_to_ik`: the fallback for those grids, a `Dict` of `hash => ik`. Empty when the dense
@@ -457,10 +463,11 @@ end
 # Every construction site that fills all fields goes through this, so the index policy lives in one
 # place: the dense table where `_use_dense_index` allows one, the Dict otherwise, never both. The
 # table is either empty or exactly `prod(ngrid)` long — the length that makes `_ik_from_hash`'s
-# `@inbounds` safe for any hash `_hash_xk` produces. `make_dict` is called only when the Dict is
-# the index that will be kept, so a caller that would have to build one from scratch does not pay
-# for it on a dense grid.
-function _make_grid_kpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift, make_dict) where {T}
+# `@inbounds` safe for any hash `_hash_xk` produces. `make_dict` supplies the Dict and is called
+# only when the Dict is the index that will be kept, so a caller that would have to build one from
+# scratch does not pay for it on a dense grid; callers holding one already can pass `() -> dict`.
+function _make_grid_kpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift,
+                            make_dict = () -> Dict{Int,Int}()) where {T}
     _dense_hash_to_ik = _build_dense_index(n, vectors, ngrid, shift)
     _xk_hash_to_ik = isempty(_dense_hash_to_ik) ? make_dict() : Dict{Int,Int}()
     GridKpoints{T}(n, vectors, weights, ngrid, shift, _xk_hash_to_ik, _dense_hash_to_ik)
@@ -473,7 +480,7 @@ function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T))) 
     prod(Int128.(ngrid)) < typemax(Int) || throw(ArgumentError(
         "prod(ngrid) = $(prod(Int128.(ngrid))) must be < typemax(Int) to avoid overflow in the k-point hash"))
     if kpts.n == 0
-        return _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), ngrid, zero(Vec3{T}), () -> Dict{Int,Int}())
+        return _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), ngrid, zero(Vec3{T}))
     end
 
     shift = mod.(first(kpts.vectors) .* ngrid, 1) ./ ngrid
@@ -493,7 +500,7 @@ end
 GridKpoints(xk::Vec3{T}) where {T <: Real} = GridKpoints(Kpoints(xk))
 
 # Empty GridKpoints (e.g. the receive-side placeholder on non-root ranks before mpi_scatter).
-GridKpoints{T}() where {T} = _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), (0, 0, 0), zero(Vec3{T}), () -> Dict{Int,Int}())
+GridKpoints{T}() where {T} = _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), (0, 0, 0), zero(Vec3{T}))
 
 # Reduce GridKpoints to Kpoints
 Kpoints(k::GridKpoints{T}) where {T} = Kpoints{T}(k.n, k.vectors, k.weights, k.ngrid)

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -278,12 +278,13 @@ that a sweep over consecutive `c3` walks the table sequentially. With those dims
 of a slot is exactly `hash + 1` for the `(c1*ng2 + c2)*ng3 + c3` packing, so this table and
 `GridKpoints._dense_hash_to_ik` share one layout.
 
-Two passes rather than one. Pass 1 only MARKS which slots occur, in a `Vector{UInt8}` instead of
-the `Array{Int,3}` of indices the single-pass version needed: the pair loop's access into the table
-is a random probe, so at 8 B per node it missed cache on nearly every pair, and 1 B per node is 8×
-more of the grid resident (8 MB vs 64 MB at 200³). Marking is also idempotent — every writer stores
-the same 1 — which is what lets the pass be threaded with no synchronization. (A `BitArray` would
-be smaller still but its writes race at word granularity.)
+Two passes rather than one. Pass 1 only MARKS which slots occur, in an `Array{Bool}` instead of the
+`Array{Int}` of indices the single-pass version needed: the pair loop's access into the table is a
+random probe, so at 8 B per node it missed cache on nearly every pair, and `Bool` is 1 B per node,
+putting 8× more of the grid in cache (8 MB vs 64 MB at 200³). Marking is also idempotent — every
+writer stores the same `true` — which is what lets the pass be threaded with no synchronization.
+(A `BitArray` would be smaller still but its writes race at word granularity; `Array{Bool}` stores
+one byte per element, so its writes do not.)
 Pass 2 sweeps the table in index order and emits the points. That discards first-appearance order,
 which is safe because `combine_kpoint_grids` sorts the result on the integer grid coordinates — a
 total order, the points being distinct — and `sort!(::GridKpoints)` renumbers the index afterwards.
@@ -291,13 +292,13 @@ total order, the points being distinct — and `sort!(::GridKpoints)` renumbers 
 function _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) where {T}
     ng1, ng2, ng3 = ngrid_kq
     _check_reduced_coords(BkS, BqS, ngrid_kq)
-    seen = zeros(UInt8, ng3, ng2, ng1)
+    seen = zeros(Bool, ng3, ng2, ng1)
     _mark_kq_pairs!(seen, BkS, BqS, sgn, ng1, ng2, ng3)
 
-    xkqs = Vector{Vec3{T}}(undef, count(!iszero, seen))
+    xkqs = Vector{Vec3{T}}(undef, count(seen))
     ikq = 0
-    @inbounds for c1 in 0:(ng1 - 1), c2 in 0:(ng2 - 1), c3 in 0:(ng3 - 1)
-        iszero(seen[c3 + 1, c2 + 1, c1 + 1]) && continue
+    for c1 in 0:(ng1 - 1), c2 in 0:(ng2 - 1), c3 in 0:(ng3 - 1)
+        seen[c3 + 1, c2 + 1, c1 + 1] || continue
         ikq += 1
         xkqs[ikq] = Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq
     end
@@ -320,9 +321,14 @@ end
 # typed arguments rather than `Core.Box`. Partitioned over `BqS` (the longer list in the k+q use),
 # each chunk sweeping the whole `BkS` — chunks share `seen` but only ever write the same value into
 # a slot, so no synchronization is needed and the result does not depend on the partition.
-function _mark_kq_pairs!(seen::Array{UInt8,3}, BkS::Vector{Vec3{Int}}, BqS::Vector{Vec3{Int}},
+function _mark_kq_pairs!(seen::Array{Bool,3}, BkS::Vector{Vec3{Int}}, BqS::Vector{Vec3{Int}},
                          sgn::Int, ng1::Int, ng2::Int, ng3::Int)
     @threads for iq in eachindex(BqS)
+        # `@inbounds` here is load-bearing for performance, not tidiness: this block runs
+        # nk*nkq ~ 1e9 times. It is safe because `_check_reduced_coords` has already established
+        # `0 <= b < ng` for every entry of both lists, so `_wrap_reduced` returns a value in
+        # `0:ng-1` on all three axes and every index below is in range. It also elides
+        # `_wrap_reduced`'s own `@boundscheck`, whose precondition that guard is what establishes.
         @inbounds begin
             bq = BqS[iq]
             q1, q2, q3 = sgn * bq[1], sgn * bq[2], sgn * bq[3]
@@ -330,7 +336,7 @@ function _mark_kq_pairs!(seen::Array{UInt8,3}, BkS::Vector{Vec3{Int}}, BqS::Vect
                 c1 = _wrap_reduced(bk[1] + q1, ng1)
                 c2 = _wrap_reduced(bk[2] + q2, ng2)
                 c3 = _wrap_reduced(bk[3] + q3, ng3)
-                seen[c3 + 1, c2 + 1, c1 + 1] = 0x01
+                seen[c3 + 1, c2 + 1, c1 + 1] = true
             end
         end
     end
@@ -406,24 +412,13 @@ function combine_kpoint_grids(kpts, qpts, op, ngrid_kq)
     shift_kq = op(shift_k, shift_q)
     sgn = Symbol(op) === :+ ? 1 : -1
 
-    # Work in integer grid coordinates on the common ngrid_kq grid. Each input point is exactly
-    # `shift + b / ngrid` with integer `b = round((xk - shift) * ngrid)`; rescaled onto ngrid_kq
-    # (an integer multiple of both input grids, checked above) the coordinate is `b * (ngrid_kq ÷
-    # ngrid)`. Then `op(k, q)` folded into the cell is plain integer arithmetic
-    #   c = mod(b_k ± b_q, ngrid_kq)  ∈ [0, ngrid_kq),
-    # which is exact and gcd-free (the old Rational arithmetic was the bottleneck), and recomputing
-    # `b` once per point (not per pair) avoids O(nk·nkq) redundant work. `c` identifies the k+q
-    # point uniquely, so it is also the de-duplication key: the Dict path packs it as
-    # `(c1*ng2 + c2)*ng3 + c3` (which happens to equal `_hash_xk(xkq)`), the dense path indexes an
-    # array by it directly.
-    # Both lists are reduced into `0:ng-1` here, once per point, so that the O(nk·nkq) fold is
-    # `_wrap_reduced` (a compare-and-add) rather than three runtime 64-bit integer divisions.
-    fk = ngrid_kq .÷ kpts.ngrid
-    fq = ngrid_kq .÷ qpts.ngrid
-    BkS = [_grid_coords_reduced(Vec3(round.(Int, (xk - shift_k).data .* kpts.ngrid) .* fk), ngrid_kq)
-           for xk in kpts.vectors]
-    BqS = [_grid_coords_reduced(Vec3(round.(Int, (xq - shift_q).data .* qpts.ngrid) .* fq), ngrid_kq)
-           for xq in qpts.vectors]
+    # Integer coordinates on the common grid, in `0:ng-1`. Every input point sits on ngrid_kq exactly
+    # (it is a multiple of both input grids, checked above), so `op(k, q)` is integer arithmetic —
+    # exact, and the reduced operands let the O(nk·nkq) fold be `_wrap_reduced` rather than `mod`.
+    # These coordinates are also the de-duplication key: `_combine_kq_dedup_dict` packs them as
+    # `(c1*ng2 + c2)*ng3 + c3` (which equals `_hash_xk(xkq)`), the dense path indexes by them.
+    BkS = [_grid_coords_reduced(xk, ngrid_kq, shift_k) for xk in kpts.vectors]
+    BqS = [_grid_coords_reduced(xq, ngrid_kq, shift_q) for xq in qpts.vectors]
 
     # Dense lookup table while it fits in the transient budget, Dict above it. The budget is loose
     # because the table lives only until this function returns. `Int128` because `prod(ngrid_kq)`
@@ -613,16 +608,17 @@ mpi_gather_and_scatter(k::GridKpoints, comm::Nothing) = k
     mod(round(Int, (xk[2] - shift[2]) * ngrid[2]), ngrid[2]),
     mod(round(Int, (xk[3] - shift[3]) * ngrid[3]), ngrid[3]))
 
-# Same reduction for coordinates that are already integers on `ngrid` — the `b` lists
-# `combine_kpoint_grids` builds are in that form.
-@inline _grid_coords_reduced(b::Vec3{Int}, ngrid) =
-    Vec3(mod(b[1], ngrid[1]), mod(b[2], ngrid[2]), mod(b[3], ngrid[3]))
-
-# Fold `d` into `0:ng-1` given `-ng < d < 2ng`, which the sum or the difference of two coordinates
-# already reduced by `_grid_coords_reduced` always satisfies. Two compares (cmov) instead of a
-# 64-bit integer division; worth naming only because the per-(k, k+q) pair loops of the GPU drivers
-# run it ~1e9 times per run.
-@inline _wrap_reduced(d::Int, ng::Int) = ifelse(d < 0, d + ng, ifelse(d >= ng, d - ng, d))
+# Fold `d` into `0:ng-1` given `-ng < d < 2ng`, which the sum or difference of two already-reduced
+# coordinates satisfies. Two compares instead of a 64-bit division, worth naming because the pair
+# loops run it ~1e9 times. Outside that range one fold does not reach `0:ng-1` and the result then
+# indexes out of bounds, so it is checked — in a `@boundscheck`, so callers that have established
+# the precondition another way (`_check_reduced_coords`) can say `@inbounds` and pay nothing.
+@inline function _wrap_reduced(d::Int, ng::Int)
+    @boundscheck -ng < d < 2ng || throw(ArgumentError(
+        "_wrap_reduced($d, $ng): argument outside (-ng, 2ng), so one fold cannot reduce it into " *
+        "0:ng-1; reduce both operands with _grid_coords_reduced before folding"))
+    ifelse(d < 0, d + ng, ifelse(d >= ng, d - ng, d))
+end
 
 function _hash_xk(xk::Vec3, ngrid, shift)
     c = _grid_coords_reduced(xk, ngrid, shift)

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -557,11 +557,29 @@ end
 mpi_gather_and_scatter(k::GridKpoints, comm::MPI.Comm) = mpi_scatter(mpi_gather(k, comm), comm)
 mpi_gather_and_scatter(k::GridKpoints, comm::Nothing) = k
 
+# Integer grid coordinates of `xk`, reduced into `0:ngrid[d]-1`: the `c` of `xk ≡ shift + c ./ ngrid`
+# (mod 1). These are what `_hash_xk` packs; they are exposed separately so that a loop over pairs of
+# grid points can reduce both operands ONCE and then fold their sum or difference with
+# `_wrap_reduced`, instead of paying `mod`'s runtime integer division per pair.
+@inline _grid_coords_reduced(xk::Vec3, ngrid, shift) = Vec3(
+    mod(round(Int, (xk[1] - shift[1]) * ngrid[1]), ngrid[1]),
+    mod(round(Int, (xk[2] - shift[2]) * ngrid[2]), ngrid[2]),
+    mod(round(Int, (xk[3] - shift[3]) * ngrid[3]), ngrid[3]))
+
+# Same reduction for coordinates that are already integers on `ngrid` — the `b` lists
+# `combine_kpoint_grids` builds are in that form.
+@inline _grid_coords_reduced(b::Vec3{Int}, ngrid) =
+    Vec3(mod(b[1], ngrid[1]), mod(b[2], ngrid[2]), mod(b[3], ngrid[3]))
+
+# Fold `d` into `0:ng-1` given `-ng < d < 2ng`, which the sum or the difference of two coordinates
+# already reduced by `_grid_coords_reduced` always satisfies. Two compares (cmov) instead of a
+# 64-bit integer division; worth naming only because the per-(k, k+q) pair loops of the GPU drivers
+# run it ~1e9 times per run.
+@inline _wrap_reduced(d::Int, ng::Int) = ifelse(d < 0, d + ng, ifelse(d >= ng, d - ng, d))
+
 function _hash_xk(xk::Vec3, ngrid, shift)
-    xk_int_1 = mod(round(Int, (xk[1] - shift[1]) * ngrid[1]), ngrid[1])
-    xk_int_2 = mod(round(Int, (xk[2] - shift[2]) * ngrid[2]), ngrid[2])
-    xk_int_3 = mod(round(Int, (xk[3] - shift[3]) * ngrid[3]), ngrid[3])
-    (xk_int_1 * ngrid[2] + xk_int_2) * ngrid[3] + xk_int_3
+    c = _grid_coords_reduced(xk, ngrid, shift)
+    (c[1] * ngrid[2] + c[2]) * ngrid[3] + c[3]
 end
 _hash_xk(xk, kpts::GridKpoints) = _hash_xk(xk, kpts.ngrid, kpts.shift)
 

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -510,12 +510,11 @@ function _build_dense_index(n, vectors, ngrid, shift)
 end
 
 # Every construction site that fills all fields goes through this, so the index policy lives in one
-# place: exactly one of the two index maps is built, never both. `make_dict` supplies the Dict and
-# is called only when the Dict is the index that will be kept, so a caller that would have to build
-# one from scratch does not pay for it on a dense grid; callers holding one already can pass
-# `() -> dict`. `index` is forwarded to `_use_dense_index`.
+# place: exactly one of the two index maps is built, never both. Pass `dict` if you already hold the
+# `hash => ik` map; leave it `nothing` and one is built here, but only on the branch that keeps it,
+# so a dense grid never pays for a Dict. `index` is forwarded to `_use_dense_index`.
 function _make_grid_kpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift,
-                            make_dict = () -> Dict{Int,Int}(); index = :auto) where {T}
+                            dict::Union{Nothing,Dict{Int,Int}} = nothing; index = :auto) where {T}
     no_table = zeros(Int, 0, 0, 0)
     if n == 0
         # Nothing to look up, so neither map is built (and `ngrid` may be (0,0,0) here).
@@ -524,7 +523,8 @@ function _make_grid_kpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift,
         GridKpoints{T}(n, vectors, weights, ngrid, shift, Dict{Int,Int}(),
                        _build_dense_index(n, vectors, ngrid, shift))
     else
-        GridKpoints{T}(n, vectors, weights, ngrid, shift, make_dict(), no_table)
+        d = dict === nothing ? Dict(_hash_xk.(vectors, Ref(ngrid), Ref(shift)) .=> 1:n) : dict
+        GridKpoints{T}(n, vectors, weights, ngrid, shift, d, no_table)
     end
 end
 
@@ -554,8 +554,7 @@ function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T)),
         end
     end
 
-    _make_grid_kpoints(kpts.n, kpts.vectors, kpts.weights, ngrid, shift,
-        () -> Dict(_hash_xk.(kpts.vectors, Ref(ngrid), Ref(shift)) .=> 1:kpts.n); index)
+    _make_grid_kpoints(kpts.n, kpts.vectors, kpts.weights, ngrid, shift; index)
 end
 
 GridKpoints(xk::Vec3{T}) where {T <: Real} = GridKpoints(Kpoints(xk))
@@ -737,7 +736,7 @@ function unfold_kpoints(kpts::GridKpoints, symmetry; index = :auto)
     sk_weights ./= length(symmetry)
 
     kpts_unfold = _make_grid_kpoints(length(sk_vectors), sk_vectors, sk_weights, ngrid, shift,
-                                     () -> sk_hash_dict; index)
+                                     sk_hash_dict; index)
     ik_to_ikirr_isym = ik_to_ikirr_isym[sortperm(kpts_unfold)]
     sort!(kpts_unfold)
 
@@ -797,7 +796,7 @@ function fold_kpoints(kpts::GridKpoints, symmetry; index = :auto)
     end
 
     kpts_irr = _make_grid_kpoints(length(vectors_irr), vectors_irr, weights_irr, ngrid, shift,
-                                  () -> hash_dict_irr; index)
+                                  hash_dict_irr; index)
 
     inds = invperm(sortperm(kpts_irr))
     sort!(kpts_irr)
@@ -820,19 +819,16 @@ end
 
 
 """
-    _kpoint_vectors_to_device(backend, kpts::AbstractKpoints) -> (3 × kpts.n) real matrix
+    _kpoints_to_device_matrix(backend, kpts::AbstractKpoints) -> (3 × kpts.n) real matrix
 
 Crystal coordinates of `kpts` as a `(3 × kpts.n)` real matrix on `backend`'s device — the layout the
-batched Fourier phase builds ([`fourier_phase!`](@ref)) read. Assembled on the host from the `Vec3`
-list and moved over once with [`to_device`](@ref).
+batched Fourier phase builds ([`fourier_phase!`](@ref)) read. `Vec3{T}` is three contiguous `T`, so
+the host side is a `reinterpret` view of `kpts.vectors` rather than a copy; [`to_device`](@ref) then
+materializes it on the device. On `CPUBackend` the result therefore **aliases `kpts.vectors`** — it
+is read-only in every caller, but do not write through it.
 """
-function _kpoint_vectors_to_device(backend, kpts::AbstractKpoints{T}) where {T}
-    xk_host = Matrix{T}(undef, 3, kpts.n)
-    for (ik, xk) in enumerate(kpts.vectors)
-        xk_host[:, ik] .= xk
-    end
-    to_device(backend, xk_host)
-end
+_kpoints_to_device_matrix(backend, kpts::AbstractKpoints{T}) where {T} =
+    to_device(backend, reshape(reinterpret(T, kpts.vectors), 3, kpts.n))
 
 
 """

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -319,8 +319,9 @@ end
 
 # Pass 1 of `_combine_kq_dedup_dense`, as a standalone function so the threaded chunks capture
 # typed arguments rather than `Core.Box`. Partitioned over `BqS` (the longer list in the k+q use),
-# each chunk sweeping the whole `BkS` — chunks share `seen` but only ever write the same value into
-# a slot, so no synchronization is needed and the result does not depend on the partition.
+# each chunk sweeping the whole `BkS`. Chunks share `seen` without synchronization: `Bool` is one
+# byte, so a mark is a lone `store i8 1` — no read-modify-write to lose a neighbour's byte, and
+# same-slot writers store the same value. (A `BitArray` would be a word RMW, hence unsafe.)
 function _mark_kq_pairs!(seen::Array{Bool,3}, BkS::Vector{Vec3{Int}}, BqS::Vector{Vec3{Int}},
                          sgn::Int, ng1::Int, ng2::Int, ng3::Int)
     @threads for iq in eachindex(BqS)

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -1,6 +1,7 @@
 # Data and functions for k points
 using MPI
 using Printf
+using Base.Threads: @threads
 
 export Kpoints
 export kpoints_grid
@@ -267,54 +268,96 @@ end
 """
     _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
 De-duplicate `k + sgn * q` over all (k, q) pairs with a dense `prod(ngrid_kq)` table indexed by the
-integer grid coordinates. Returns the unique k+q points in order of first appearance.
+integer grid coordinates. Returns the unique k+q points, in grid order.
 - `BkS`, `BqS`: integer grid coordinates of the k and of the q points on the common `ngrid_kq`
-    grid, i.e. the `b` of `xk = shift + b ./ ngrid_kq`. Built by `combine_kpoint_grids`.
+    grid, i.e. the `b` of `xk = shift + b ./ ngrid_kq`, each already reduced into `0:ng-1` by
+    `combine_kpoint_grids` so that `bk + sgn*bq` needs only `_wrap_reduced`.
 
 The table is `(ng3, ng2, ng1)` indexed `[c3+1, c2+1, c1+1]`, making `c3` the unit-stride index so
 that a sweep over consecutive `c3` walks the table sequentially. With those dims the linear index
 of a slot is exactly `hash + 1` for the `(c1*ng2 + c2)*ng3 + c3` packing, so this table and
 `GridKpoints._dense_hash_to_ik` share one layout.
+
+Two passes rather than one. Pass 1 only MARKS which slots occur, in a `Vector{UInt8}` instead of
+the `Array{Int,3}` of indices the single-pass version needed: the pair loop's access into the table
+is a random probe, so at 8 B per node it missed cache on nearly every pair, and 1 B per node is 8×
+more of the grid resident (8 MB vs 64 MB at 200³). Marking is also idempotent — every writer stores
+the same 1 — which is what lets the pass be threaded with no synchronization. (A `BitArray` would
+be smaller still but its writes race at word granularity.)
+Pass 2 sweeps the table in index order and emits the points. That discards first-appearance order,
+which is safe because `combine_kpoint_grids` sorts the result on the integer grid coordinates — a
+total order, the points being distinct — and `sort!(::GridKpoints)` renumbers the index afterwards.
 """
 function _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) where {T}
     ng1, ng2, ng3 = ngrid_kq
-    xkqs = Vector{Vec3{T}}()
-    xkq_hash_to_ikq = zeros(Int, ng3, ng2, ng1)
-    ikq = 0
-    for bq in BqS
-        for bk in BkS
-            c1 = mod(bk[1] + sgn * bq[1], ng1)
-            c2 = mod(bk[2] + sgn * bq[2], ng2)
-            c3 = mod(bk[3] + sgn * bq[3], ng3)
+    _check_reduced_coords(BkS, BqS, ngrid_kq)
+    seen = zeros(UInt8, ng3, ng2, ng1)
+    _mark_kq_pairs!(seen, BkS, BqS, sgn, ng1, ng2, ng3)
 
-            # Find new k+q points, append to xkq_hash_to_ikq and xkqs
-            if xkq_hash_to_ikq[c3 + 1, c2 + 1, c1 + 1] == 0
-                ikq += 1
-                xkq_hash_to_ikq[c3 + 1, c2 + 1, c1 + 1] = ikq
-                push!(xkqs, Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq)
+    xkqs = Vector{Vec3{T}}(undef, count(!iszero, seen))
+    ikq = 0
+    @inbounds for c1 in 0:(ng1 - 1), c2 in 0:(ng2 - 1), c3 in 0:(ng3 - 1)
+        iszero(seen[c3 + 1, c2 + 1, c1 + 1]) && continue
+        ikq += 1
+        xkqs[ikq] = Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq
+    end
+    xkqs
+end
+
+# The `0:ng-1` precondition of the two de-duplication routines, enforced once over the two lists
+# (O(nk + nkq), microseconds) rather than per pair. Not optional politeness: the pair loops fold
+# with `_wrap_reduced` and write the table under `@inbounds`, so an unreduced coordinate is a
+# segfault rather than a wrong answer.
+function _check_reduced_coords(BkS, BqS, ngrid)
+    for (name, B) in (("BkS", BkS), ("BqS", BqS)), b in B
+        all(0 .<= b.data .< ngrid) || throw(ArgumentError(
+            "$name entry $b is not reduced into 0:ngrid-1 for ngrid = $ngrid; " *
+            "call _grid_coords_reduced on the integer grid coordinates first"))
+    end
+end
+
+# Pass 1 of `_combine_kq_dedup_dense`, as a standalone function so the threaded chunks capture
+# typed arguments rather than `Core.Box`. Partitioned over `BqS` (the longer list in the k+q use),
+# each chunk sweeping the whole `BkS` — chunks share `seen` but only ever write the same value into
+# a slot, so no synchronization is needed and the result does not depend on the partition.
+function _mark_kq_pairs!(seen::Array{UInt8,3}, BkS::Vector{Vec3{Int}}, BqS::Vector{Vec3{Int}},
+                         sgn::Int, ng1::Int, ng2::Int, ng3::Int)
+    @threads for iq in eachindex(BqS)
+        @inbounds begin
+            bq = BqS[iq]
+            q1, q2, q3 = sgn * bq[1], sgn * bq[2], sgn * bq[3]
+            for bk in BkS
+                c1 = _wrap_reduced(bk[1] + q1, ng1)
+                c2 = _wrap_reduced(bk[2] + q2, ng2)
+                c3 = _wrap_reduced(bk[3] + q3, ng3)
+                seen[c3 + 1, c2 + 1, c1 + 1] = 0x01
             end
         end
     end
-    xkqs
+    seen
 end
 
 """
     _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)
 Same map as `_combine_kq_dedup_dense`, keyed by the packed hash in a `Dict` so the memory is
 O(number of unique points) instead of O(prod(ngrid_kq)). Used when the dense table would exceed the
-transient memory budget in `combine_kpoint_grids`.
+transient memory budget in `combine_kpoint_grids`. Same reduced-coordinate precondition, and it
+returns the points in order of FIRST APPEARANCE (a `Dict` has no order to sweep), where the dense
+path returns them in grid order — `combine_kpoint_grids` sorts either, so the two agree as sets.
 """
 function _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) where {T}
     ng1, ng2, ng3 = ngrid_kq
+    _check_reduced_coords(BkS, BqS, ngrid_kq)
     xkqs = Vector{Vec3{T}}()
     cs = Vector{NTuple{3,Int}}()  # integer coords per stored point, for the collision guard
     xkq_hash_to_ikq = Dict{Int, Int}()
     ikq = 0
     for bq in BqS
+        q1, q2, q3 = sgn * bq[1], sgn * bq[2], sgn * bq[3]
         for bk in BkS
-            c1 = mod(bk[1] + sgn * bq[1], ng1)
-            c2 = mod(bk[2] + sgn * bq[2], ng2)
-            c3 = mod(bk[3] + sgn * bq[3], ng3)
+            c1 = _wrap_reduced(bk[1] + q1, ng1)
+            c2 = _wrap_reduced(bk[2] + q2, ng2)
+            c3 = _wrap_reduced(bk[3] + q3, ng3)
             xk_hash_value = (c1 * ng2 + c2) * ng3 + c3
 
             # Find new k+q points, append to xkq_hash_to_ikq and xkqs
@@ -373,10 +416,14 @@ function combine_kpoint_grids(kpts, qpts, op, ngrid_kq)
     # point uniquely, so it is also the de-duplication key: the Dict path packs it as
     # `(c1*ng2 + c2)*ng3 + c3` (which happens to equal `_hash_xk(xkq)`), the dense path indexes an
     # array by it directly.
+    # Both lists are reduced into `0:ng-1` here, once per point, so that the O(nk·nkq) fold is
+    # `_wrap_reduced` (a compare-and-add) rather than three runtime 64-bit integer divisions.
     fk = ngrid_kq .÷ kpts.ngrid
     fq = ngrid_kq .÷ qpts.ngrid
-    BkS = [Vec3(round.(Int, (xk - shift_k).data .* kpts.ngrid) .* fk) for xk in kpts.vectors]
-    BqS = [Vec3(round.(Int, (xq - shift_q).data .* qpts.ngrid) .* fq) for xq in qpts.vectors]
+    BkS = [_grid_coords_reduced(Vec3(round.(Int, (xk - shift_k).data .* kpts.ngrid) .* fk), ngrid_kq)
+           for xk in kpts.vectors]
+    BqS = [_grid_coords_reduced(Vec3(round.(Int, (xq - shift_q).data .* qpts.ngrid) .* fq), ngrid_kq)
+           for xq in qpts.vectors]
 
     # Dense lookup table while it fits in the transient budget, Dict above it. The budget is loose
     # because the table lives only until this function returns. `Int128` because `prod(ngrid_kq)`

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -820,6 +820,22 @@ end
 
 
 """
+    _kpoint_vectors_to_device(backend, kpts::AbstractKpoints) -> (3 × kpts.n) real matrix
+
+Crystal coordinates of `kpts` as a `(3 × kpts.n)` real matrix on `backend`'s device — the layout the
+batched Fourier phase builds ([`fourier_phase!`](@ref)) read. Assembled on the host from the `Vec3`
+list and moved over once with [`to_device`](@ref).
+"""
+function _kpoint_vectors_to_device(backend, kpts::AbstractKpoints{T}) where {T}
+    xk_host = Matrix{T}(undef, 3, kpts.n)
+    for (ik, xk) in enumerate(kpts.vectors)
+        xk_host[:, ik] .= xk
+    end
+    to_device(backend, xk_host)
+end
+
+
+"""
     print_in_qe_format(kpts::AbstractKpoints, unit = :Crystal; recip_lattice = nothing, alat = nothing)
 Print k points in the format of Quantum ESPRESSO input.
 - `unit`: Unit of k points. Must be :Crystal, :Cartesian, or :tpiba. Default is :Crystal.

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -245,6 +245,91 @@ function kpoints_create_subgrid(k::Kpoints, nsubgrid)
     Kpoints(new_n, new_vectors, new_weights, new_ngrid)
 end
 
+# Two dense tables of `prod(ngrid)` `Int`s are built in this file, and each has its own size
+# budget. They are deliberately two constants, not one: the de-duplication table is a transient
+# freed when `combine_kpoint_grids` returns, while the inverse index is retained for the lifetime of
+# every `GridKpoints` (and `split_kpoints` makes N of them), so the retained one is budgeted much
+# more tightly. Exceeding either budget selects the Dict implementation of the same map: slower,
+# O(number of points) memory, and identical results.
+#
+# The index budget is a soft cap, not a ceiling: `_use_dense_index` waives it whenever the table
+# cannot exceed the Dict it would fall back to (`prod(ngrid) <= 4n`, which every full grid
+# satisfies at any size), so the retained index can be larger than 256 MB. It is still bounded, and
+# roughly by the Dict's own size — in that regime the table is `8·prod <= 32n` bytes against the
+# Dict's ~34n, so an object carrying both indices stays under ~1.94x what the Dict alone would
+# cost. Both are retained today, so that is the real worst case; dropping the Dict once the dense
+# path has proven itself is what removes the duplication, not a tighter gate.
+const _DEDUP_TABLE_MAX_BYTES = 8 * 1024^3    # transient in `combine_kpoint_grids`
+const _DENSE_INDEX_MAX_BYTES = 256 * 1024^2  # retained in `GridKpoints._dense_hash_to_ik`
+
+"""
+    _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
+De-duplicate `op(k, q)` over all (k, q) pairs with a dense `prod(ngrid_kq)` table indexed by the
+integer grid coordinates. Returns the unique k+q points in order of first appearance.
+
+The table is `[c1+1, c2+1, c3+1]` on `(ng1, ng2, ng3)`; de-duplication only needs *a* bijection
+from grid coordinates to table slots, so the order is free here. It is deliberately **not** the
+`hash + 1` order of `GridKpoints._dense_hash_to_ik`, which is the transposed `(ng3, ng2, ng1)`
+layout — the two tables are unrelated and neither is derived from the other.
+"""
+function _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) where {T}
+    ng1, ng2, ng3 = ngrid_kq
+    xkqs = Vector{Vec3{T}}()
+    xkq_hash_to_ikq = zeros(Int, ng1, ng2, ng3)
+    ikq = 0
+    for bq in BqS
+        for bk in BkS
+            c1 = mod(bk[1] + sgn * bq[1], ng1)
+            c2 = mod(bk[2] + sgn * bq[2], ng2)
+            c3 = mod(bk[3] + sgn * bq[3], ng3)
+
+            # Find new k+q points, append to xkq_hash_to_ikq and xkqs
+            if xkq_hash_to_ikq[c1 + 1, c2 + 1, c3 + 1] == 0
+                ikq += 1
+                xkq_hash_to_ikq[c1 + 1, c2 + 1, c3 + 1] = ikq
+                push!(xkqs, Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq)
+            end
+        end
+    end
+    xkqs
+end
+
+"""
+    _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)
+Same map as `_combine_kq_dedup_dense`, keyed by the packed hash in a `Dict` so the memory is
+O(number of unique points) instead of O(prod(ngrid_kq)). Used when the dense table would exceed
+`_DEDUP_TABLE_MAX_BYTES`.
+"""
+function _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) where {T}
+    ng1, ng2, ng3 = ngrid_kq
+    xkqs = Vector{Vec3{T}}()
+    cs = Vector{NTuple{3,Int}}()  # integer coords per stored point, for the collision guard
+    xkq_hash_to_ikq = Dict{Int, Int}()
+    ikq = 0
+    for bq in BqS
+        for bk in BkS
+            c1 = mod(bk[1] + sgn * bq[1], ng1)
+            c2 = mod(bk[2] + sgn * bq[2], ng2)
+            c3 = mod(bk[3] + sgn * bq[3], ng3)
+            xk_hash_value = (c1 * ng2 + c2) * ng3 + c3
+
+            # Find new k+q points, append to xkq_hash_to_ikq and xkqs
+            ikq_found = get(xkq_hash_to_ikq, xk_hash_value, 0)
+            if ikq_found == 0
+                ikq += 1
+                xkq_hash_to_ikq[xk_hash_value] = ikq
+                push!(cs, (c1, c2, c3))
+                push!(xkqs, Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq)
+            else
+                # A hash hit must be the same grid point. A mismatch here means an off-grid input
+                # or a hash that overflowed Int (prod(ngrid_kq) too large) — fail loudly.
+                @assert cs[ikq_found] == (c1, c2, c3)
+            end
+        end
+    end
+    xkqs
+end
+
 """
     combine_kpoint_grids(kpts, qpts, op, ngrid_kq)
 For k and q in kpts and qpts, return a `GridKpoints` with `kq = op(k, q)`.
@@ -269,7 +354,6 @@ function combine_kpoint_grids(kpts, qpts, op, ngrid_kq)
         "ngrid_kq = $ngrid_kq must be divisible by qpts.ngrid = $(qpts.ngrid)"))
 
     T = eltype(kpts.weights)
-    ng1, ng2, ng3 = ngrid_kq
     shift_k = kpts.vectors[1]
     shift_q = qpts.vectors[1]
     shift_kq = op(shift_k, shift_q)
@@ -281,61 +365,22 @@ function combine_kpoint_grids(kpts, qpts, op, ngrid_kq)
     # ngrid)`. Then `op(k, q)` folded into the cell is plain integer arithmetic
     #   c = mod(b_k ± b_q, ngrid_kq)  ∈ [0, ngrid_kq),
     # which is exact and gcd-free (the old Rational arithmetic was the bottleneck), and recomputing
-    # `b` once per point (not per pair) avoids O(nk·nkq) redundant work. The packed index
-    # `(c1*ng2 + c2)*ng3 + c3` equals `_hash_xk(xkq)` and is a bijection on the grid, so it doubles
-    # as the de-duplication key. Stays a sparse Dict (one entry per unique point), never O(prod(ngrid)).
+    # `b` once per point (not per pair) avoids O(nk·nkq) redundant work. `c` identifies the k+q
+    # point uniquely, so it is also the de-duplication key: the Dict path packs it as
+    # `(c1*ng2 + c2)*ng3 + c3` (which happens to equal `_hash_xk(xkq)`), the dense path indexes an
+    # array by it directly.
     fk = ngrid_kq .÷ kpts.ngrid
     fq = ngrid_kq .÷ qpts.ngrid
     BkS = [Vec3(round.(Int, (xk - shift_k).data .* kpts.ngrid) .* fk) for xk in kpts.vectors]
     BqS = [Vec3(round.(Int, (xq - shift_q).data .* qpts.ngrid) .* fq) for xq in qpts.vectors]
 
-    xkqs = Vector{Vec3{T}}()
-    # cs = Vector{NTuple{3,Int}}()          # integer coords per stored point, for the collision guard
-    # xkq_hash_to_ikq = Dict{Int, Int}()
-    # ikq = 0
-    # for bq in BqS
-    #     for bk in BkS
-    #         c1 = mod(bk[1] + sgn * bq[1], ng1)
-    #         c2 = mod(bk[2] + sgn * bq[2], ng2)
-    #         c3 = mod(bk[3] + sgn * bq[3], ng3)
-    #         xk_hash_value = (c1 * ng2 + c2) * ng3 + c3
-
-    #         # Find new k+q points, append to xkq_hash_to_ikq and xkqs
-    #         ikq_found = get(xkq_hash_to_ikq, xk_hash_value, 0)
-    #         if ikq_found == 0
-    #             ikq += 1
-    #             xkq_hash_to_ikq[xk_hash_value] = ikq
-    #             push!(cs, (c1, c2, c3))
-    #             push!(xkqs, Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq)
-    #         else
-    #             # A hash hit must be the same grid point. A mismatch here means an off-grid input
-    #             # or a hash that overflowed Int (prod(ngrid_kq) too large) — fail loudly.
-    #             @assert cs[ikq_found] == (c1, c2, c3)
-    #         end
-    #     end
-    # end
-    # Optimization using a 3d array
-    if ng1 * ng2 * ng3 > 1e9
-        throw(ArgumentError("ngrid_kq is too large, use smaller grid or use the old Dict implementation"))
-        # TODO: Specialize uniform grid kpoints type ?
-    end
-    xkq_hash_to_ikq = zeros(Int, ng1, ng2, ng3)
-    ikq = 0
-    for bq in BqS
-        for bk in BkS
-            c1 = mod(bk[1] + sgn * bq[1], ng1)
-            c2 = mod(bk[2] + sgn * bq[2], ng2)
-            c3 = mod(bk[3] + sgn * bq[3], ng3)
-
-            # Find new k+q points, append to xkq_hash_to_ikq and xkqs
-            # ikq_found = get(xkq_hash_to_ikq, xk_hash_value, 0)
-            ikq_found = xkq_hash_to_ikq[c1 + 1, c2 + 1, c3 + 1]
-            if ikq_found == 0
-                ikq += 1
-                xkq_hash_to_ikq[c1 + 1, c2 + 1, c3 + 1] = ikq
-                push!(xkqs, Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq)
-            end
-        end
+    # Dense lookup table while it fits in the transient budget, Dict above it. `Int128` because
+    # `prod(ngrid_kq)` itself may overflow `Int` here (it is only checked in the `GridKpoints`
+    # constructor below, which the Dict path reaches).
+    xkqs = if prod(Int128.(ngrid_kq)) * sizeof(Int) <= _DEDUP_TABLE_MAX_BYTES
+        _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
+    else
+        _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)
     end
 
     nkq = length(xkqs)
@@ -363,6 +408,9 @@ Additional arguments for `GridKpoints`:
 - `ngrid`: size of the grid
 - `shift`: shift of the grid from (0, 0, 0)
 - `_xk_hash_to_ik`: dictionary for mapping `_hash_xk(kpts.vectors[ik], kpts)` to `ik`
+- `_dense_hash_to_ik`: derived cache for the same map, a flat `prod(ngrid)` vector indexed by
+    `_hash_xk(kpts.vectors[ik], kpts) + 1` (`0` marks a grid node that is not a k point). Empty when
+    the grid is too sparse or too large for it (`_build_dense_index`); then the `Dict` is used.
 """
 struct GridKpoints{T} <: AbstractKpoints{T}
     n::Int
@@ -371,6 +419,45 @@ struct GridKpoints{T} <: AbstractKpoints{T}
     ngrid::NTuple{3,Int}
     shift::Vec3{T}
     _xk_hash_to_ik::Dict{Int,Int}
+    _dense_hash_to_ik::Vector{Int}
+end
+
+# Whether `n` points on a `prod(ngrid)`-node grid get a dense inverse index, which costs one `Int`
+# per grid node whereas the `Dict` costs ~34 B per stored point (17 B per slot at a load factor of
+# at most 0.75).
+function _use_dense_index(n, ngrid)
+    nnode = prod(ngrid)
+    # Not for a grid far sparser than its point count: a multigrid/AMR grid can have a huge `ngrid`
+    # holding a handful of points, where the Dict is small, L2-resident and already fast.
+    dense_enough = nnode <= max(8 * n, 2^20)
+    # Not above the size cap either — unless the Dict it would fall back to is the bigger of the
+    # two, which is the case below 34/8 = 4.25 nodes per point (rounded down to stay conservative).
+    fits_cap = nnode <= _DENSE_INDEX_MAX_BYTES ÷ sizeof(Int)
+    beats_dict = nnode <= 4 * n
+    dense_enough && (fits_cap || beats_dict)
+end
+
+# Build the dense inverse index, or return an empty vector if it should not be built.
+function _build_dense_index(n, vectors, ngrid, shift)
+    n == 0 && return Int[]
+    _use_dense_index(n, ngrid) || return Int[]
+
+    nnode = prod(ngrid)
+    table = zeros(Int, nnode)
+    # Serial and ascending, so a repeated point resolves to the last `ik` — the same tie-break as
+    # `Dict(hashes .=> 1:n)`, where later pairs overwrite earlier ones.
+    for ik in 1:n
+        table[_hash_xk(vectors[ik], ngrid, shift) + 1] = ik
+    end
+    table
+end
+
+# Every construction site that fills all fields goes through this, so the dense-index policy lives
+# in one place and the table is either empty or exactly `prod(ngrid)` long — the length that makes
+# `_ik_from_hash`'s `@inbounds` safe for any hash `_hash_xk` produces.
+function _make_grid_kpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift, _xk_hash_to_ik) where {T}
+    _dense_hash_to_ik = _build_dense_index(n, vectors, ngrid, shift)
+    GridKpoints{T}(n, vectors, weights, ngrid, shift, _xk_hash_to_ik, _dense_hash_to_ik)
 end
 
 function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T))) where {T}
@@ -380,7 +467,7 @@ function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T))) 
     prod(Int128.(ngrid)) < typemax(Int) || throw(ArgumentError(
         "prod(ngrid) = $(prod(Int128.(ngrid))) must be < typemax(Int) to avoid overflow in the k-point hash"))
     if kpts.n == 0
-        return GridKpoints{T}(0, Vector{Vec3{T}}(), Vector{T}(), ngrid, zero(Vec3{T}), Dict{Int,Int}())
+        return _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), ngrid, zero(Vec3{T}), Dict{Int,Int}())
     end
 
     shift = mod.(first(kpts.vectors) .* ngrid, 1) ./ ngrid
@@ -394,13 +481,13 @@ function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T))) 
     end
 
     _xk_hash_to_ik = Dict(_hash_xk.(kpts.vectors, Ref(ngrid), Ref(shift)) .=> 1:kpts.n)
-    GridKpoints{T}(kpts.n, kpts.vectors, kpts.weights, ngrid, shift, _xk_hash_to_ik)
+    _make_grid_kpoints(kpts.n, kpts.vectors, kpts.weights, ngrid, shift, _xk_hash_to_ik)
 end
 
 GridKpoints(xk::Vec3{T}) where {T <: Real} = GridKpoints(Kpoints(xk))
 
 # Empty GridKpoints (e.g. the receive-side placeholder on non-root ranks before mpi_scatter).
-GridKpoints{T}() where {T} = GridKpoints{T}(0, Vector{Vec3{T}}(), Vector{T}(), (0, 0, 0), zero(Vec3{T}), Dict{Int,Int}())
+GridKpoints{T}() where {T} = _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), (0, 0, 0), zero(Vec3{T}), Dict{Int,Int}())
 
 # Reduce GridKpoints to Kpoints
 Kpoints(k::GridKpoints{T}) where {T} = Kpoints{T}(k.n, k.vectors, k.weights, k.ngrid)
@@ -447,8 +534,26 @@ function _hash_xk(xk::Vec3, ngrid, shift)
 end
 _hash_xk(xk, kpts::GridKpoints) = _hash_xk(xk, kpts.ngrid, kpts.shift)
 
+# Index of the k point with the given hash, 0 if there is none. `ik` is 1-based, so 0 is
+# unambiguous even though 0 is itself a legal hash (Γ on an unshifted grid).
+# PRECONDITION: `0 <= hash < prod(kpts.ngrid)`. Every hash built by `_hash_xk` satisfies it (it mods
+# each coordinate by `ngrid`), as does the equivalent integer-coordinate arithmetic in the GPU
+# outer-k loop. A caller that packs a hash by hand against a different `ngrid` violates it, and the
+# `@inbounds` below then reads out of bounds instead of reporting a miss.
+@inline function _ik_from_hash(kpts::GridKpoints, hash::Int)
+    dense = kpts._dense_hash_to_ik
+    if isempty(dense)
+        get(kpts._xk_hash_to_ik, hash, 0)
+    else
+        @inbounds dense[hash + 1]
+    end
+end
+
 # Retern index of given xk vector
-xk_to_ik(xk, kpts) = get(kpts._xk_hash_to_ik, _hash_xk(xk, kpts), nothing)
+function xk_to_ik(xk, kpts)
+    ik = _ik_from_hash(kpts, _hash_xk(xk, kpts))
+    ik == 0 ? nothing : ik
+end
 
 Base.sortperm(k::GridKpoints) = sortperm(map(xk -> round.(Int, (xk - k.shift).data .* k.ngrid), k.vectors))
 
@@ -456,18 +561,21 @@ function Base.sort!(k::GridKpoints)
     inds = sortperm(k)
     k.vectors .= k.vectors[inds]
     k.weights .= k.weights[inds]
+    # Ascending, so a repeated point keeps the same tie-break as construction.
     for (ik, xk) in enumerate(k.vectors)
-        k._xk_hash_to_ik[_hash_xk(xk, k)] = ik
+        hash = _hash_xk(xk, k)
+        k._xk_hash_to_ik[hash] = ik
+        isempty(k._dense_hash_to_ik) || (k._dense_hash_to_ik[hash + 1] = ik)
     end
     k
 end
 
+# The two indices are derived from (vectors, ngrid, shift), so they are not compared.
 Base.:(==)(k1::GridKpoints, k2::GridKpoints) = (k1.n ≈ k2.n
     && k1.vectors ≈ k2.vectors
     && k1.weights ≈ k2.weights
     && k1.shift ≈ k2.shift
     && k1.ngrid == k2.ngrid
-    && k1._xk_hash_to_ik == k2._xk_hash_to_ik
 )
 
 get_filtered_kpoints(k::GridKpoints, ik_keep) = GridKpoints(get_filtered_kpoints(Kpoints(k), ik_keep))
@@ -526,7 +634,7 @@ function unfold_kpoints(kpts::GridKpoints, symmetry)
     # Each k point is mapped to length(symmetry) sk points, so divide weights by length(symmetry).
     sk_weights ./= length(symmetry)
 
-    kpts_unfold = GridKpoints(length(sk_vectors), sk_vectors, sk_weights, ngrid, shift, sk_hash_dict)
+    kpts_unfold = _make_grid_kpoints(length(sk_vectors), sk_vectors, sk_weights, ngrid, shift, sk_hash_dict)
     ik_to_ikirr_isym = ik_to_ikirr_isym[sortperm(kpts_unfold)]
     sort!(kpts_unfold)
 
@@ -582,7 +690,7 @@ function fold_kpoints(kpts::GridKpoints, symmetry)
         end
     end
 
-    kpts_irr = GridKpoints(length(vectors_irr), vectors_irr, weights_irr, ngrid, shift, hash_dict_irr)
+    kpts_irr = _make_grid_kpoints(length(vectors_irr), vectors_irr, weights_irr, ngrid, shift, hash_dict_irr)
 
     inds = invperm(sortperm(kpts_irr))
     sort!(kpts_irr)

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -245,42 +245,41 @@ function kpoints_create_subgrid(k::Kpoints, nsubgrid)
     Kpoints(new_n, new_vectors, new_weights, new_ngrid)
 end
 
-# Two dense tables of `prod(ngrid)` `Int`s are built in this file, and each has its own size
-# budget. They are deliberately two constants, not one: the de-duplication table is a transient
-# freed when `combine_kpoint_grids` returns, while the inverse index is retained for the lifetime of
-# every `GridKpoints` (and `split_kpoints` makes N of them), so the retained one is budgeted much
-# more tightly. Exceeding either budget selects the Dict implementation of the same map: slower,
-# O(number of points) memory, and identical results.
+# Two places in this file need an `xk -> ik` map for `xk` on a grid of size `ngrid`:
+# `combine_kpoint_grids` below, to de-duplicate k+q, and `GridKpoints` further down, as its inverse
+# index. There are two ways to build such a map — a hash `Dict` keyed by the packed grid coordinate,
+# or a dense table with one slot per grid node — and they return identical results.
 #
-# The index budget is a soft cap, not a ceiling. A `GridKpoints` keeps at most one of the two
-# indices, but how far the dense table can exceed the Dict it replaces depends on which clause of
-# `_use_dense_index` admitted it (table 8 B per grid node, Dict ~34 B per point):
-#   - waiver, `prod <= 4n` (includes every full grid at any size): `8·prod <= 32n` bytes against
-#     ~34n, so the table is never the bigger of the two. This is the clause that lets the retained
-#     index exceed 256 MB, and it is safe precisely because the Dict would have cost more.
-#   - density band, `4n < prod <= 8n`: up to `64n` bytes against ~34n, so up to ~1.9x the Dict —
-#     bounded in absolute terms by the 256 MB cap.
-#   - node floor, `prod <= 2^20`: the ratio is unbounded (5000 points on a (101,101,101) grid is an
-#     8.2 MB table for a ~170 kB Dict, ~48x), which is acceptable only because the floor itself
-#     bounds the table at 8 MB. That absolute bound is why this clause may ignore density at all.
-# Outside the waiver, exceeding the cap selects the Dict.
-const _DEDUP_TABLE_MAX_BYTES = 8 * 1024^3    # transient in `combine_kpoint_grids`
-const _DENSE_INDEX_MAX_BYTES = 256 * 1024^2  # retained in `GridKpoints._dense_hash_to_ik`
+# The tradeoff. The `Dict` costs ~34 B per stored point (17 B per slot at a load factor of at most
+# 0.75), so its memory scales with the number of points `n`: it is the cheap one on a grid far
+# sparser than its point count. The dense table costs a fixed 8 B per grid node whatever `n` is, so
+# it wins on a nearly full grid: at `n >= prod(ngrid)/4` it already uses less memory than the Dict,
+# which costs ~4x (34/8) the bytes per point that the table costs per node. Dense access is also
+# faster — an array load instead of a hash probe.
+#
+# So each map is built dense while it fits a memory cap and as a `Dict` above it. The caps are per
+# map, not shared: the de-duplication table is transient (freed when `combine_kpoint_grids`
+# returns), while the index is retained for the lifetime of every `GridKpoints` (and
+# `split_kpoints` makes N of them), so the retained one is budgeted much more tightly. A
+# `GridKpoints` keeps at most one of the two index maps; `_use_dense_index` is the authority on
+# which one it gets.
 
 """
     _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
-De-duplicate `op(k, q)` over all (k, q) pairs with a dense `prod(ngrid_kq)` table indexed by the
+De-duplicate `k + sgn * q` over all (k, q) pairs with a dense `prod(ngrid_kq)` table indexed by the
 integer grid coordinates. Returns the unique k+q points in order of first appearance.
+- `BkS`, `BqS`: integer grid coordinates of the k and of the q points on the common `ngrid_kq`
+    grid, i.e. the `b` of `xk = shift + b ./ ngrid_kq`. Built by `combine_kpoint_grids`.
 
-The table is `[c1+1, c2+1, c3+1]` on `(ng1, ng2, ng3)`; de-duplication only needs *a* bijection
-from grid coordinates to table slots, so the order is free here. It is deliberately **not** the
-`hash + 1` order of `GridKpoints._dense_hash_to_ik`, which is the transposed `(ng3, ng2, ng1)`
-layout — the two tables are unrelated and neither is derived from the other.
+The table is `(ng3, ng2, ng1)` indexed `[c3+1, c2+1, c1+1]`, making `c3` the unit-stride index so
+that a sweep over consecutive `c3` walks the table sequentially. With those dims the linear index
+of a slot is exactly `hash + 1` for the `(c1*ng2 + c2)*ng3 + c3` packing, so this table and
+`GridKpoints._dense_hash_to_ik` share one layout.
 """
 function _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) where {T}
     ng1, ng2, ng3 = ngrid_kq
     xkqs = Vector{Vec3{T}}()
-    xkq_hash_to_ikq = zeros(Int, ng1, ng2, ng3)
+    xkq_hash_to_ikq = zeros(Int, ng3, ng2, ng1)
     ikq = 0
     for bq in BqS
         for bk in BkS
@@ -289,9 +288,9 @@ function _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) whe
             c3 = mod(bk[3] + sgn * bq[3], ng3)
 
             # Find new k+q points, append to xkq_hash_to_ikq and xkqs
-            if xkq_hash_to_ikq[c1 + 1, c2 + 1, c3 + 1] == 0
+            if xkq_hash_to_ikq[c3 + 1, c2 + 1, c1 + 1] == 0
                 ikq += 1
-                xkq_hash_to_ikq[c1 + 1, c2 + 1, c3 + 1] = ikq
+                xkq_hash_to_ikq[c3 + 1, c2 + 1, c1 + 1] = ikq
                 push!(xkqs, Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq)
             end
         end
@@ -302,8 +301,8 @@ end
 """
     _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)
 Same map as `_combine_kq_dedup_dense`, keyed by the packed hash in a `Dict` so the memory is
-O(number of unique points) instead of O(prod(ngrid_kq)). Used when the dense table would exceed
-`_DEDUP_TABLE_MAX_BYTES`.
+O(number of unique points) instead of O(prod(ngrid_kq)). Used when the dense table would exceed the
+transient memory budget in `combine_kpoint_grids`.
 """
 function _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) where {T}
     ng1, ng2, ng3 = ngrid_kq
@@ -379,10 +378,12 @@ function combine_kpoint_grids(kpts, qpts, op, ngrid_kq)
     BkS = [Vec3(round.(Int, (xk - shift_k).data .* kpts.ngrid) .* fk) for xk in kpts.vectors]
     BqS = [Vec3(round.(Int, (xq - shift_q).data .* qpts.ngrid) .* fq) for xq in qpts.vectors]
 
-    # Dense lookup table while it fits in the transient budget, Dict above it. `Int128` because
-    # `prod(ngrid_kq)` itself may overflow `Int` here (it is only checked in the `GridKpoints`
-    # constructor below, which the Dict path reaches).
-    xkqs = if prod(Int128.(ngrid_kq)) * sizeof(Int) <= _DEDUP_TABLE_MAX_BYTES
+    # Dense lookup table while it fits in the transient budget, Dict above it. The budget is loose
+    # because the table lives only until this function returns. `Int128` because `prod(ngrid_kq)`
+    # itself may overflow `Int` here (it is only checked in the `GridKpoints` constructor below,
+    # which the Dict path reaches).
+    dedup_table_max_bytes = 8 * 1024^3  # 8 GB
+    xkqs = if prod(Int128.(ngrid_kq)) * sizeof(Int) <= dedup_table_max_bytes
         _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
     else
         _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)
@@ -415,8 +416,9 @@ Additional arguments for `GridKpoints`:
 Both of the following are derived caches of the same `_hash_xk(kpts.vectors[ik], kpts) -> ik` map,
 and at most one of them is populated — exactly one when `n > 0`, and `_use_dense_index` picks which;
 an empty `GridKpoints` has neither. Read them only through `_ik_from_hash`.
-- `_dense_hash_to_ik`: a flat `prod(ngrid)` vector indexed by `hash + 1`, where `0` marks a grid
-    node that is not a k point. Empty when the grid is too sparse or too large for it.
+- `_dense_hash_to_ik`: a `(ngrid[3], ngrid[2], ngrid[1])` table of `ik`, where `0` marks a grid node
+    that is not a k point. Those dims make the linear index of a node exactly `hash + 1`, which is
+    how `_ik_from_hash` reads it. Empty when the grid is too sparse or too large for it.
 - `_xk_hash_to_ik`: the fallback for those grids, a `Dict` of `hash => ik`. Empty when the dense
     table was built.
 """
@@ -427,31 +429,35 @@ struct GridKpoints{T} <: AbstractKpoints{T}
     ngrid::NTuple{3,Int}
     shift::Vec3{T}
     _xk_hash_to_ik::Dict{Int,Int}
-    _dense_hash_to_ik::Vector{Int}
+    _dense_hash_to_ik::Array{Int,3}
 end
 
-# Whether `n` points on a `prod(ngrid)`-node grid get a dense inverse index, which costs one `Int`
-# per grid node whereas the `Dict` costs ~34 B per stored point (17 B per slot at a load factor of
-# at most 0.75).
-function _use_dense_index(n, ngrid)
+# The index-map policy for `GridKpoints`: whether `n` points on a `prod(ngrid)`-node grid get the
+# dense inverse index (8 B per grid node) or the `Dict` (~34 B per stored point). See the discussion
+# of the tradeoff above `_combine_kq_dedup_dense`.
+# `index` overrides the policy: `:auto` applies it, `:dense`/`:dict` force one map regardless of
+# size (`:dense` on a huge grid will happily try to allocate it).
+function _use_dense_index(n, ngrid; index = :auto)
+    index === :dense && return true
+    index === :dict && return false
+    index === :auto || throw(ArgumentError("index must be :auto, :dense or :dict, got $index"))
+
     nnode = prod(ngrid)
     # Not for a grid far sparser than its point count: a multigrid/AMR grid can have a huge `ngrid`
     # holding a handful of points, where the Dict is small, L2-resident and already fast.
     dense_enough = nnode <= max(8 * n, 2^20)
     # Not above the size cap either — unless the Dict it would fall back to is the bigger of the
     # two, which is the case below 34/8 = 4.25 nodes per point (rounded down to stay conservative).
-    fits_cap = nnode <= _DENSE_INDEX_MAX_BYTES ÷ sizeof(Int)
+    dense_index_max_bytes = 256 * 1024^2  # 256 MB, retained for the lifetime of the GridKpoints
+    fits_cap = nnode <= dense_index_max_bytes ÷ sizeof(Int)
     beats_dict = nnode <= 4 * n
     dense_enough && (fits_cap || beats_dict)
 end
 
-# Build the dense inverse index, or return an empty vector if it should not be built.
+# Build the dense inverse index. Shaped so that the linear index of `[c3+1, c2+1, c1+1]` is exactly
+# `_hash_xk + 1`, which is how `_ik_from_hash` and `sort!` address it.
 function _build_dense_index(n, vectors, ngrid, shift)
-    n == 0 && return Int[]
-    _use_dense_index(n, ngrid) || return Int[]
-
-    nnode = prod(ngrid)
-    table = zeros(Int, nnode)
+    table = zeros(Int, ngrid[3], ngrid[2], ngrid[1])
     # Serial and ascending, so a repeated point resolves to the last `ik` — the same tie-break as
     # `Dict(hashes .=> 1:n)`, where later pairs overwrite earlier ones.
     for ik in 1:n
@@ -461,19 +467,31 @@ function _build_dense_index(n, vectors, ngrid, shift)
 end
 
 # Every construction site that fills all fields goes through this, so the index policy lives in one
-# place: the dense table where `_use_dense_index` allows one, the Dict otherwise, never both. The
-# table is either empty or exactly `prod(ngrid)` long — the length that makes `_ik_from_hash`'s
-# `@inbounds` safe for any hash `_hash_xk` produces. `make_dict` supplies the Dict and is called
-# only when the Dict is the index that will be kept, so a caller that would have to build one from
-# scratch does not pay for it on a dense grid; callers holding one already can pass `() -> dict`.
+# place: exactly one of the two index maps is built, never both. `make_dict` supplies the Dict and
+# is called only when the Dict is the index that will be kept, so a caller that would have to build
+# one from scratch does not pay for it on a dense grid; callers holding one already can pass
+# `() -> dict`. `index` is forwarded to `_use_dense_index`.
 function _make_grid_kpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift,
-                            make_dict = () -> Dict{Int,Int}()) where {T}
-    _dense_hash_to_ik = _build_dense_index(n, vectors, ngrid, shift)
-    _xk_hash_to_ik = isempty(_dense_hash_to_ik) ? make_dict() : Dict{Int,Int}()
-    GridKpoints{T}(n, vectors, weights, ngrid, shift, _xk_hash_to_ik, _dense_hash_to_ik)
+                            make_dict = () -> Dict{Int,Int}(); index = :auto) where {T}
+    no_table = zeros(Int, 0, 0, 0)
+    if n == 0
+        # Nothing to look up, so neither map is built (and `ngrid` may be (0,0,0) here).
+        GridKpoints{T}(n, vectors, weights, ngrid, shift, Dict{Int,Int}(), no_table)
+    elseif _use_dense_index(n, ngrid; index)
+        GridKpoints{T}(n, vectors, weights, ngrid, shift, Dict{Int,Int}(),
+                       _build_dense_index(n, vectors, ngrid, shift))
+    else
+        GridKpoints{T}(n, vectors, weights, ngrid, shift, make_dict(), no_table)
+    end
 end
 
-function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T))) where {T}
+"""
+    GridKpoints(kpts::Kpoints, ngrid = kpts.ngrid; atol, index = :auto)
+`index` selects the xk->ik index map: `:auto` leaves it to `_use_dense_index`, `:dense` and `:dict`
+force one of the two.
+"""
+function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T)),
+                     index = :auto) where {T}
     all(ngrid .> 0) || throw(ArgumentError("ngrid must be set or provided to make GridKpoints"))
     # `_hash_xk` packs the grid index into a single Int and can reach prod(ngrid) - 1, so
     # prod(ngrid) must fit in Int. Widen the product so prod(ngrid) itself cannot overflow.
@@ -494,7 +512,7 @@ function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T))) 
     end
 
     _make_grid_kpoints(kpts.n, kpts.vectors, kpts.weights, ngrid, shift,
-        () -> Dict(_hash_xk.(kpts.vectors, Ref(ngrid), Ref(shift)) .=> 1:kpts.n))
+        () -> Dict(_hash_xk.(kpts.vectors, Ref(ngrid), Ref(shift)) .=> 1:kpts.n); index)
 end
 
 GridKpoints(xk::Vec3{T}) where {T <: Real} = GridKpoints(Kpoints(xk))
@@ -549,16 +567,16 @@ _hash_xk(xk, kpts::GridKpoints) = _hash_xk(xk, kpts.ngrid, kpts.shift)
 
 # Index of the k point with the given hash, 0 if there is none. `ik` is 1-based, so 0 is
 # unambiguous even though 0 is itself a legal hash (Γ on an unshifted grid).
-# PRECONDITION: `0 <= hash < prod(kpts.ngrid)`. Every hash built by `_hash_xk` satisfies it (it mods
-# each coordinate by `ngrid`), as does the equivalent integer-coordinate arithmetic in the GPU
-# outer-k loop. A caller that packs a hash by hand against a different `ngrid` violates it, and the
-# `@inbounds` below then reads out of bounds instead of reporting a miss.
+# `hash` must be in `0:prod(kpts.ngrid)-1`, which every hash from `_hash_xk` is (it mods each
+# coordinate by `ngrid`), as is the equivalent integer-coordinate arithmetic in the GPU outer-k
+# loop. The dense index is bounds-checked, so a caller that packs a hash by hand against a different
+# `ngrid` gets a `BoundsError` rather than a silently wrong `ik`.
 @inline function _ik_from_hash(kpts::GridKpoints, hash::Int)
     dense = kpts._dense_hash_to_ik
     if isempty(dense)
         get(kpts._xk_hash_to_ik, hash, 0)
     else
-        @inbounds dense[hash + 1]
+        dense[hash + 1]
     end
 end
 
@@ -601,15 +619,18 @@ get_filtered_kpoints(k::GridKpoints, ik_keep) = GridKpoints(get_filtered_kpoints
 kpoints_create_subgrid(k::GridKpoints, nsubgrid) = GridKpoints(kpoints_create_subgrid(Kpoints(k), nsubgrid))
 
 """
-    unfold_kpoints(kpts::GridKpoints, symmetry) => kpts_unfold, ik_to_ikirr_isym
+    unfold_kpoints(kpts::GridKpoints, symmetry; index = :auto) => kpts_unfold, ik_to_ikirr_isym
 
 Unfold k points using symmetry to the full Brillouin zone.
 Output `ik_to_ikirr_isym` gives a map ik => (ikirr, isym) such that ``xk[ik] = S[isym](xkirr[ikirr])``.
+`index` is the `GridKpoints` index-map override, see `_use_dense_index`.
 """
-function unfold_kpoints(kpts::GridKpoints, symmetry)
+function unfold_kpoints(kpts::GridKpoints, symmetry; index = :auto)
     # If symmetry is trivial, do nothing and return a copy of input kpts
     if symmetry.nsym == 1
-        return deepcopy(kpts), [(ik, 1) for ik in 1:kpts.n]
+        kpts_unfold = index === :auto ? deepcopy(kpts) : _make_grid_kpoints(
+            kpts.n, copy(kpts.vectors), copy(kpts.weights), kpts.ngrid, kpts.shift; index)
+        return kpts_unfold, [(ik, 1) for ik in 1:kpts.n]
     end
 
     ngrid = kpts.ngrid
@@ -653,7 +674,8 @@ function unfold_kpoints(kpts::GridKpoints, symmetry)
     # Each k point is mapped to length(symmetry) sk points, so divide weights by length(symmetry).
     sk_weights ./= length(symmetry)
 
-    kpts_unfold = _make_grid_kpoints(length(sk_vectors), sk_vectors, sk_weights, ngrid, shift, () -> sk_hash_dict)
+    kpts_unfold = _make_grid_kpoints(length(sk_vectors), sk_vectors, sk_weights, ngrid, shift,
+                                     () -> sk_hash_dict; index)
     ik_to_ikirr_isym = ik_to_ikirr_isym[sortperm(kpts_unfold)]
     sort!(kpts_unfold)
 
@@ -661,13 +683,16 @@ function unfold_kpoints(kpts::GridKpoints, symmetry)
 end
 
 """
-    fold_kpoints(kpts, symmetry) => kpts_irr, ik_to_ikirr_isym
+    fold_kpoints(kpts, symmetry; index = :auto) => kpts_irr, ik_to_ikirr_isym
 Inverse of `unfold_kpoints`. Reduce `kpts` to the irreducible BZ using `symmetry`.
 Output ik_to_ikirr_isym gives a map ik => (ikirr, isym) such that ``xk[ik] = S[isym](xkirr[ikirr])``.
+`index` is the `GridKpoints` index-map override, see `_use_dense_index`.
 """
-function fold_kpoints(kpts::GridKpoints, symmetry)
+function fold_kpoints(kpts::GridKpoints, symmetry; index = :auto)
     if symmetry.nsym == 1
-        return deepcopy(kpts), [(ik, 1) for ik = 1:kpts.n]
+        kpts_irr = index === :auto ? deepcopy(kpts) : _make_grid_kpoints(
+            kpts.n, copy(kpts.vectors), copy(kpts.weights), kpts.ngrid, kpts.shift; index)
+        return kpts_irr, [(ik, 1) for ik = 1:kpts.n]
     end
 
     ngrid = kpts.ngrid
@@ -709,7 +734,8 @@ function fold_kpoints(kpts::GridKpoints, symmetry)
         end
     end
 
-    kpts_irr = _make_grid_kpoints(length(vectors_irr), vectors_irr, weights_irr, ngrid, shift, () -> hash_dict_irr)
+    kpts_irr = _make_grid_kpoints(length(vectors_irr), vectors_irr, weights_irr, ngrid, shift,
+                                  () -> hash_dict_irr; index)
 
     inds = invperm(sortperm(kpts_irr))
     sort!(kpts_irr)

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -509,12 +509,18 @@ function _build_dense_index(n, vectors, ngrid, shift)
     table
 end
 
-# Every construction site that fills all fields goes through this, so the index policy lives in one
-# place: exactly one of the two index maps is built, never both. Pass `dict` if you already hold the
-# `hash => ik` map; leave it `nothing` and one is built here, but only on the branch that keeps it,
-# so a dense grid never pays for a Dict. `index` is forwarded to `_use_dense_index`.
-function _make_grid_kpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift,
-                            dict::Union{Nothing,Dict{Int,Int}} = nothing; index = :auto) where {T}
+"""
+    GridKpoints{T}(n, vectors, weights, ngrid, shift; index = :auto)
+
+Build a `GridKpoints` and its xk->ik index. Every construction site that fills all fields goes
+through here, so the index policy lives in one place: exactly one of the two maps is built, never
+both, and `index` is forwarded to [`_use_dense_index`](@ref) to pick which.
+"""
+GridKpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift; index = :auto) where {T} =
+    GridKpoints{T}(n, vectors, weights, ngrid, shift; index)
+
+function GridKpoints{T}(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift;
+                        index = :auto) where {T}
     no_table = zeros(Int, 0, 0, 0)
     if n == 0
         # Nothing to look up, so neither map is built (and `ngrid` may be (0,0,0) here).
@@ -523,8 +529,10 @@ function _make_grid_kpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift,
         GridKpoints{T}(n, vectors, weights, ngrid, shift, Dict{Int,Int}(),
                        _build_dense_index(n, vectors, ngrid, shift))
     else
-        d = dict === nothing ? Dict(_hash_xk.(vectors, Ref(ngrid), Ref(shift)) .=> 1:n) : dict
-        GridKpoints{T}(n, vectors, weights, ngrid, shift, d, no_table)
+        # 30 ms at n = 536k, and only on this branch, so it is not worth threading an
+        # already-built Dict through every caller.
+        GridKpoints{T}(n, vectors, weights, ngrid, shift,
+                       Dict(_hash_xk.(vectors, Ref(ngrid), Ref(shift)) .=> 1:n), no_table)
     end
 end
 
@@ -541,7 +549,7 @@ function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T)),
     prod(Int128.(ngrid)) < typemax(Int) || throw(ArgumentError(
         "prod(ngrid) = $(prod(Int128.(ngrid))) must be < typemax(Int) to avoid overflow in the k-point hash"))
     if kpts.n == 0
-        return _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), ngrid, zero(Vec3{T}))
+        return GridKpoints(0, Vector{Vec3{T}}(), Vector{T}(), ngrid, zero(Vec3{T}))
     end
 
     shift = mod.(first(kpts.vectors) .* ngrid, 1) ./ ngrid
@@ -554,13 +562,13 @@ function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T)),
         end
     end
 
-    _make_grid_kpoints(kpts.n, kpts.vectors, kpts.weights, ngrid, shift; index)
+    GridKpoints(kpts.n, kpts.vectors, kpts.weights, ngrid, shift; index)
 end
 
 GridKpoints(xk::Vec3{T}) where {T <: Real} = GridKpoints(Kpoints(xk))
 
 # Empty GridKpoints (e.g. the receive-side placeholder on non-root ranks before mpi_scatter).
-GridKpoints{T}() where {T} = _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), (0, 0, 0), zero(Vec3{T}))
+GridKpoints{T}() where {T} = GridKpoints(0, Vector{Vec3{T}}(), Vector{T}(), (0, 0, 0), zero(Vec3{T}))
 
 # Reduce GridKpoints to Kpoints
 Kpoints(k::GridKpoints{T}) where {T} = Kpoints{T}(k.n, k.vectors, k.weights, k.ngrid)
@@ -668,14 +676,6 @@ function Base.sort!(k::GridKpoints)
     k
 end
 
-# The two indices are derived from (vectors, ngrid, shift), so they are not compared.
-Base.:(==)(k1::GridKpoints, k2::GridKpoints) = (k1.n ≈ k2.n
-    && k1.vectors ≈ k2.vectors
-    && k1.weights ≈ k2.weights
-    && k1.shift ≈ k2.shift
-    && k1.ngrid == k2.ngrid
-)
-
 get_filtered_kpoints(k::GridKpoints, ik_keep) = GridKpoints(get_filtered_kpoints(Kpoints(k), ik_keep))
 kpoints_create_subgrid(k::GridKpoints, nsubgrid) = GridKpoints(kpoints_create_subgrid(Kpoints(k), nsubgrid))
 
@@ -689,7 +689,7 @@ Output `ik_to_ikirr_isym` gives a map ik => (ikirr, isym) such that ``xk[ik] = S
 function unfold_kpoints(kpts::GridKpoints, symmetry; index = :auto)
     # If symmetry is trivial, do nothing and return a copy of input kpts
     if symmetry.nsym == 1
-        kpts_unfold = index === :auto ? deepcopy(kpts) : _make_grid_kpoints(
+        kpts_unfold = index === :auto ? deepcopy(kpts) : GridKpoints(
             kpts.n, copy(kpts.vectors), copy(kpts.weights), kpts.ngrid, kpts.shift; index)
         return kpts_unfold, [(ik, 1) for ik in 1:kpts.n]
     end
@@ -735,8 +735,7 @@ function unfold_kpoints(kpts::GridKpoints, symmetry; index = :auto)
     # Each k point is mapped to length(symmetry) sk points, so divide weights by length(symmetry).
     sk_weights ./= length(symmetry)
 
-    kpts_unfold = _make_grid_kpoints(length(sk_vectors), sk_vectors, sk_weights, ngrid, shift,
-                                     sk_hash_dict; index)
+    kpts_unfold = GridKpoints(length(sk_vectors), sk_vectors, sk_weights, ngrid, shift; index)
     ik_to_ikirr_isym = ik_to_ikirr_isym[sortperm(kpts_unfold)]
     sort!(kpts_unfold)
 
@@ -751,7 +750,7 @@ Output ik_to_ikirr_isym gives a map ik => (ikirr, isym) such that ``xk[ik] = S[i
 """
 function fold_kpoints(kpts::GridKpoints, symmetry; index = :auto)
     if symmetry.nsym == 1
-        kpts_irr = index === :auto ? deepcopy(kpts) : _make_grid_kpoints(
+        kpts_irr = index === :auto ? deepcopy(kpts) : GridKpoints(
             kpts.n, copy(kpts.vectors), copy(kpts.weights), kpts.ngrid, kpts.shift; index)
         return kpts_irr, [(ik, 1) for ik = 1:kpts.n]
     end
@@ -795,8 +794,7 @@ function fold_kpoints(kpts::GridKpoints, symmetry; index = :auto)
         end
     end
 
-    kpts_irr = _make_grid_kpoints(length(vectors_irr), vectors_irr, weights_irr, ngrid, shift,
-                                  hash_dict_irr; index)
+    kpts_irr = GridKpoints(length(vectors_irr), vectors_irr, weights_irr, ngrid, shift; index)
 
     inds = invperm(sortperm(kpts_irr))
     sort!(kpts_irr)

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -255,10 +255,9 @@ end
 # The index budget is a soft cap, not a ceiling: `_use_dense_index` waives it whenever the table
 # cannot exceed the Dict it would fall back to (`prod(ngrid) <= 4n`, which every full grid
 # satisfies at any size), so the retained index can be larger than 256 MB. It is still bounded, and
-# roughly by the Dict's own size — in that regime the table is `8·prod <= 32n` bytes against the
-# Dict's ~34n, so an object carrying both indices stays under ~1.94x what the Dict alone would
-# cost. Both are retained today, so that is the real worst case; dropping the Dict once the dense
-# path has proven itself is what removes the duplication, not a tighter gate.
+# in the waiver regime by the Dict's own size — `8·prod <= 32n` bytes against the Dict's ~34n. A
+# `GridKpoints` keeps exactly one of the two indices, so its index cost is never worse than the
+# Dict alone would have been, and above the cap it is the Dict.
 const _DEDUP_TABLE_MAX_BYTES = 8 * 1024^3    # transient in `combine_kpoint_grids`
 const _DENSE_INDEX_MAX_BYTES = 256 * 1024^2  # retained in `GridKpoints._dense_hash_to_ik`
 
@@ -407,10 +406,13 @@ of integers, which cost more memory.)
 Additional arguments for `GridKpoints`:
 - `ngrid`: size of the grid
 - `shift`: shift of the grid from (0, 0, 0)
-- `_xk_hash_to_ik`: dictionary for mapping `_hash_xk(kpts.vectors[ik], kpts)` to `ik`
-- `_dense_hash_to_ik`: derived cache for the same map, a flat `prod(ngrid)` vector indexed by
-    `_hash_xk(kpts.vectors[ik], kpts) + 1` (`0` marks a grid node that is not a k point). Empty when
-    the grid is too sparse or too large for it (`_build_dense_index`); then the `Dict` is used.
+Both of the following are derived caches of the same `_hash_xk(kpts.vectors[ik], kpts) -> ik` map,
+and exactly one of them is populated (`_use_dense_index` picks which). Read them only through
+`_ik_from_hash`.
+- `_dense_hash_to_ik`: a flat `prod(ngrid)` vector indexed by `hash + 1`, where `0` marks a grid
+    node that is not a k point. Empty when the grid is too sparse or too large for it.
+- `_xk_hash_to_ik`: the fallback for those grids, a `Dict` of `hash => ik`. Empty when the dense
+    table was built.
 """
 struct GridKpoints{T} <: AbstractKpoints{T}
     n::Int
@@ -452,11 +454,15 @@ function _build_dense_index(n, vectors, ngrid, shift)
     table
 end
 
-# Every construction site that fills all fields goes through this, so the dense-index policy lives
-# in one place and the table is either empty or exactly `prod(ngrid)` long — the length that makes
-# `_ik_from_hash`'s `@inbounds` safe for any hash `_hash_xk` produces.
-function _make_grid_kpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift, _xk_hash_to_ik) where {T}
+# Every construction site that fills all fields goes through this, so the index policy lives in one
+# place: the dense table where `_use_dense_index` allows one, the Dict otherwise, never both. The
+# table is either empty or exactly `prod(ngrid)` long — the length that makes `_ik_from_hash`'s
+# `@inbounds` safe for any hash `_hash_xk` produces. `make_dict` is called only when the Dict is
+# the index that will be kept, so a caller that would have to build one from scratch does not pay
+# for it on a dense grid.
+function _make_grid_kpoints(n, vectors::Vector{Vec3{T}}, weights, ngrid, shift, make_dict) where {T}
     _dense_hash_to_ik = _build_dense_index(n, vectors, ngrid, shift)
+    _xk_hash_to_ik = isempty(_dense_hash_to_ik) ? make_dict() : Dict{Int,Int}()
     GridKpoints{T}(n, vectors, weights, ngrid, shift, _xk_hash_to_ik, _dense_hash_to_ik)
 end
 
@@ -467,7 +473,7 @@ function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T))) 
     prod(Int128.(ngrid)) < typemax(Int) || throw(ArgumentError(
         "prod(ngrid) = $(prod(Int128.(ngrid))) must be < typemax(Int) to avoid overflow in the k-point hash"))
     if kpts.n == 0
-        return _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), ngrid, zero(Vec3{T}), Dict{Int,Int}())
+        return _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), ngrid, zero(Vec3{T}), () -> Dict{Int,Int}())
     end
 
     shift = mod.(first(kpts.vectors) .* ngrid, 1) ./ ngrid
@@ -480,14 +486,14 @@ function GridKpoints(kpts::Kpoints{T}, ngrid = kpts.ngrid; atol = sqrt(eps(T))) 
         end
     end
 
-    _xk_hash_to_ik = Dict(_hash_xk.(kpts.vectors, Ref(ngrid), Ref(shift)) .=> 1:kpts.n)
-    _make_grid_kpoints(kpts.n, kpts.vectors, kpts.weights, ngrid, shift, _xk_hash_to_ik)
+    _make_grid_kpoints(kpts.n, kpts.vectors, kpts.weights, ngrid, shift,
+        () -> Dict(_hash_xk.(kpts.vectors, Ref(ngrid), Ref(shift)) .=> 1:kpts.n))
 end
 
 GridKpoints(xk::Vec3{T}) where {T <: Real} = GridKpoints(Kpoints(xk))
 
 # Empty GridKpoints (e.g. the receive-side placeholder on non-root ranks before mpi_scatter).
-GridKpoints{T}() where {T} = _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), (0, 0, 0), zero(Vec3{T}), Dict{Int,Int}())
+GridKpoints{T}() where {T} = _make_grid_kpoints(0, Vector{Vec3{T}}(), Vector{T}(), (0, 0, 0), zero(Vec3{T}), () -> Dict{Int,Int}())
 
 # Reduce GridKpoints to Kpoints
 Kpoints(k::GridKpoints{T}) where {T} = Kpoints{T}(k.n, k.vectors, k.weights, k.ngrid)
@@ -561,11 +567,17 @@ function Base.sort!(k::GridKpoints)
     inds = sortperm(k)
     k.vectors .= k.vectors[inds]
     k.weights .= k.weights[inds]
-    # Ascending, so a repeated point keeps the same tie-break as construction.
-    for (ik, xk) in enumerate(k.vectors)
-        hash = _hash_xk(xk, k)
-        k._xk_hash_to_ik[hash] = ik
-        isempty(k._dense_hash_to_ik) || (k._dense_hash_to_ik[hash + 1] = ik)
+    # Renumber whichever index is the populated one, ascending so that a repeated point keeps the
+    # same tie-break as construction. A permutation does not change the set of hashes, so no entry
+    # goes stale.
+    if isempty(k._dense_hash_to_ik)
+        for (ik, xk) in enumerate(k.vectors)
+            k._xk_hash_to_ik[_hash_xk(xk, k)] = ik
+        end
+    else
+        for (ik, xk) in enumerate(k.vectors)
+            k._dense_hash_to_ik[_hash_xk(xk, k) + 1] = ik
+        end
     end
     k
 end
@@ -634,7 +646,7 @@ function unfold_kpoints(kpts::GridKpoints, symmetry)
     # Each k point is mapped to length(symmetry) sk points, so divide weights by length(symmetry).
     sk_weights ./= length(symmetry)
 
-    kpts_unfold = _make_grid_kpoints(length(sk_vectors), sk_vectors, sk_weights, ngrid, shift, sk_hash_dict)
+    kpts_unfold = _make_grid_kpoints(length(sk_vectors), sk_vectors, sk_weights, ngrid, shift, () -> sk_hash_dict)
     ik_to_ikirr_isym = ik_to_ikirr_isym[sortperm(kpts_unfold)]
     sort!(kpts_unfold)
 
@@ -690,7 +702,7 @@ function fold_kpoints(kpts::GridKpoints, symmetry)
         end
     end
 
-    kpts_irr = _make_grid_kpoints(length(vectors_irr), vectors_irr, weights_irr, ngrid, shift, hash_dict_irr)
+    kpts_irr = _make_grid_kpoints(length(vectors_irr), vectors_irr, weights_irr, ngrid, shift, () -> hash_dict_irr)
 
     inds = invperm(sortperm(kpts_irr))
     sort!(kpts_irr)

--- a/src/compute_states.jl
+++ b/src/compute_states.jl
@@ -137,75 +137,81 @@ function _compute_electron_states_gpu!(states, model::Model{FT}, kpts, quantitie
     (; need_vfull, need_vdiag, need_position) = _electron_state_needs(model, quantities)
 
     backend = gpu_backend()
-    E = nothing; U = nothing; rbar = nothing; vel = nothing
     itp_elham = get_interpolator(to_device(backend, model.el_ham); fourier_mode="batched", batch_size=kpts.n)
+
     if quantities == ["eigenvalue"]
         E = Array(get_el_eigen_valueonly_batched(itp_elham, kpts.vectors))
+        return _scatter_electron_states!(states, kpts.vectors, window, E, nothing, nothing, nothing,
+                                        need_vfull, need_vdiag)
+    end
+
+    E_dev, U_dev = get_el_eigen_batched(itp_elham, kpts.vectors)
+    rbar_dev = if need_position
+        itp_pos = get_interpolator(to_device(backend, model.el_pos); fourier_mode="batched", batch_size=kpts.n)
+        get_el_velocity_direct_batched(itp_pos, kpts.vectors, U_dev)
     else
-        E_dev, U_dev = get_el_eigen_batched(itp_elham, kpts.vectors)
-        E = Array(E_dev); U = Array(U_dev)
-        rbar_dev = nothing
-        if need_position
-            itp_pos = get_interpolator(to_device(backend, model.el_pos); fourier_mode="batched", batch_size=kpts.n)
-            rbar_dev = get_el_velocity_direct_batched(itp_pos, kpts.vectors, U_dev)
-            rbar = Array(rbar_dev)
+        nothing
+    end
+    vel_dev = if need_vfull || need_vdiag
+        Mop = if el_velocity_mode === :Direct
+            model.el_vel
+        elseif el_velocity_mode === :BerryConnection
+            model.el_ham_R
+        else
+            throw(ArgumentError("unknown el_velocity_mode $el_velocity_mode"))
         end
-        if need_vfull || need_vdiag
-            Mop = if el_velocity_mode === :Direct
-                model.el_vel
-            elseif el_velocity_mode === :BerryConnection
-                model.el_ham_R
-            else
-                throw(ArgumentError("unknown el_velocity_mode $el_velocity_mode"))
-            end
-            itp_vel = get_interpolator(to_device(backend, Mop); fourier_mode="batched", batch_size=kpts.n)
-            vel_dev = get_el_velocity_direct_batched(itp_vel, kpts.vectors, U_dev)
-            if el_velocity_mode === :BerryConnection && need_vfull
-                nk = kpts.n
-                vel_dev .+= im .* (reshape(E_dev, nw, 1, 1, nk) .- reshape(E_dev, 1, nw, 1, nk)) .* rbar_dev
-            end
-            vel = Array(vel_dev)
+        itp_vel = get_interpolator(to_device(backend, Mop); fourier_mode="batched", batch_size=kpts.n)
+        v_dev = get_el_velocity_direct_batched(itp_vel, kpts.vectors, U_dev)
+        if el_velocity_mode === :BerryConnection && need_vfull
+            nk = kpts.n
+            v_dev .+= im .* (reshape(E_dev, nw, 1, 1, nk) .- reshape(E_dev, 1, nw, 1, nk)) .* rbar_dev
         end
+        v_dev
+    else
+        nothing
     end
 
-    # Copy the batched device results into the per-k states (on the host).
-    @threads for iks in chunks(kpts.vectors; n=2nthreads())
+    _scatter_electron_states!(states, kpts.vectors, window, Array(E_dev), Array(U_dev),
+                             rbar_dev === nothing ? nothing : Array(rbar_dev),
+                             vel_dev === nothing ? nothing : Array(vel_dev),
+                             need_vfull, need_vdiag)
+end
+
+# Function barrier: `U`/`rbar`/`vel` are `nothing` or an `Array` depending on `quantities`, so they
+# must arrive as typed arguments for the reads below to be static.
+function _scatter_electron_states!(states::Vector{ElectronState{FT}}, xks, window, E, U, rbar, vel,
+                                   need_vfull, need_vdiag) where FT
+    @threads for iks in chunks(xks; n=2nthreads())
         for ik in iks
-            xk = kpts.vectors[ik]
             el = states[ik]
-
-            if quantities == ["eigenvalue"]
-                el.xk = xk; @views el.e_full .= E[:, ik]; el.nband = 0; el.rng = 1:0
-                set_window!(el, _window_for(window, ik))
-            else
-                el.xk = xk
-                @views el.e_full .= E[:, ik]
-                @views el.u_full .= U[:, :, ik]
-                el.nband = 0; el.rng = 1:0
-                set_window!(el, _window_for(window, ik))
-                r = el.rng
-                if need_position
-                    rbar_w = reshape(reinterpret(Complex{FT}, no_offset_view(el.rbar)), 3, el.nband, el.nband)
-                    @views for idir in 1:3
-                        rbar_w[idir, :, :] .= rbar[r, r, idir, ik]
-                    end
-                end
-                if need_vfull
-                    v_w = reshape(reinterpret(Complex{FT}, no_offset_view(el.v)), 3, el.nband, el.nband)
-                    @views for idir in 1:3
-                        v_w[idir, :, :] .= vel[r, r, idir, ik]
-                    end
-                    for i in el.rng
-                        el.vdiag[i] = real.(el.v[i, i])
-                    end
-                elseif need_vdiag
-                    for i in el.rng
-                        el.vdiag[i] = real.(Vec3(vel[i, i, 1, ik], vel[i, i, 2, ik], vel[i, i, 3, ik]))
-                    end
+            el.xk = xks[ik]
+            @views el.e_full .= E[:, ik]
+            U === nothing || (@views el.u_full .= U[:, :, ik])
+            el.nband = 0; el.rng = 1:0
+            set_window!(el, _window_for(window, ik))
+            U === nothing && continue
+            r = el.rng
+            if rbar !== nothing
+                rbar_w = reshape(reinterpret(Complex{FT}, no_offset_view(el.rbar)), 3, el.nband, el.nband)
+                @views for idir in 1:3
+                    rbar_w[idir, :, :] .= rbar[r, r, idir, ik]
                 end
             end
-        end
-    end
+            if need_vfull
+                v_w = reshape(reinterpret(Complex{FT}, no_offset_view(el.v)), 3, el.nband, el.nband)
+                @views for idir in 1:3
+                    v_w[idir, :, :] .= vel[r, r, idir, ik]
+                end
+                for i in el.rng
+                    el.vdiag[i] = real.(el.v[i, i])
+                end
+            elseif need_vdiag
+                for i in el.rng
+                    el.vdiag[i] = real.(Vec3(vel[i, i, 1, ik], vel[i, i, 2, ik], vel[i, i, 3, ik]))
+                end
+            end
+        end  # ik
+    end  # iks
 end
 
 """
@@ -282,6 +288,7 @@ function _compute_phonon_states_gpu!(states, model::Model{FT}, kpts, quantities,
     need_velocity = "velocity_diagonal" ∈ quantities
     polar = model.polar_phonon
     polar.use && error("compute_phonon_states use_gpu does not support polar phonons")
+    "velocity" ∈ quantities && error("full velocity for phonons not implemented")
 
     backend = gpu_backend()
     itp_dyn = get_interpolator(to_device(backend, model.ph_dyn); fourier_mode="batched", batch_size=kpts.n)
@@ -292,37 +299,53 @@ function _compute_phonon_states_gpu!(states, model::Model{FT}, kpts, quantities,
     E_dev, U_dev = eigen_batched(D)              # E_dev = ω² (nmodes,nq), U_dev (nmodes,nmodes,nq)
     U_dev ./= reshape(msqrt_d, nmodes, 1, 1)     # eigenvector mass factor: u[i,:] /= sqrt(mass[i])
     E = Array(sign.(E_dev) .* sqrt.(abs.(E_dev)))  # ω = sign(ω²)·√|ω²|
-    U = Array(U_dev)
-    vel = nothing
-    if need_velocity
+    U = quantities == ["eigenvalue"] ? nothing : Array(U_dev)
+    vel = if need_velocity
         itp_phvel = get_interpolator(to_device(backend, model.ph_dyn_R); fourier_mode="batched", batch_size=kpts.n)
-        vel = Array(get_el_velocity_direct_batched(itp_phvel, kpts.vectors, U_dev))
+        Array(get_el_velocity_direct_batched(itp_phvel, kpts.vectors, U_dev))
+    else
+        nothing
     end
 
-    # Copy the batched device results into the per-q states (on the host).
-    @threads for iks in chunks(kpts.vectors; n = nthreads())
-        for ik in iks
-            xk = kpts.vectors[ik]
-            ph = states[ik]
+    _scatter_phonon_states!(states, kpts.vectors, E, U, vel,
+                            "eph_dipole_coeff" ∈ quantities, eph_phonon_basis, polar)
+end
 
-            if quantities == ["eigenvalue"]
-                ph.xq = xk; @views ph.e .= E[:, ik]
-            else
-                ph.xq = xk; @views ph.e .= E[:, ik]; @views ph.u .= U[:, :, ik]
-                if "velocity" ∈ quantities
-                    # not implemented
-                    error("full velocity for phonons not implemented")
-                elseif "velocity_diagonal" ∈ quantities
-                    for i in 1:nmodes
-                        ph.vdiag[i] = real.(Vec3(vel[i, i, 1, ik], vel[i, i, 2, ik], vel[i, i, 3, ik])) ./ (2 * ph.e[i])
-                    end
-                end
-                if "eph_dipole_coeff" ∈ quantities
-                    # Use ph.u for eigenmode basis, nothing for Cartesian basis
-                    u_ph_for_dipole = (eph_phonon_basis == :eigenmode) ? ph.u : nothing
-                    get_eph_dipole_coeffs!(ph.eph_dipole_coeff, ph.eph_r_coeff, xk, polar, u_ph_for_dipole)
+# Function barrier: `U`/`vel` are `nothing` or an `Array` depending on `quantities`, so they must
+# arrive as typed arguments for the reads below to be static.
+#
+# TODO: replace the `Vector{PhononState}` with a struct-of-arrays `BatchedPhononState{T, AT}` holding
+# the whole q-grid in dense stacks — `e` (nmodes, nq), `u` (nmodes, nmodes, nq), `vdiag`,
+# `eph_dipole_coeff` — with `AT` selecting host or device storage, so the same type serves both
+# backends and the GPU path never leaves the device. A `Vector` of per-q mutable structs costs ~13
+# allocations and ~1.5 kB per q point, which at the q-grids the outer-k driver builds (nq = 6.9 M for
+# Cu at nk = 200) is ~90 M allocations and ~10 GiB of churn, most of the setup's GC time.
+# `_loop_eph_over_k_and_kq_gpu` shows how little of it is wanted: it reads only `.u` and `.e`, and
+# gathers them straight back into dense stacks to re-upload — data `E_dev`/`U_dev` above already hold
+# on the device — while `velocity_diagonal` and `eph_dipole_coeff`, which that driver requests, are
+# never read. Measured on Cu at nq = 436 k: 1.62 s / 5.67 M allocations / 669 MiB for the per-q
+# states, versus 0.60 s / ~3 k allocations for the device stacks alone.
+# Blast radius: `PhononState` is also consumed per-q by the CPU drivers (`epstate.ph = ph_save[iq]`),
+# `run_eph_over_q_and_k`, `wfpt.jl`, `run_coherence.jl` and `gamma_adaptive.jl`, so a per-q view into
+# the batch has to keep the `set_*!`/`copyto!` interface those rely on.
+function _scatter_phonon_states!(states, xqs, E, U, vel, need_dipole, eph_phonon_basis, polar)
+    @threads for iqs in chunks(xqs; n = nthreads())
+        for iq in iqs
+            ph = states[iq]
+            ph.xq = xqs[iq]
+            @views ph.e .= E[:, iq]
+            U === nothing && continue
+            @views ph.u .= U[:, :, iq]
+            if vel !== nothing
+                for i in 1:ph.nmodes
+                    ph.vdiag[i] = real.(Vec3(vel[i, i, 1, iq], vel[i, i, 2, iq], vel[i, i, 3, iq])) ./ (2 * ph.e[i])
                 end
             end
-        end  # ik
-    end  # iks
+            if need_dipole
+                # Use ph.u for eigenmode basis, nothing for Cartesian basis
+                u_ph_for_dipole = (eph_phonon_basis == :eigenmode) ? ph.u : nothing
+                get_eph_dipole_coeffs!(ph.eph_dipole_coeff, ph.eph_r_coeff, ph.xq, polar, u_ph_for_dipole)
+            end
+        end  # iq
+    end  # iqs
 end

--- a/src/wannier/WannierObject.jl
+++ b/src/wannier/WannierObject.jl
@@ -132,3 +132,21 @@ function get_next_wannier_object(parent :: WannierObject{T}; ndata_child = nothi
     end
     WannierObject(parent.irvec_next, zeros(Complex{T}, (ndata_child_full, nr_child)); ndata = ndata_child)
 end
+
+
+"""
+    _irvec_to_device_matrix(irvec, proto, ::Type{T}) -> (nr × 3) real matrix
+
+R-vectors of a `WannierObject` as an `(nr × 3)` real matrix on the backend of `proto`, the layout
+[`fourier_phase!`](@ref) expects. Built on the host and copied over once.
+"""
+function _irvec_to_device_matrix(irvec, proto, ::Type{T}) where {T}
+    nr = length(irvec)
+    irvec_host = Matrix{T}(undef, nr, 3)
+    for ir in 1:nr, d in 1:3
+        irvec_host[ir, d] = irvec[ir][d]
+    end
+    irvec_mat = _alloc_array(proto, T, nr, 3)
+    copyto!(irvec_mat, irvec_host)
+    irvec_mat
+end

--- a/src/wannier/WannierObject.jl
+++ b/src/wannier/WannierObject.jl
@@ -135,18 +135,18 @@ end
 
 
 """
-    _irvec_to_device_matrix(irvec, proto, ::Type{T}) -> (nr × 3) real matrix
+    _irvec_to_device_matrix(irvec, device, ::Type{T}) -> (nr × 3) real matrix
 
-R-vectors of a `WannierObject` as an `(nr × 3)` real matrix on the backend of `proto`, the layout
-[`fourier_phase!`](@ref) expects. Built on the host and copied over once.
+R-vectors of a `WannierObject` as an `(nr × 3)` real matrix on the backend of `device` (the
+`WannierObject` whose storage the result should match), the layout [`fourier_phase!`](@ref) expects.
+Built on the host and copied over once.
+
+Uses [`_alloc_array`](@ref) rather than `to_device`: `to_device` needs a backend, and this is reached
+from `BatchedFourierCore(parent)`, which has only the object. `_alloc_array` also keeps a
+`DiskWannierObject`'s matrix on the host, which a backend cannot express.
 """
-function _irvec_to_device_matrix(irvec, proto, ::Type{T}) where {T}
+function _irvec_to_device_matrix(irvec, device, ::Type{T}) where {T}
     nr = length(irvec)
-    irvec_host = Matrix{T}(undef, nr, 3)
-    for ir in 1:nr, d in 1:3
-        irvec_host[ir, d] = irvec[ir][d]
-    end
-    irvec_mat = _alloc_array(proto, T, nr, 3)
-    copyto!(irvec_mat, irvec_host)
-    irvec_mat
+    irvec_host = T[irvec[ir][d] for ir in 1:nr, d in 1:3]
+    copyto!(_alloc_array(device, T, nr, 3), irvec_host)
 end

--- a/src/wannier/batched_fourier_core.jl
+++ b/src/wannier/batched_fourier_core.jl
@@ -7,6 +7,43 @@ _alloc_array(parent::WannierObject, ::Type{S}, dims...) where {S} = similar(pare
 
 
 """
+    fourier_phase!(phase, irvec_mat, xkmat)
+
+Wannier → Bloch phase matrix `phase[ip, j] = exp(2πi R_p · x_j)` for the R-vectors in `irvec_mat`
+(`(nr × 3)` real, row `ip` = `R_p`) and the crystal-coordinate points in `xkmat` (`(3 × nk)` real).
+All three arrays live on the same backend; the whole thing is a single broadcast (no scalar
+indexing, no scratch), so it runs unchanged on CPU and GPU.
+
+Stateless on purpose: the phase depends only on `(R_p, x)`, so a caller whose `x` list is
+loop-invariant can build it once and apply it many times (this is what the GPU outer-k e-ph loop
+does with its k+q-convention phase tile).
+"""
+function fourier_phase!(phase, irvec_mat, xkmat)
+    @views phase .= cispi.(2 .* (irvec_mat[:, 1] .* transpose(xkmat[1, :]) .+
+                                 irvec_mat[:, 2] .* transpose(xkmat[2, :]) .+
+                                 irvec_mat[:, 3] .* transpose(xkmat[3, :])))
+    phase
+end
+
+"""
+    _irvec_matrix(irvec, proto, ::Type{T}) -> (nr × 3) real matrix
+
+R-vectors as an `(nr × 3)` real matrix on the backend of `proto` (a `WannierObject`), the layout
+[`fourier_phase!`](@ref) expects. Built on the host and copied over once.
+"""
+function _irvec_matrix(irvec, proto, ::Type{T}) where {T}
+    nr = length(irvec)
+    irvec_host = Matrix{T}(undef, nr, 3)
+    for ir in 1:nr, d in 1:3
+        irvec_host[ir, d] = irvec[ir][d]
+    end
+    irvec_mat = _alloc_array(proto, T, nr, 3)
+    copyto!(irvec_mat, irvec_host)
+    irvec_mat
+end
+
+
+"""
     BatchedFourierCore{T, WT, MC, MR}
 
 Stateless whole-batch Wannier → Bloch Fourier engine. Holds only the persistent GEMM scratch
@@ -34,7 +71,6 @@ struct BatchedFourierCore{T, WT <: AbstractWannierObject, MC, MR}
     irvec_mat::MR
 
     # Scratch for the batched phase computation, on parent's backend
-    rdotk::MR                # (nr × batch_cap) real, scratch for irvec·k
     phase::MC                # (nr × batch_cap) complex
 
     # Persistent k-point matrix (3 × batch_cap): built on the host, copied to the backend.
@@ -45,39 +81,27 @@ end
 function BatchedFourierCore(parent::WT; batch_cap::Int=32) where {WT <: AbstractWannierObject{T}} where {T}
     nr = length(parent.irvec)
 
-    # R-vectors as an (nr × 3) real matrix on the backend, for the GEMM phase computation.
-    irvec_host = Matrix{T}(undef, nr, 3)
-    for ir in 1:nr, d in 1:3
-        irvec_host[ir, d] = parent.irvec[ir][d]
-    end
-    irvec_mat = _alloc_array(parent, T, nr, 3)
-    copyto!(irvec_mat, irvec_host)
-
-    rdotk = _alloc_array(parent, T, nr, batch_cap)
+    irvec_mat = _irvec_matrix(parent.irvec, parent, T)
     phase = _alloc_array(parent, Complex{T}, nr, batch_cap)
 
     xkmat_host = Matrix{T}(undef, 3, batch_cap)
     xkmat = _alloc_array(parent, T, 3, batch_cap)
 
     BatchedFourierCore{T, WT, typeof(phase), typeof(irvec_mat)}(
-        parent, batch_cap, irvec_mat, rdotk, phase, xkmat_host, xkmat)
+        parent, batch_cap, irvec_mat, phase, xkmat_host, xkmat)
 end
 
 
 """
-    fourier_batched!(out, core::BatchedFourierCore, xks)
+    _build_phase!(core::BatchedFourierCore, xks) -> view of `core.phase`
 
-Fourier-transform `core.parent` at all k-points in `xks` at once, writing into `out`
-(`(ndata, length(xks))` on the backend of `core.parent.op_r`). `length(xks)` must be
-`≤ core.batch_cap`. Uses one GEMM for the phases (`irvec_mat * xkmat`) and one GEMM for the
-transform (`op_r * phase`), so it works on any backend (no scalar indexing of device buffers).
+Stage the k-points `xks` into `core`'s persistent `(3 × batch_cap)` k-matrix and build
+`core.phase[:, 1:nk] = exp(2πi R · x)` there, returning that view. `length(xks) ≤ core.batch_cap`.
 """
-function fourier_batched!(out, core::BatchedFourierCore{T, WT}, xks) where {T, WT}
-    (; parent, irvec_mat, rdotk, phase, xkmat_host, xkmat) = core
-    ndata = parent.ndata
+function _build_phase!(core::BatchedFourierCore, xks)
+    (; irvec_mat, phase, xkmat_host, xkmat) = core
     nk = length(xks)
     @assert nk <= core.batch_cap
-    @assert size(out) == (ndata, nk)
 
     # k-point matrix (3 × nk), built in the persistent host buffer then copied to the backend.
     # For a CPU parent this copy is a redundant host→host move, but it is what lets the same code
@@ -90,8 +114,26 @@ function fourier_batched!(out, core::BatchedFourierCore{T, WT}, xks) where {T, W
     # host-SubArray → device-view `copyto!` would fall back to scalar indexing on the GPU).
     copyto!(xkmat, 1, xkmat_host, 1, 3 * nk)
 
-    @views mul!(rdotk[:, 1:nk], irvec_mat, xkmat[:, 1:nk])       # (nr × nk) real
-    @views @. phase[:, 1:nk] = cispi(2 * rdotk[:, 1:nk])
+    @views fourier_phase!(phase[:, 1:nk], irvec_mat, xkmat[:, 1:nk])
+    @view phase[:, 1:nk]
+end
+
+
+"""
+    fourier_batched!(out, core::BatchedFourierCore, xks)
+
+Fourier-transform `core.parent` at all k-points in `xks` at once, writing into `out`
+(`(ndata, length(xks))` on the backend of `core.parent.op_r`). `length(xks)` must be
+`≤ core.batch_cap`. Uses one broadcast for the phases ([`fourier_phase!`](@ref)) and one GEMM for
+the transform (`op_r * phase`), so it works on any backend (no scalar indexing of device buffers).
+"""
+function fourier_batched!(out, core::BatchedFourierCore{T, WT}, xks) where {T, WT}
+    (; parent, phase) = core
+    ndata = parent.ndata
+    nk = length(xks)
+    @assert size(out) == (ndata, nk)
+
+    _build_phase!(core, xks)
 
     if WT <: DiskWannierObject
         # For disk objects, still need to loop over R

--- a/src/wannier/batched_fourier_core.jl
+++ b/src/wannier/batched_fourier_core.jl
@@ -19,19 +19,20 @@ loop-invariant can build it once and apply it many times (this is what the GPU o
 does with its k+q-convention phase tile).
 """
 function fourier_phase!(phase, irvec_mat, xkmat)
-    @views phase .= cispi.(2 .* (irvec_mat[:, 1] .* transpose(xkmat[1, :]) .+
-                                 irvec_mat[:, 2] .* transpose(xkmat[2, :]) .+
-                                 irvec_mat[:, 3] .* transpose(xkmat[3, :])))
+    # `xkmat[d:d, :]` is the `1 × nk` row of coordinate `d`, broadcast against the `nr` R-vectors.
+    @views phase .= cispi.(2 .* (irvec_mat[:, 1] .* xkmat[1:1, :] .+
+                                 irvec_mat[:, 2] .* xkmat[2:2, :] .+
+                                 irvec_mat[:, 3] .* xkmat[3:3, :]))
     phase
 end
 
 """
-    _irvec_matrix(irvec, proto, ::Type{T}) -> (nr × 3) real matrix
+    _irvec_matrix_to_device(irvec, proto, ::Type{T}) -> (nr × 3) real matrix
 
 R-vectors as an `(nr × 3)` real matrix on the backend of `proto` (a `WannierObject`), the layout
 [`fourier_phase!`](@ref) expects. Built on the host and copied over once.
 """
-function _irvec_matrix(irvec, proto, ::Type{T}) where {T}
+function _irvec_matrix_to_device(irvec, proto, ::Type{T}) where {T}
     nr = length(irvec)
     irvec_host = Matrix{T}(undef, nr, 3)
     for ir in 1:nr, d in 1:3
@@ -81,7 +82,7 @@ end
 function BatchedFourierCore(parent::WT; batch_cap::Int=32) where {WT <: AbstractWannierObject{T}} where {T}
     nr = length(parent.irvec)
 
-    irvec_mat = _irvec_matrix(parent.irvec, parent, T)
+    irvec_mat = _irvec_matrix_to_device(parent.irvec, parent, T)
     phase = _alloc_array(parent, Complex{T}, nr, batch_cap)
 
     xkmat_host = Matrix{T}(undef, 3, batch_cap)

--- a/src/wannier/batched_fourier_core.jl
+++ b/src/wannier/batched_fourier_core.jl
@@ -18,29 +18,15 @@ Stateless on purpose: the phase depends only on `(R_p, x)`, so a caller whose `x
 loop-invariant can build it once and apply it many times (this is what the GPU outer-k e-ph loop
 does with its k+q-convention phase tile).
 """
+# `phase` is `(nr, nk)`: entry `[ir, ik]` is `exp(2πi R[ir] · x[ik])`, an outer product over the
+# `(nr × 3)` R-vectors and the `(3 × nk)` crystal coordinates. Verified allocation-free (`@allocated`
+# returns 0 on CPU), so it needs no `rdotk` temporary.
 function fourier_phase!(phase, irvec_mat, xkmat)
     # `xkmat[d:d, :]` is the `1 × nk` row of coordinate `d`, broadcast against the `nr` R-vectors.
     @views phase .= cispi.(2 .* (irvec_mat[:, 1] .* xkmat[1:1, :] .+
                                  irvec_mat[:, 2] .* xkmat[2:2, :] .+
                                  irvec_mat[:, 3] .* xkmat[3:3, :]))
     phase
-end
-
-"""
-    _irvec_matrix_to_device(irvec, proto, ::Type{T}) -> (nr × 3) real matrix
-
-R-vectors as an `(nr × 3)` real matrix on the backend of `proto` (a `WannierObject`), the layout
-[`fourier_phase!`](@ref) expects. Built on the host and copied over once.
-"""
-function _irvec_matrix_to_device(irvec, proto, ::Type{T}) where {T}
-    nr = length(irvec)
-    irvec_host = Matrix{T}(undef, nr, 3)
-    for ir in 1:nr, d in 1:3
-        irvec_host[ir, d] = irvec[ir][d]
-    end
-    irvec_mat = _alloc_array(proto, T, nr, 3)
-    copyto!(irvec_mat, irvec_host)
-    irvec_mat
 end
 
 
@@ -82,7 +68,7 @@ end
 function BatchedFourierCore(parent::WT; batch_cap::Int=32) where {WT <: AbstractWannierObject{T}} where {T}
     nr = length(parent.irvec)
 
-    irvec_mat = _irvec_matrix_to_device(parent.irvec, parent, T)
+    irvec_mat = _irvec_to_device_matrix(parent.irvec, parent, T)
     phase = _alloc_array(parent, Complex{T}, nr, batch_cap)
 
     xkmat_host = Matrix{T}(undef, 3, batch_cap)

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -153,7 +153,7 @@ end
 #  wins on the GPU. Rotation matrices are stacked along the batch dimension.
 
 """
-    get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat::BatchedWannierInterpolator, ks, uks)
+    get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat::BatchedWannierInterpolator, ks, uks; kq_convention_phase=nothing)
 
 Batched over a list of k-points `ks`. `uks` is `(nw, nband, nk)` (one `uk` per k).
 Writes `ep_ekpR_all`, shape `(nw*nband*nmodes, nr_ep, nk)` — column `k` is the `op_r` of the
@@ -162,6 +162,15 @@ electron-Bloch / phonon-Wannier object at `ks[k]`.
 One batched Fourier (`get_fourier_batched!`) over `R_el`, then one `batched_gemm!` for the
 per-k rotation by `uk` (recast as `transpose(uk(k)) * permute(g(k))`).
 
+# k+q convention
+`kq_convention_phase`, if given, is `(nr_ep × nk)` with `P[ip, k] = exp(2πi R_p · x_k)` (build it
+with [`fourier_phase!`](@ref)); the child object is then stored in the **k+q convention**
+`g̃(k, R_p) = conj(P[ip, k]) · g(k, R_p)` instead of the plain `g(k, R_p)`. Because `R_p` is an
+integer vector, the following `R_p` Fourier can then be evaluated at `x_{k+q}` directly rather than
+at `q = x_{k+q} - x_k`: `exp(2πi R_p·q) = exp(2πi R_p·x_{k+q}) · conj(exp(2πi R_p·x_k))`. Its phase
+matrix therefore depends only on the k+q list and is loop-invariant in `k`. Folded into the final
+`copyto!`, which already reads and writes the whole array, so it costs nothing.
+
 Requires a UNIFORM `nband` across the batch: `ep_ekpR_all` is sized exactly
 `(nw*nband*nmodes, …)`, so all `nk` k-points must share the same `nband` (unlike the per-k
 `get_eph_RR_to_kR!`, which handles a per-k window). A windowed run satisfies this by projecting
@@ -169,7 +178,8 @@ every k onto the same `nbandk_max`-wide eigenvector window (`nband = nbandk_max`
 `nband = nw` special case.
 """
 function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
-                                   itp_epmat::BatchedWannierInterpolator{T}, ks, uks) where {T}
+                                   itp_epmat::BatchedWannierInterpolator{T}, ks, uks;
+                                   kq_convention_phase=nothing) where {T}
     epmat = itp_epmat.parent
     nr_ep = length(epmat.irvec_next)
     nw, nband, nk = size(uks)
@@ -186,7 +196,13 @@ function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
     C = similar(g, Complex{T}, nband, nw * M, nk)
     batched_gemm!('T', 'N', uks, reshape(gp, nw, nw * M, nk), C)        # C(k)=transpose(uk(k))*gp(k)
     out = permutedims(reshape(C, nband, nw, M, nk), (2, 1, 3, 4))       # (nw, nband, M, k)
-    copyto!(ep_ekpR_all, reshape(out, nw * nband * nmodes, nr_ep, nk))
+    out3 = reshape(out, nw * nband * nmodes, nr_ep, nk)
+    if kq_convention_phase === nothing
+        copyto!(ep_ekpR_all, out3)
+    else
+        @assert size(kq_convention_phase) == (nr_ep, nk)
+        ep_ekpR_all .= out3 .* conj.(reshape(kq_convention_phase, 1, nr_ep, nk))
+    end
     ep_ekpR_all
 end
 
@@ -211,44 +227,64 @@ function KRtoKQWorkspace(gpu_array, ndata::Int, nbandkq::Int, nbandk::Int, nmode
 end
 
 """
+    get_eph_kR_to_kq_batched!(ep_kq_all, ep_kR::AbstractMatrix, phase::AbstractMatrix, u_phs, ukqs; ws=nothing)
     get_eph_kR_to_kq_batched!(ep_kq_all, itp_ep_ekpR::BatchedWannierInterpolator, qs, u_phs, ukqs; ws=nothing)
 
-Batched over a list of q-points `qs` (for a fixed k). `ukqs` is `(nw, nbandkq, nq)` and
+Batched over a list of q-points (for a fixed k). `ukqs` is `(nw, nbandkq, nq)` and
 `u_phs` is `(nmodes, nmodes, nq)`. Writes `ep_kq_all`, shape `(nbandkq, nbandk, nmodes, nq)`.
 
 One batched Fourier over `R_ep`, then two `batched_gemm!`s for the per-q rotations
 (`ukq(q)'` on the left, `u_ph(q)` on the right).
+
+The routine really consumes three things: the kR intermediate `g(k, R_p)`, the Fourier phase
+`exp(2πi R_p · x_q)` and the rotations. The **first method** takes those directly — `ep_kR` is
+`(nw*nbandk*nmodes, nr)` and `phase` is `(nr, nq)` — so a caller that can build one phase matrix
+and reuse it over many `k` (the GPU outer-k loop, via the k+q convention of
+[`get_eph_RR_to_kR_batched!`](@ref)) never rebuilds it. The **second method** is the convenience
+form: it builds the phase from the q-list `qs` into the interpolator's scratch and delegates.
 
 Pass a [`KRtoKQWorkspace`](@ref) as `ws` (sized for at least this `nq`) to reuse the `g` / `tmp`
 scratch across calls instead of allocating it each call — the per-k hot path in the GPU loop does
 this, sizing `ws` for the max batch width and passing `nq ≤` that for a partial final batch.
 """
 function get_eph_kR_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
-                                   itp_ep_ekpR::BatchedWannierInterpolator{T}, qs, u_phs, ukqs;
+                                   ep_kR::AbstractMatrix, phase::AbstractMatrix, u_phs, ukqs;
                                    ws::Union{Nothing,KRtoKQWorkspace}=nothing,
                                    g2_out=nothing, ωq=nothing) where {T}
     nbandkq, nbandk, nmodes, nq = size(ep_kq_all)
     nw = size(ukqs, 1)
+    ndata = nw * nbandk * nmodes
     @assert size(ukqs) == (nw, nbandkq, nq)
     @assert size(u_phs) == (nmodes, nmodes, nq)
-    parent = itp_ep_ekpR.parent
-    @assert parent.ndata == nw * nbandk * nmodes
+    @assert size(ep_kR, 1) == ndata
+    @assert size(phase) == (size(ep_kR, 2), nq)
 
     if ws === nothing
-        g   = similar(parent.op_r, Complex{T}, parent.ndata, nq)
-        tmp = similar(parent.op_r, Complex{T}, nbandkq, nbandk * nmodes, nq)
+        g   = similar(ep_kR, Complex{T}, ndata, nq)
+        tmp = similar(ep_kR, Complex{T}, nbandkq, nbandk * nmodes, nq)
     else
         # `ws` is sized for the max batch width; use the first `nq` columns (a partial final batch
         # passes nq < capacity), so the whole loop runs without padding the batch back up.
-        @assert size(ws.g, 1) == parent.ndata && size(ws.g, 2) >= nq
+        @assert size(ws.g, 1) == ndata && size(ws.g, 2) >= nq
         @assert size(ws.tmp, 1) == nbandkq && size(ws.tmp, 2) == nbandk * nmodes && size(ws.tmp, 3) >= nq
         g   = view(ws.g, :, 1:nq)
         tmp = view(ws.tmp, :, :, 1:nq)
     end
 
-    get_fourier_batched!(g, itp_ep_ekpR, qs)                           # (nw*nbandk*nmodes, nq)
+    mul!(g, ep_kR, phase)                                              # (nw*nbandk*nmodes, nq)
     eph_apply_rotations!(ep_kq_all, g, ukqs, u_phs, tmp; g2_out, ωq)
     ep_kq_all
+end
+
+function get_eph_kR_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
+                                   itp_ep_ekpR::BatchedWannierInterpolator{T}, qs, u_phs, ukqs;
+                                   ws::Union{Nothing,KRtoKQWorkspace}=nothing,
+                                   g2_out=nothing, ωq=nothing) where {T}
+    parent = itp_ep_ekpR.parent
+    ndata = parent.ndata
+    phase = _build_phase!(itp_ep_ekpR.core, qs)
+    @views get_eph_kR_to_kq_batched!(ep_kq_all, parent.op_r[1:ndata, :], phase, u_phs, ukqs;
+                                     ws, g2_out, ωq)
 end
 
 """

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -454,8 +454,12 @@ const _FUSED_ROT_MAX_NWNM = 24
 # Target `M` for the kR→kq GEMM `(ndata*nk_b) × nr_ep` × `nr_ep × nq`. `M = ndata` alone is far
 # below a cuBLAS M-tile at small `ndata`, so each phase element feeds only `ndata` rows of MACs and
 # the k-invariant phase tile is re-read once per k. Measured on an A100-80GB (225 W cap, Cu shapes
-# ndata = 21, nr_ep = 833, nq = 226380): 7.45 TFLOP/s at M = 21 rising to 11.93 at M = 168 and
-# saturating by M ≈ 336.
+# ndata = 21, nr_ep = 833, nq = 226380): 7.45 TFLOP/s at M = 21, 10.67 at M = 84, 11.93 at M = 168,
+# saturating at 12.41 by M = 336.
+# 128 sits deliberately below the saturation point, because `M` is bought with per-q device memory:
+# it gives nk_b = 7 at those Cu shapes (M = 147, ~2.0 kB/q of extra `ws.g`), where chasing the last
+# ~4% of throughput at M = 336 would cost ~4.9 kB/q out of a 14.7 kB/q per-q budget and shrink the
+# q-tile by a third on a memory-bound run.
 const _KRKQ_GEMM_M_TARGET = 128
 
 """
@@ -478,7 +482,18 @@ end
 
 # The two-GEMM rotation paths merge `g`'s band and mode axes with a `reshape`, which needs `g` to be
 # densely packed — a reshape of a strided view is a `ReshapedArray`, which the batched GEMMs reject.
-_is_dense(a::AbstractArray) = strides(a) == Base.size_to_strides(1, size(a)...)
+# A non-strided array is `false`, not an error, so the caller's own assertion message is what the
+# user sees. Axes of length 1 carry no meaningful stride, so they are skipped.
+function _is_dense(a::AbstractArray)
+    a isa StridedArray || return false
+    st, sz = strides(a), size(a)
+    expected = 1
+    for d in eachindex(sz)
+        (sz[d] == 1 || st[d] == expected) || return false
+        expected *= sz[d]
+    end
+    true
+end
 
 """
     eph_apply_rotations!(ep_kq_all, g, ukqs, u_phs, tmp; g2_out=nothing, ωq=nothing)

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -156,8 +156,13 @@ end
     get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat::BatchedWannierInterpolator, ks, uks; kq_convention_phase=nothing)
 
 Batched over a list of k-points `ks`. `uks` is `(nw, nband, nk)` (one `uk` per k).
-Writes `ep_ekpR_all`, shape `(nw*nband*nmodes, nr_ep, nk)` — column `k` is the `op_r` of the
+Writes `ep_ekpR_all`, shape `(nw*nband*nmodes, nk, nr_ep)` — slice `[:, k, :]` is the `op_r` of the
 electron-Bloch / phonon-Wannier object at `ks[k]`.
+
+The `k` axis sits in the MIDDLE so that a contiguous run of `nk_b` k-points is a plain `lda` view
+of the 2-D reshape `(nw*nband*nmodes*nk, nr_ep)`: the outer-k GPU loop stacks such a run into one
+tall kR→kq GEMM (see `_krkq_strip_width`), which needs the stacked k to be adjacent in the row
+index. A per-k slice is then strided in `R_p`, which the kR→kq GEMM handles as an `lda`.
 
 One batched Fourier (`get_fourier_batched!`) over `R_el`, then one `batched_gemm!` for the
 per-k rotation by `uk` (recast as `transpose(uk(k)) * permute(g(k))`).
@@ -190,7 +195,7 @@ function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
     M = nmodes * nr_ep
     @assert nmodes * nw^2 * nr_ep == epmat.ndata
     @assert length(ks) == nk
-    @assert size(ep_ekpR_all) == (nw * nband * nmodes, nr_ep, nk)
+    @assert size(ep_ekpR_all) == (nw * nband * nmodes, nk, nr_ep)
 
     g = similar(epmat.op_r, Complex{T}, epmat.ndata, nk)
     get_fourier_batched!(g, itp_epmat, ks)                              # (nw^2*nmodes*nr_ep, nk)
@@ -199,34 +204,59 @@ function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
     C = similar(g, Complex{T}, nband, nw * M, nk)
     batched_gemm!('T', 'N', uks, reshape(gp, nw, nw * M, nk), C)        # C(k)=transpose(uk(k))*gp(k)
     out = permutedims(reshape(C, nband, nw, M, nk), (2, 1, 3, 4))       # (nw, nband, M, k)
-    out3 = reshape(out, nw * nband * nmodes, nr_ep, nk)
+    out3 = PermutedDimsArray(reshape(out, nw * nband * nmodes, nr_ep, nk), (1, 3, 2))
     if kq_convention_phase === nothing
         copyto!(ep_ekpR_all, out3)
     else
         @assert size(kq_convention_phase) == (nr_ep, nk)
-        ep_ekpR_all .= out3 .* conj.(reshape(kq_convention_phase, 1, nr_ep, nk))
+        # `P'` is the lazy conjugate transpose, i.e. `P'[k, ip] = conj(P[ip, k])`.
+        ep_ekpR_all .= out3 .* reshape(kq_convention_phase', 1, nk, nr_ep)
     end
     ep_ekpR_all
 end
 
 """
-    KRtoKQWorkspace(gpu_array, ndata, nbandkq, nbandk, nmodes, nq)
+    KRtoKQWorkspace(gpu_array, ndata, nbandkq, nbandk, nmodes, nq; nk_b = 1)
 
 Preallocated scratch for [`get_eph_kR_to_kq_batched!`](@ref), reused across the per-k calls so the
 driver does no per-call `similar`. `gpu_array` is an array on the target backend (e.g. `parent.op_r`);
 the buffers follow its backend and element type. `ndata = nw*nbandk*nmodes`.
 
+`nk_b` is the kR→kq GEMM strip width ([`_krkq_strip_width`](@ref)): `g` holds the Fourier output of
+`nk_b` stacked outer-k, so it is `(ndata*nk_b, nq)`. `tmp` is per-k and does not scale with it.
+
 TODO: merge this with the other Wannier→Bloch scratch (the eigensolve / velocity buffers) into a
 single shared workspace so a whole computation allocates its device scratch once.
 """
 struct KRtoKQWorkspace{MT<:AbstractMatrix, AT<:AbstractArray}
-    g::MT      # (ndata, nq)                  — Fourier output g(k+R_ep) for all q
+    g::MT      # (ndata*nk_b, nq)             — Fourier output g(k+R_ep) for all q, nk_b k stacked
     tmp::AT    # (nbandkq, nbandk*nmodes, nq) — after the ukq' rotation
 end
-function KRtoKQWorkspace(gpu_array, ndata::Int, nbandkq::Int, nbandk::Int, nmodes::Int, nq::Int)
+function KRtoKQWorkspace(gpu_array, ndata::Int, nbandkq::Int, nbandk::Int, nmodes::Int, nq::Int;
+                         nk_b::Int = 1)
     T = real(eltype(gpu_array))
-    KRtoKQWorkspace(similar(gpu_array, Complex{T}, ndata, nq),
+    KRtoKQWorkspace(similar(gpu_array, Complex{T}, ndata * nk_b, nq),
                     similar(gpu_array, Complex{T}, nbandkq, nbandk * nmodes, nq))
+end
+
+"""
+    eph_kR_to_kq_fourier!(g, ep_kR, phase)
+
+Fourier half of the kR→kq step: `g = ep_kR * phase`, i.e. `g(k, q) = Σ_p g̃(k, R_p) exp(2πi R_p·x_q)`
+(`x_q` is `x_{k+q}` in the k+q convention of [`get_eph_RR_to_kR_batched!`](@ref)). `ep_kR` is
+`(m, nr)`, `phase` is `(nr, nq)`, `g` is `(m, nq)`; all three may be strided views.
+
+`m` is deliberately unconstrained: the caller may stack several outer-k on top of each other
+(`m = ndata*nk_b`, see [`_krkq_strip_width`](@ref)) to turn `nk_b` skinny GEMMs into one tall one
+that reads the `k`-invariant `phase` once. Splitting this out of
+[`get_eph_kR_to_kq_batched!`](@ref) is what lets the Fourier and the rotation run at different loop
+levels, exactly as the phase build was hoisted above the transform.
+"""
+function eph_kR_to_kq_fourier!(g, ep_kR, phase)
+    @assert size(g) == (size(ep_kR, 1), size(phase, 2))
+    @assert size(ep_kR, 2) == size(phase, 1)
+    mul!(g, ep_kR, phase)
+    g
 end
 
 """
@@ -276,8 +306,9 @@ function get_eph_kR_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
         tmp = view(ws.tmp, :, :, 1:nq)
     end
 
-    mul!(g, ep_kR, phase)                                              # (nw*nbandk*nmodes, nq)
-    eph_apply_rotations!(ep_kq_all, g, ukqs, u_phs, tmp; g2_out, ωq)
+    eph_kR_to_kq_fourier!(g, ep_kR, phase)                             # (nw*nbandk*nmodes, nq)
+    eph_apply_rotations!(ep_kq_all, reshape(g, nw, nbandk, nmodes, nq), ukqs, u_phs, tmp;
+                         g2_out, ωq)
     ep_kq_all
 end
 
@@ -412,23 +443,66 @@ function add_eph_dipole_batched!(eps, coeffs, ukqs, uks, mmats)
     eps
 end
 
+# Above this `nw*nmodes` the two rotation GEMMs are large enough that cuBLAS beats the CUDA
+# extension's fused kernel; see `_fused_eph_rot_kernel!` for the full rationale. It lives here
+# rather than in the extension because the outer-k loop reads it to decide whether it may hand
+# `eph_apply_rotations!` a strided `g` (only the fused kernel takes one) — see
+# [`_krkq_strip_width`](@ref). The crossover is hardware-dependent: the value was tuned on one GPU
+# and should be retuned elsewhere.
+const _FUSED_ROT_MAX_NWNM = 24
+
+# Target `M` for the kR→kq GEMM `(ndata*nk_b) × nr_ep` × `nr_ep × nq`. `M = ndata` alone is far
+# below a cuBLAS M-tile at small `ndata`, so each phase element feeds only `ndata` rows of MACs and
+# the k-invariant phase tile is re-read once per k. Measured on an A100-80GB (225 W cap, Cu shapes
+# ndata = 21, nr_ep = 833, nq = 226380): 7.45 TFLOP/s at M = 21 rising to 11.93 at M = 168 and
+# saturating by M ≈ 336.
+const _KRKQ_GEMM_M_TARGET = 128
+
+"""
+    _krkq_strip_width(; nw, nbandk_max, nmodes, nk_batch_max) -> nk_b
+
+Number of outer-k the GPU outer-k loop stacks into one tall kR→kq GEMM
+([`eph_kR_to_kq_fourier!`](@ref)). Shape-derived from `ndata = nw*nbandk_max*nmodes` so that the
+GEMM's `M = ndata*nk_b` reaches `_KRKQ_GEMM_M_TARGET`; the extra device memory is therefore
+`16·(M_target - ndata)` bytes per q, independent of the model.
+
+Returns 1 — no strip, the layout of every buffer as before — when `ndata` already fills the M-tile
+(large `nw`/`nmodes`, where the strip would only cost memory) or when `nw*nmodes` exceeds
+`_FUSED_ROT_MAX_NWNM`: a strip's per-k `g` slice is strided in `q`, which only the fused rotation
+kernel can read.
+"""
+function _krkq_strip_width(; nw, nbandk_max, nmodes, nk_batch_max)
+    nw * nmodes <= _FUSED_ROT_MAX_NWNM || return 1
+    clamp(cld(_KRKQ_GEMM_M_TARGET, nw * nbandk_max * nmodes), 1, Int(nk_batch_max))
+end
+
+# The two-GEMM rotation paths merge `g`'s band and mode axes with a `reshape`, which needs `g` to be
+# densely packed — a reshape of a strided view is a `ReshapedArray`, which the batched GEMMs reject.
+_is_dense(a::AbstractArray) = strides(a) == Base.size_to_strides(1, size(a)...)
+
 """
     eph_apply_rotations!(ep_kq_all, g, ukqs, u_phs, tmp; g2_out=nothing, ωq=nothing)
 
-Apply the two e-ph gauge rotations to the Fourier-interpolated `g` (`(ndata, nq)`, reshaped to
-`(nw, nbandk, nmodes, nq)`), writing the eigenbasis e-ph matrix `ep_kq_all`
+Apply the two e-ph gauge rotations to the Fourier-interpolated `g` `(nw, nbandk, nmodes, nq)`,
+writing the eigenbasis e-ph matrix `ep_kq_all`
 `(nbandkq, nbandk, nmodes, nq)` = `ukq(q)' * g(q) * u_ph(q)`. If `g2_out !== nothing`, also write
 `g2 = |ep_kq|² / (2 ωq)` (with `ωq` `(nmodes, nq)`) in the same pass.
+
+`g` may be a view strided in `q` — one k's slice of a `nk_b`-wide kR→kq strip
+([`_krkq_strip_width`](@ref)) is exactly that — but only on the CUDA extension's fused path, which
+indexes `g` elementwise. The generic two-GEMM method below requires a dense `g`.
 
 Generic method: the two strided-batched GEMMs (`ukq'` on the left, `u_ph` on the right) plus an
 optional `g2` broadcast — identical to the previous inline code, so any backend works. The CUDA
 extension overrides this with a fused per-q kernel for small `nw*nmodes`, which avoids cuBLAS'
 tiny-matmul inefficiency (the 4×4 / nmodes×nmodes strided-batched GEMMs run at ~2% of FP64 peak).
 """
-function eph_apply_rotations!(ep_kq_all::AbstractArray{Complex{T},4}, g,
+function eph_apply_rotations!(ep_kq_all::AbstractArray{Complex{T},4}, g::AbstractArray{Complex{T},4},
                               ukqs, u_phs, tmp; g2_out=nothing, ωq=nothing) where {T}
     nbandkq, nbandk, nmodes, nq = size(ep_kq_all)
     nw = size(ukqs, 1)
+    @assert size(g) == (nw, nbandk, nmodes, nq)
+    @assert _is_dense(g) "the two-GEMM rotation path needs a dense g; a strided kR→kq strip slice is only supported by the CUDA fused kernel"
     batched_gemm!('C', 'N', ukqs, reshape(g, nw, nbandk * nmodes, nq), tmp)   # ukq(q)' * g(q)
     batched_gemm!('N', 'N', reshape(tmp, nbandkq * nbandk, nmodes, nq), u_phs,
                   reshape(ep_kq_all, nbandkq * nbandk, nmodes, nq))           # * u_ph(q)

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -156,13 +156,8 @@ end
     get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat::BatchedWannierInterpolator, ks, uks; kq_convention_phase=nothing)
 
 Batched over a list of k-points `ks`. `uks` is `(nw, nband, nk)` (one `uk` per k).
-Writes `ep_ekpR_all`, shape `(nw*nband*nmodes, nk, nr_ep)` — slice `[:, k, :]` is the `op_r` of the
+Writes `ep_ekpR_all`, shape `(nw*nband*nmodes, nr_ep, nk)` — column `k` is the `op_r` of the
 electron-Bloch / phonon-Wannier object at `ks[k]`.
-
-The `k` axis sits in the MIDDLE so that a contiguous run of `nk_b` k-points is a plain `lda` view
-of the 2-D reshape `(nw*nband*nmodes*nk, nr_ep)`: the outer-k GPU loop stacks such a run into one
-tall kR→kq GEMM (see `_krkq_strip_width`), which needs the stacked k to be adjacent in the row
-index. A per-k slice is then strided in `R_p`, which the kR→kq GEMM handles as an `lda`.
 
 One batched Fourier (`get_fourier_batched!`) over `R_el`, then one `batched_gemm!` for the
 per-k rotation by `uk` (recast as `transpose(uk(k)) * permute(g(k))`).
@@ -195,7 +190,7 @@ function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
     M = nmodes * nr_ep
     @assert nmodes * nw^2 * nr_ep == epmat.ndata
     @assert length(ks) == nk
-    @assert size(ep_ekpR_all) == (nw * nband * nmodes, nk, nr_ep)
+    @assert size(ep_ekpR_all) == (nw * nband * nmodes, nr_ep, nk)
 
     g = similar(epmat.op_r, Complex{T}, epmat.ndata, nk)
     get_fourier_batched!(g, itp_epmat, ks)                              # (nw^2*nmodes*nr_ep, nk)
@@ -204,59 +199,34 @@ function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
     C = similar(g, Complex{T}, nband, nw * M, nk)
     batched_gemm!('T', 'N', uks, reshape(gp, nw, nw * M, nk), C)        # C(k)=transpose(uk(k))*gp(k)
     out = permutedims(reshape(C, nband, nw, M, nk), (2, 1, 3, 4))       # (nw, nband, M, k)
-    out3 = PermutedDimsArray(reshape(out, nw * nband * nmodes, nr_ep, nk), (1, 3, 2))
+    out3 = reshape(out, nw * nband * nmodes, nr_ep, nk)
     if kq_convention_phase === nothing
         copyto!(ep_ekpR_all, out3)
     else
         @assert size(kq_convention_phase) == (nr_ep, nk)
-        # `P'` is the lazy conjugate transpose, i.e. `P'[k, ip] = conj(P[ip, k])`.
-        ep_ekpR_all .= out3 .* reshape(kq_convention_phase', 1, nk, nr_ep)
+        ep_ekpR_all .= out3 .* conj.(reshape(kq_convention_phase, 1, nr_ep, nk))
     end
     ep_ekpR_all
 end
 
 """
-    KRtoKQWorkspace(gpu_array, ndata, nbandkq, nbandk, nmodes, nq; nk_b = 1)
+    KRtoKQWorkspace(gpu_array, ndata, nbandkq, nbandk, nmodes, nq)
 
 Preallocated scratch for [`get_eph_kR_to_kq_batched!`](@ref), reused across the per-k calls so the
 driver does no per-call `similar`. `gpu_array` is an array on the target backend (e.g. `parent.op_r`);
 the buffers follow its backend and element type. `ndata = nw*nbandk*nmodes`.
 
-`nk_b` is the kR→kq GEMM strip width ([`_krkq_strip_width`](@ref)): `g` holds the Fourier output of
-`nk_b` stacked outer-k, so it is `(ndata*nk_b, nq)`. `tmp` is per-k and does not scale with it.
-
 TODO: merge this with the other Wannier→Bloch scratch (the eigensolve / velocity buffers) into a
 single shared workspace so a whole computation allocates its device scratch once.
 """
 struct KRtoKQWorkspace{MT<:AbstractMatrix, AT<:AbstractArray}
-    g::MT      # (ndata*nk_b, nq)             — Fourier output g(k+R_ep) for all q, nk_b k stacked
+    g::MT      # (ndata, nq)                  — Fourier output g(k+R_ep) for all q
     tmp::AT    # (nbandkq, nbandk*nmodes, nq) — after the ukq' rotation
 end
-function KRtoKQWorkspace(gpu_array, ndata::Int, nbandkq::Int, nbandk::Int, nmodes::Int, nq::Int;
-                         nk_b::Int = 1)
+function KRtoKQWorkspace(gpu_array, ndata::Int, nbandkq::Int, nbandk::Int, nmodes::Int, nq::Int)
     T = real(eltype(gpu_array))
-    KRtoKQWorkspace(similar(gpu_array, Complex{T}, ndata * nk_b, nq),
+    KRtoKQWorkspace(similar(gpu_array, Complex{T}, ndata, nq),
                     similar(gpu_array, Complex{T}, nbandkq, nbandk * nmodes, nq))
-end
-
-"""
-    eph_kR_to_kq_fourier!(g, ep_kR, phase)
-
-Fourier half of the kR→kq step: `g = ep_kR * phase`, i.e. `g(k, q) = Σ_p g̃(k, R_p) exp(2πi R_p·x_q)`
-(`x_q` is `x_{k+q}` in the k+q convention of [`get_eph_RR_to_kR_batched!`](@ref)). `ep_kR` is
-`(m, nr)`, `phase` is `(nr, nq)`, `g` is `(m, nq)`; all three may be strided views.
-
-`m` is deliberately unconstrained: the caller may stack several outer-k on top of each other
-(`m = ndata*nk_b`, see [`_krkq_strip_width`](@ref)) to turn `nk_b` skinny GEMMs into one tall one
-that reads the `k`-invariant `phase` once. Splitting this out of
-[`get_eph_kR_to_kq_batched!`](@ref) is what lets the Fourier and the rotation run at different loop
-levels, exactly as the phase build was hoisted above the transform.
-"""
-function eph_kR_to_kq_fourier!(g, ep_kR, phase)
-    @assert size(g) == (size(ep_kR, 1), size(phase, 2))
-    @assert size(ep_kR, 2) == size(phase, 1)
-    mul!(g, ep_kR, phase)
-    g
 end
 
 """
@@ -306,7 +276,7 @@ function get_eph_kR_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
         tmp = view(ws.tmp, :, :, 1:nq)
     end
 
-    eph_kR_to_kq_fourier!(g, ep_kR, phase)                             # (nw*nbandk*nmodes, nq)
+    mul!(g, ep_kR, phase)                                              # (nw*nbandk*nmodes, nq)
     eph_apply_rotations!(ep_kq_all, reshape(g, nw, nbandk, nmodes, nq), ukqs, u_phs, tmp;
                          g2_out, ωq)
     ep_kq_all
@@ -445,48 +415,18 @@ end
 
 # Above this `nw*nmodes` the two rotation GEMMs are large enough that cuBLAS beats the CUDA
 # extension's fused kernel; see `_fused_eph_rot_kernel!` for the full rationale. It lives here
-# rather than in the extension because the outer-k loop reads it to decide whether it may hand
-# `eph_apply_rotations!` a strided `g` (only the fused kernel takes one) — see
-# [`_krkq_strip_width`](@ref). The crossover is hardware-dependent: the value was tuned on one GPU
-# and should be retuned elsewhere.
+# rather than in the extension so the base package documents the crossover the generic
+# `eph_apply_rotations!` docstring refers to. The crossover is hardware-dependent: the value was
+# tuned on one GPU and should be retuned elsewhere.
 const _FUSED_ROT_MAX_NWNM = 24
-
-# Target `M` for the kR→kq GEMM `(ndata*nk_b) × nr_ep` × `nr_ep × nq`. `M = ndata` alone is far
-# below a cuBLAS M-tile at small `ndata`, so each phase element feeds only `ndata` rows of MACs and
-# the k-invariant phase tile is re-read once per k. Measured on an A100-80GB (225 W cap, Cu shapes
-# ndata = 21, nr_ep = 833, nq = 226380): 7.45 TFLOP/s at M = 21, 10.67 at M = 84, 11.93 at M = 168,
-# saturating at 12.41 by M = 336.
-# 128 sits deliberately below the saturation point, because `M` is bought with per-q device memory:
-# it gives nk_b = 7 at those Cu shapes (M = 147, ~2.0 kB/q of extra `ws.g`), where chasing the last
-# ~4% of throughput at M = 336 would cost ~4.9 kB/q out of a 14.7 kB/q per-q budget and shrink the
-# q-tile by a third on a memory-bound run.
-const _KRKQ_GEMM_M_TARGET = 128
-
-"""
-    _krkq_strip_width(; nw, nbandk_max, nmodes, nk_batch_max) -> nk_b
-
-Number of outer-k the GPU outer-k loop stacks into one tall kR→kq GEMM
-([`eph_kR_to_kq_fourier!`](@ref)). Shape-derived from `ndata = nw*nbandk_max*nmodes` so that the
-GEMM's `M = ndata*nk_b` reaches `_KRKQ_GEMM_M_TARGET`; the extra device memory is therefore
-`16·(M_target - ndata)` bytes per q, independent of the model.
-
-Returns 1 — no strip, the layout of every buffer as before — when `ndata` already fills the M-tile
-(large `nw`/`nmodes`, where the strip would only cost memory) or when `nw*nmodes` exceeds
-`_FUSED_ROT_MAX_NWNM`: a strip's per-k `g` slice is strided in `q`, which only the fused rotation
-kernel can read.
-"""
-function _krkq_strip_width(; nw, nbandk_max, nmodes, nk_batch_max)
-    nw * nmodes <= _FUSED_ROT_MAX_NWNM || return 1
-    clamp(cld(_KRKQ_GEMM_M_TARGET, nw * nbandk_max * nmodes), 1, Int(nk_batch_max))
-end
 
 # The two-GEMM rotation paths merge `g`'s band and mode axes with a `reshape`, which needs `g` to be
 # densely packed — a reshape of a strided view is a `ReshapedArray`, which the batched GEMMs reject.
 # A non-strided array is `false`, not an error, so the caller's own assertion message is what the
 # user sees. Axes of length 1 carry no meaningful stride, so they are skipped.
 # Necessary but not sufficient on the device: a `view` that drops an axis can be dense and still
-# reshape to a pointerless `ReshapedArray`. Callers must hand over an operand that survives the
-# reshape — that is what [`_strip_g_slice`](@ref) is for.
+# reshape to a pointerless `ReshapedArray`, while a contiguous 2-D column slice reshapes back to a
+# plain device array. Callers must hand over an operand that survives the reshape.
 function _is_dense(a::AbstractArray)
     a isa StridedArray || return false
     st, sz = strides(a), size(a)
@@ -498,23 +438,6 @@ function _is_dense(a::AbstractArray)
     true
 end
 
-# One k's operand for `eph_apply_rotations!`, taken out of a kR→kq strip: `g_2d` is the strip's
-# `(ndata*nk_b, nq_max)` Fourier buffer and `g_strip5` its `(nw, nbandk, nmodes, nk_b, nq_max)`
-# view; `kloc` is the k's position in the strip and `rng_q` the q-tile's column range.
-#
-# At `nk_b > 1` the slice is q-strided, which only the fused rotation kernel reads. At `nk_b = 1`
-# the strip IS the k, and the slice is taken off the 2-D buffer instead of as `g_strip5[…, 1, rng_q]`
-# even though the two address the same elements: a `view` that drops the k axis is dense but its
-# `reshape` — which the two-GEMM branches do to merge the band and mode axes — is a `ReshapedArray`
-# with no pointer, while a contiguous 2-D column slice reshapes back to a plain device array. That
-# is the operand shape the two-GEMM branches need, and `nk_b = 1` is exactly the case a large-`nw`
-# model gets, where the fused kernel is not available (see [`_krkq_strip_width`](@ref)).
-function _strip_g_slice(g_2d::AbstractMatrix, g_strip5::AbstractArray{<:Any,5}, kloc::Int, rng_q)
-    nw, nbandk, nmodes, nk_b, _ = size(g_strip5)
-    nk_b == 1 && return reshape(view(g_2d, :, rng_q), nw, nbandk, nmodes, length(rng_q))
-    view(g_strip5, :, :, :, kloc, rng_q)
-end
-
 """
     eph_apply_rotations!(ep_kq_all, g, ukqs, u_phs, tmp; g2_out=nothing, ωq=nothing)
 
@@ -523,9 +446,8 @@ writing the eigenbasis e-ph matrix `ep_kq_all`
 `(nbandkq, nbandk, nmodes, nq)` = `ukq(q)' * g(q) * u_ph(q)`. If `g2_out !== nothing`, also write
 `g2 = |ep_kq|² / (2 ωq)` (with `ωq` `(nmodes, nq)`) in the same pass.
 
-`g` may be a view strided in `q` — one k's slice of a `nk_b`-wide kR→kq strip
-([`_krkq_strip_width`](@ref)) is exactly that — but only on the CUDA extension's fused path, which
-indexes `g` elementwise. The generic two-GEMM method below requires a dense `g`.
+The two-GEMM paths merge `g`'s band and mode axes with a `reshape`, so they require a dense `g`
+(asserted); the CUDA extension's fused path indexes `g` elementwise and takes any strided view.
 
 Generic method: the two strided-batched GEMMs (`ukq'` on the left, `u_ph` on the right) plus an
 optional `g2` broadcast — identical to the previous inline code, so any backend works. The CUDA
@@ -537,7 +459,7 @@ function eph_apply_rotations!(ep_kq_all::AbstractArray{Complex{T},4}, g::Abstrac
     nbandkq, nbandk, nmodes, nq = size(ep_kq_all)
     nw = size(ukqs, 1)
     @assert size(g) == (nw, nbandk, nmodes, nq)
-    @assert _is_dense(g) "the two-GEMM rotation path needs a dense g; a strided kR→kq strip slice is only supported by the CUDA fused kernel"
+    @assert _is_dense(g) "the two-GEMM rotation path needs a dense g; a strided g is only supported by the CUDA fused kernel"
     batched_gemm!('C', 'N', ukqs, reshape(g, nw, nbandk * nmodes, nq), tmp)   # ukq(q)' * g(q)
     batched_gemm!('N', 'N', reshape(tmp, nbandkq * nbandk, nmodes, nq), u_phs,
                   reshape(ep_kq_all, nbandkq * nbandk, nmodes, nq))           # * u_ph(q)

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -226,7 +226,6 @@ end
 
 """
     get_eph_kR_to_kq_batched!(ep_kq_all, ep_kR::AbstractMatrix, phase::AbstractMatrix, u_phs, ukqs; ws=nothing)
-    get_eph_kR_to_kq_batched!(ep_kq_all, itp_ep_ekpR::BatchedWannierInterpolator, qs, u_phs, ukqs; ws=nothing)
 
 Batched over a list of q-points (for a fixed k). `ukqs` is `(nw, nbandkq, nq)` and
 `u_phs` is `(nmodes, nmodes, nq)`. Writes `ep_kq_all`, shape `(nbandkq, nbandk, nmodes, nq)`.
@@ -234,16 +233,10 @@ Batched over a list of q-points (for a fixed k). `ukqs` is `(nw, nbandkq, nq)` a
 One batched Fourier over `R_ep`, then two `batched_gemm!`s for the per-q rotations
 (`ukq(q)'` on the left, `u_ph(q)` on the right).
 
-The routine really consumes three things: the kR intermediate `g(k, R_p)`, the Fourier phase
-`exp(2πi R_p · x_q)` and the rotations. The **first method** takes those directly — `ep_kR` is
-`(nw*nbandk*nmodes, nr)` and `phase` is `(nr, nq)` — so a caller that can build one phase matrix
-and reuse it over many `k` (the GPU outer-k loop, via the k+q convention of
-[`get_eph_RR_to_kR_batched!`](@ref)) never rebuilds it; it is the form the driver uses.
-The **second method** is the convenience form for a caller that just has a q-list: it builds the
-phase from `qs` into the interpolator's scratch and delegates. No `src` caller uses it — it is what
-`test/test_gpu.jl` calls, so that the tests exercise the routine without duplicating the phase build
-at every call site. It needs an **in-memory** parent (it reads `parent.op_r`), so unlike
-[`fourier_batched!`](@ref) it does not support a `DiskWannierObject` parent.
+The three inputs are the kR intermediate `g(k, R_p)` as `ep_kR`, `(nw*nbandk*nmodes, nr)`; the
+Fourier phase `exp(2πi R_p · x_q)` as `phase`, `(nr, nq)`; and the rotations. Taking the phase
+rather than a q-list is what lets a caller build it once and reuse it over many `k` — the GPU
+outer-k loop does that via the k+q convention of [`get_eph_RR_to_kR_batched!`](@ref).
 
 Pass a [`KRtoKQWorkspace`](@ref) as `ws` (sized for at least this `nq`) to reuse the `g` / `tmp`
 scratch across calls instead of allocating it each call — the per-k hot path in the GPU loop does
@@ -277,17 +270,6 @@ function get_eph_kR_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
     eph_apply_rotations!(ep_kq_all, reshape(g, nw, nbandk, nmodes, nq), ukqs, u_phs, tmp;
                          g2_out, ωq)
     ep_kq_all
-end
-
-function get_eph_kR_to_kq_batched!(ep_kq_all::AbstractArray{Complex{T},4},
-                                   itp_ep_ekpR::BatchedWannierInterpolator{T}, qs, u_phs, ukqs;
-                                   ws::Union{Nothing,KRtoKQWorkspace}=nothing,
-                                   g2_out=nothing, ωq=nothing) where {T}
-    parent = itp_ep_ekpR.parent
-    ndata = parent.ndata
-    phase = _build_phase!(itp_ep_ekpR.core, qs)
-    @views get_eph_kR_to_kq_batched!(ep_kq_all, parent.op_r[1:ndata, :], phase, u_phs, ukqs;
-                                     ws, g2_out, ωq)
 end
 
 """
@@ -414,8 +396,13 @@ end
 # extension's fused kernel; see `_fused_eph_rot_kernel!` for the full rationale. It lives here
 # rather than in the extension so the base package documents the crossover the generic
 # `eph_apply_rotations!` docstring refers to. The crossover is hardware-dependent: the value was
-# tuned on one GPU and should be retuned elsewhere. Worth measuring before removing it: on the Cu
-# outer-k BTE loop (nw=7, nmodes=3, A100) the fused path is 31.1 s against 47.0 s for the two GEMMs.
+# tuned on one GPU and should be retuned elsewhere.
+#
+# Measured, so it does not get removed as a "small-size optimization": at nw=7, nmodes=3 (Cu,
+# ndata=21) the fused kernel is **1.51x faster than cuBLAS** — 34% less wall on the whole outer-k
+# BTE loop, 31.07 s vs 47.00 s at nk=150 on an A100-80GB. Note the two paths are not bit-identical
+# (the fused one folds g2 = |ep|^2/(2w) from registers instead of in a second full-array pass), so
+# compare them with a tolerance, not bitwise.
 const _FUSED_ROT_MAX_NWNM = 24
 
 # The two-GEMM rotation paths merge `g`'s band and mode axes with a `reshape`, which needs `g` to be

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -484,6 +484,9 @@ end
 # densely packed — a reshape of a strided view is a `ReshapedArray`, which the batched GEMMs reject.
 # A non-strided array is `false`, not an error, so the caller's own assertion message is what the
 # user sees. Axes of length 1 carry no meaningful stride, so they are skipped.
+# Necessary but not sufficient on the device: a `view` that drops an axis can be dense and still
+# reshape to a pointerless `ReshapedArray`. Callers must hand over an operand that survives the
+# reshape — that is what [`_strip_g_slice`](@ref) is for.
 function _is_dense(a::AbstractArray)
     a isa StridedArray || return false
     st, sz = strides(a), size(a)
@@ -493,6 +496,23 @@ function _is_dense(a::AbstractArray)
         expected *= sz[d]
     end
     true
+end
+
+# One k's operand for `eph_apply_rotations!`, taken out of a kR→kq strip: `g_2d` is the strip's
+# `(ndata*nk_b, nq_max)` Fourier buffer and `g_strip5` its `(nw, nbandk, nmodes, nk_b, nq_max)`
+# view; `kloc` is the k's position in the strip and `rng_q` the q-tile's column range.
+#
+# At `nk_b > 1` the slice is q-strided, which only the fused rotation kernel reads. At `nk_b = 1`
+# the strip IS the k, and the slice is taken off the 2-D buffer instead of as `g_strip5[…, 1, rng_q]`
+# even though the two address the same elements: a `view` that drops the k axis is dense but its
+# `reshape` — which the two-GEMM branches do to merge the band and mode axes — is a `ReshapedArray`
+# with no pointer, while a contiguous 2-D column slice reshapes back to a plain device array. That
+# is the operand shape the two-GEMM branches need, and `nk_b = 1` is exactly the case a large-`nw`
+# model gets, where the fused kernel is not available (see [`_krkq_strip_width`](@ref)).
+function _strip_g_slice(g_2d::AbstractMatrix, g_strip5::AbstractArray{<:Any,5}, kloc::Int, rng_q)
+    nw, nbandk, nmodes, nk_b, _ = size(g_strip5)
+    nk_b == 1 && return reshape(view(g_2d, :, rng_q), nw, nbandk, nmodes, length(rng_q))
+    view(g_strip5, :, :, :, kloc, rng_q)
 end
 
 """

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -163,11 +163,11 @@ One batched Fourier (`get_fourier_batched!`) over `R_el`, then one `batched_gemm
 per-k rotation by `uk` (recast as `transpose(uk(k)) * permute(g(k))`).
 
 `additional_phase`, if given, is `(nr_ep × nk)` — one entry per (parent `irvec_next` R-vector, k) —
-and is conjugated into the output, so the stored child object is
-`conj(additional_phase[ip, k]) · g(k, R_p)` instead of the plain `g(k, R_p)`. It is folded into the
-final `copyto!`, which already reads and writes the whole array, so it costs nothing. The GPU
-outer-k loop passes `exp(2πi R_p · x_k)` here to store `g` in the k+q convention, which makes the
-following `R_p` Fourier a function of `x_{k+q}` alone and hence independent of the outer `k`.
+and multiplies the output, so the stored child object is `additional_phase[ip, k] · g(k, R_p)`
+instead of the plain `g(k, R_p)`. It is folded into the final `copyto!`, which already reads and
+writes the whole array, so it costs nothing. The GPU outer-k loop passes `conj(exp(2πi R_p · x_k))`
+here to store `g` in the k+q convention, which makes the following `R_p` Fourier a function of
+`x_{k+q}` alone and hence independent of the outer `k`.
 
 Requires a UNIFORM `nband` across the batch: `ep_ekpR_all` is sized exactly
 `(nw*nband*nmodes, …)`, so all `nk` k-points must share the same `nband` (unlike the per-k
@@ -199,7 +199,7 @@ function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
         copyto!(ep_ekpR_all, out3)
     else
         @assert size(additional_phase) == (nr_ep, nk)
-        ep_ekpR_all .= out3 .* conj.(reshape(additional_phase, 1, nr_ep, nk))
+        ep_ekpR_all .= out3 .* reshape(additional_phase, 1, nr_ep, nk)
     end
     ep_ekpR_all
 end

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -153,7 +153,7 @@ end
 #  wins on the GPU. Rotation matrices are stacked along the batch dimension.
 
 """
-    get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat::BatchedWannierInterpolator, ks, uks; kq_convention_phase=nothing)
+    get_eph_RR_to_kR_batched!(ep_ekpR_all, itp_epmat::BatchedWannierInterpolator, ks, uks; additional_phase=nothing)
 
 Batched over a list of k-points `ks`. `uks` is `(nw, nband, nk)` (one `uk` per k).
 Writes `ep_ekpR_all`, shape `(nw*nband*nmodes, nr_ep, nk)` — column `k` is the `op_r` of the
@@ -162,17 +162,12 @@ electron-Bloch / phonon-Wannier object at `ks[k]`.
 One batched Fourier (`get_fourier_batched!`) over `R_el`, then one `batched_gemm!` for the
 per-k rotation by `uk` (recast as `transpose(uk(k)) * permute(g(k))`).
 
-# k+q convention
-`kq_convention_phase`, if given, is `(nr_ep × nk)` with `P[ip, k] = exp(2πi R_p · x_k)`, where
-`R_p` must be the parent's **`irvec_next`** list, in order (build it with
-[`fourier_phase!`](@ref) from `_irvec_matrix(epmat.irvec_next, …)` — the size assert cannot catch a
-phase built from the wrong R list when `nr_el == nr_ep`); the child object is then stored in the
-**k+q convention**
-`g̃(k, R_p) = conj(P[ip, k]) · g(k, R_p)` instead of the plain `g(k, R_p)`. Because `R_p` is an
-integer vector, the following `R_p` Fourier can then be evaluated at `x_{k+q}` directly rather than
-at `q = x_{k+q} - x_k`: `exp(2πi R_p·q) = exp(2πi R_p·x_{k+q}) · conj(exp(2πi R_p·x_k))`. Its phase
-matrix therefore depends only on the k+q list and is loop-invariant in `k`. Folded into the final
-`copyto!`, which already reads and writes the whole array, so it costs nothing.
+`additional_phase`, if given, is `(nr_ep × nk)` — one entry per (parent `irvec_next` R-vector, k) —
+and is conjugated into the output, so the stored child object is
+`conj(additional_phase[ip, k]) · g(k, R_p)` instead of the plain `g(k, R_p)`. It is folded into the
+final `copyto!`, which already reads and writes the whole array, so it costs nothing. The GPU
+outer-k loop passes `exp(2πi R_p · x_k)` here to store `g` in the k+q convention, which makes the
+following `R_p` Fourier a function of `x_{k+q}` alone and hence independent of the outer `k`.
 
 Requires a UNIFORM `nband` across the batch: `ep_ekpR_all` is sized exactly
 `(nw*nband*nmodes, …)`, so all `nk` k-points must share the same `nband` (unlike the per-k
@@ -182,7 +177,7 @@ every k onto the same `nbandk_max`-wide eigenvector window (`nband = nbandk_max`
 """
 function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
                                    itp_epmat::BatchedWannierInterpolator{T}, ks, uks;
-                                   kq_convention_phase=nothing) where {T}
+                                   additional_phase=nothing) where {T}
     epmat = itp_epmat.parent
     nr_ep = length(epmat.irvec_next)
     nw, nband, nk = size(uks)
@@ -200,11 +195,11 @@ function get_eph_RR_to_kR_batched!(ep_ekpR_all::AbstractArray{Complex{T},3},
     batched_gemm!('T', 'N', uks, reshape(gp, nw, nw * M, nk), C)        # C(k)=transpose(uk(k))*gp(k)
     out = permutedims(reshape(C, nband, nw, M, nk), (2, 1, 3, 4))       # (nw, nband, M, k)
     out3 = reshape(out, nw * nband * nmodes, nr_ep, nk)
-    if kq_convention_phase === nothing
+    if additional_phase === nothing
         copyto!(ep_ekpR_all, out3)
     else
-        @assert size(kq_convention_phase) == (nr_ep, nk)
-        ep_ekpR_all .= out3 .* conj.(reshape(kq_convention_phase, 1, nr_ep, nk))
+        @assert size(additional_phase) == (nr_ep, nk)
+        ep_ekpR_all .= out3 .* conj.(reshape(additional_phase, 1, nr_ep, nk))
     end
     ep_ekpR_all
 end
@@ -243,10 +238,12 @@ The routine really consumes three things: the kR intermediate `g(k, R_p)`, the F
 `exp(2πi R_p · x_q)` and the rotations. The **first method** takes those directly — `ep_kR` is
 `(nw*nbandk*nmodes, nr)` and `phase` is `(nr, nq)` — so a caller that can build one phase matrix
 and reuse it over many `k` (the GPU outer-k loop, via the k+q convention of
-[`get_eph_RR_to_kR_batched!`](@ref)) never rebuilds it. The **second method** is the convenience
-form: it builds the phase from the q-list `qs` into the interpolator's scratch and delegates; it
-needs an **in-memory** parent (it reads `parent.op_r`), so unlike [`fourier_batched!`](@ref) it does
-not support a `DiskWannierObject` parent.
+[`get_eph_RR_to_kR_batched!`](@ref)) never rebuilds it; it is the form the driver uses.
+The **second method** is the convenience form for a caller that just has a q-list: it builds the
+phase from `qs` into the interpolator's scratch and delegates. No `src` caller uses it — it is what
+`test/test_gpu.jl` calls, so that the tests exercise the routine without duplicating the phase build
+at every call site. It needs an **in-memory** parent (it reads `parent.op_r`), so unlike
+[`fourier_batched!`](@ref) it does not support a `DiskWannierObject` parent.
 
 Pass a [`KRtoKQWorkspace`](@ref) as `ws` (sized for at least this `nq`) to reuse the `g` / `tmp`
 scratch across calls instead of allocating it each call — the per-k hot path in the GPU loop does
@@ -417,7 +414,8 @@ end
 # extension's fused kernel; see `_fused_eph_rot_kernel!` for the full rationale. It lives here
 # rather than in the extension so the base package documents the crossover the generic
 # `eph_apply_rotations!` docstring refers to. The crossover is hardware-dependent: the value was
-# tuned on one GPU and should be retuned elsewhere.
+# tuned on one GPU and should be retuned elsewhere. Worth measuring before removing it: on the Cu
+# outer-k BTE loop (nw=7, nmodes=3, A100) the fused path is 31.1 s against 47.0 s for the two GEMMs.
 const _FUSED_ROT_MAX_NWNM = 24
 
 # The two-GEMM rotation paths merge `g`'s band and mode axes with a `reshape`, which needs `g` to be

--- a/src/wannier_to_bloch_batched.jl
+++ b/src/wannier_to_bloch_batched.jl
@@ -163,8 +163,11 @@ One batched Fourier (`get_fourier_batched!`) over `R_el`, then one `batched_gemm
 per-k rotation by `uk` (recast as `transpose(uk(k)) * permute(g(k))`).
 
 # k+q convention
-`kq_convention_phase`, if given, is `(nr_ep × nk)` with `P[ip, k] = exp(2πi R_p · x_k)` (build it
-with [`fourier_phase!`](@ref)); the child object is then stored in the **k+q convention**
+`kq_convention_phase`, if given, is `(nr_ep × nk)` with `P[ip, k] = exp(2πi R_p · x_k)`, where
+`R_p` must be the parent's **`irvec_next`** list, in order (build it with
+[`fourier_phase!`](@ref) from `_irvec_matrix(epmat.irvec_next, …)` — the size assert cannot catch a
+phase built from the wrong R list when `nr_el == nr_ep`); the child object is then stored in the
+**k+q convention**
 `g̃(k, R_p) = conj(P[ip, k]) · g(k, R_p)` instead of the plain `g(k, R_p)`. Because `R_p` is an
 integer vector, the following `R_p` Fourier can then be evaluated at `x_{k+q}` directly rather than
 at `q = x_{k+q} - x_k`: `exp(2πi R_p·q) = exp(2πi R_p·x_{k+q}) · conj(exp(2πi R_p·x_k))`. Its phase
@@ -241,7 +244,9 @@ The routine really consumes three things: the kR intermediate `g(k, R_p)`, the F
 `(nw*nbandk*nmodes, nr)` and `phase` is `(nr, nq)` — so a caller that can build one phase matrix
 and reuse it over many `k` (the GPU outer-k loop, via the k+q convention of
 [`get_eph_RR_to_kR_batched!`](@ref)) never rebuilds it. The **second method** is the convenience
-form: it builds the phase from the q-list `qs` into the interpolator's scratch and delegates.
+form: it builds the phase from the q-list `qs` into the interpolator's scratch and delegates; it
+needs an **in-memory** parent (it reads `parent.op_r`), so unlike [`fourier_batched!`](@ref) it does
+not support a `DiskWannierObject` parent.
 
 Pass a [`KRtoKQWorkspace`](@ref) as `ws` (sized for at least this `nq`) to reuse the `g` / `tmp`
 scratch across calls instead of allocating it each call — the per-k hot path in the GPU loop does

--- a/test/boltzmann/test_hdf5.jl
+++ b/test/boltzmann/test_hdf5.jl
@@ -101,5 +101,16 @@ end
     arr_read = @inferred test_hdf_io_btdata(arr)
     @test arr ≈ arr_read
 
-    # TODO: Kpoints, GridKpoints, ...
+    # GridKpoints: the xk->ik indices are derived caches, so they are not written and are rebuilt
+    # by the constructor on load.
+    kpts = GridKpoints(ElectronPhonon.kpoints_grid((2, 2, 3)))
+    kpts_read = test_hdf_io_btdata(kpts)
+    @test kpts_read == kpts
+    @test all(xk_to_ik.(kpts_read.vectors, Ref(kpts_read)) .== 1:kpts_read.n)
+    @test !isempty(kpts_read._dense_hash_to_ik)
+    h5open(joinpath(tmp_dir, "tmp_data.h5"), "r") do f
+        @test Set(keys(f)) == Set(["n", "vectors", "weights", "ngrid", "shift"])
+    end
+
+    # TODO: Kpoints, ...
 end

--- a/test/boltzmann/test_hdf5.jl
+++ b/test/boltzmann/test_hdf5.jl
@@ -105,7 +105,12 @@ end
     # by the constructor on load.
     kpts = GridKpoints(ElectronPhonon.kpoints_grid((2, 2, 3)))
     kpts_read = test_hdf_io_btdata(kpts)
-    @test kpts_read == kpts
+    # Compare the written fields; the index maps are derived caches, rebuilt on load.
+    @test kpts_read.n == kpts.n
+    @test kpts_read.vectors == kpts.vectors
+    @test kpts_read.weights == kpts.weights
+    @test kpts_read.ngrid == kpts.ngrid
+    @test kpts_read.shift == kpts.shift
     @test all(xk_to_ik.(kpts_read.vectors, Ref(kpts_read)) .== 1:kpts_read.n)
     @test !isempty(kpts_read._dense_hash_to_ik)
     h5open(joinpath(tmp_dir, "tmp_data.h5"), "r") do f

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("common_models_from_artifacts.jl")
     include("test_occupation.jl")
     include("test_smearing.jl")
     include("test_kpoints.jl")
+    include("test_iq_build.jl")  # GPU outer-k loop's `iq` index build (host arithmetic, CPU-only)
     include("test_symmetry.jl")
     include("test_wannier.jl")
     include("test_gpu.jl")  # skips gracefully when CUDA is unavailable

--- a/test/test_calculator_contract.jl
+++ b/test/test_calculator_contract.jl
@@ -89,8 +89,7 @@ ElectronPhonon.calculator_begin!(c::_ModeDispatchCalc, ::OuterIterationBatch, ::
 
     # `_ModeDispatchCalc` defines only OuterIteration/SingleMode and OuterIterationBatch/BatchedMode.
     # There is no default bracket, so the other two (scope, mode) combinations ERROR — a missing
-    # bracket is loud, not a silent no-op. The two defined combinations still select by MODE, not
-    # backend (the batched loop fires the per-k `OuterIteration` in BatchedMode).
+    # bracket is loud, not a silent no-op. The two defined combinations select by MODE, not backend.
     c = _ModeDispatchCalc()
     calculator_begin!(c, OuterIteration(), ctx_pt)                                  # -> (:iter, :point)
     @test_throws ErrorException calculator_begin!(c, OuterIteration(), ctx_bt)       # no BatchedMode method
@@ -98,15 +97,20 @@ ElectronPhonon.calculator_begin!(c::_ModeDispatchCalc, ::OuterIterationBatch, ::
     @test_throws ErrorException calculator_begin!(c, OuterIterationBatch(), ctx_pt)  # no SingleMode method
     @test c.fired == [(:iter, :point), (:batch, :batched)]
 
-    # The reference calculators dispatch their real brackets by mode, not backend, and every combination
-    # the loops fire resolves to a calculator-owned method — never the AbstractCalculator error fallback.
-    # BoltzmannCalculator does real work in OuterIteration/SingleMode and defines an explicit no-op for
-    # OuterIteration/BatchedMode (the batched outer-k loop fires the per-k bracket on a device backend).
+    # The reference calculators dispatch their real brackets by mode, not backend, and every
+    # combination the loops FIRE resolves to a calculator-owned method — never the AbstractCalculator
+    # error fallback. For BoltzmannCalculator those are OuterIteration/SingleMode (the CPU outer-k
+    # loop) and OuterIterationBatch/BatchedMode (the GPU outer-k loop). OuterIteration/BatchedMode is
+    # NOT one of them: the GPU outer-k loop runs its q-tile loop outside the k loop, so a single k has
+    # no begin/end point and no per-k bracket is fired; that combination correctly falls through to
+    # the erroring fallback, which is what makes a calculator relying on it fail loudly.
     BC = ElectronPhonon.BoltzmannCalculator
     m_single = which(calculator_begin!, (BC, OuterIteration, LoopContext{CPUBackend, SingleMode}))
     @test Base.unwrap_unionall(m_single.sig).parameters[2] !== AbstractCalculator
-    m_batched = which(calculator_begin!, (BC, OuterIteration, LoopContext{CPUBackend, BatchedMode}))
-    @test Base.unwrap_unionall(m_batched.sig).parameters[2] !== AbstractCalculator
+    m_batch = which(calculator_begin!, (BC, OuterIterationBatch, LoopContext{CPUBackend, BatchedMode}))
+    @test Base.unwrap_unionall(m_batch.sig).parameters[2] !== AbstractCalculator
+    m_unfired = which(calculator_begin!, (BC, OuterIteration, LoopContext{CPUBackend, BatchedMode}))
+    @test Base.unwrap_unionall(m_unfired.sig).parameters[2] === AbstractCalculator
 
     # Backend-routed `to_device`: the CPU backend is an identity (no CUDA needed on the host path).
     v = [1.0, 2.0, 3.0]

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -1003,6 +1003,28 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
                                                nk_batch_max = 256) == 1   # nw·nmodes = 36 > 24
     end
 
+    @testset "kR→kq strip q-tile shrinkage warning (predicate + quiet plan_batch)" begin
+        # The loop warns when the strip more than halved a memory-bound q-tile. Its condition is the
+        # accountant asked twice, so pin it here on a shape where `ws.g` dominates `per_point`
+        # (small nr_ep, small ndata ⇒ large nk_b) — the driver's own shapes never reach it.
+        shape = (; nw = 3, nbandk_max = 1, nmodes = 4, nr_ep = 8, nk = 10, nkq = 500,
+                 nq_grid = 500, nk_batch_max = 64, calculators = [],
+                 ndata_epmat = 3 * 3 * 4 * 8, nr_epmat = 5, FT)
+        nk_b = ElectronPhonon._krkq_strip_width(; shape.nw, shape.nbandk_max, shape.nmodes,
+                                               shape.nk_batch_max)
+        @test nk_b == 11
+        per_point, committed = _outer_k_staging_bytes(; shape..., nk_b)
+        per_point_1, _       = _outer_k_staging_bytes(; shape..., nk_b = 1)
+        @test per_point > 2 * per_point_1
+        b = _StubBackend(committed + 20 * per_point)          # memory-bound q-tile
+        nq  = plan_batch(b, per_point,   committed, shape.nkq; warn = false)
+        nq1 = plan_batch(b, per_point_1, committed, shape.nkq; warn = false)
+        @test nq * 2 < nq1                                   # (14 vs 38) — the loop warns here
+        # A counterfactual query must not tell the user their batch was reduced.
+        @test_logs plan_batch(b, per_point, committed, shape.nkq; warn = false)
+        @test_logs (:warn,) plan_batch(b, per_point, committed, shape.nkq)
+    end
+
     @testset "outer-q parity" begin
         nw, nmodes, nr_el_ham, nr_ep_eRpq = 4, 21, 250, 419
         for use_polar_eph in (false, true)

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -410,7 +410,12 @@ function check_krkq_strip(arr_dev; nw, nmodes, nk, nk_b, rtol, exact = false)
         rows = ndata * (sstart - 1) + 1 : ndata * (sstart - 1 + nks)
         ElectronPhonon.eph_kR_to_kq_fourier!(view(ws.g, 1:ndata*nks, :), view(ep2d, rows, :), phase)
         for ik in sstart:(sstart + nks - 1)
-            eph_apply_rotations!(view(out, :, :, :, :, ik), view(g5, :, :, :, ik - sstart + 1, :),
+            # Build the rotation's operand exactly as the loop does. `nk_b = 1` must give a dense
+            # one — that is what lets a large-`nw` run, which has no fused kernel to fall back on,
+            # take the strip code path at all; `nk_b > 1` gives a q-strided one, fused-kernel only.
+            gk = ElectronPhonon._strip_g_slice(ws.g, g5, ik - sstart + 1, 1:nq)
+            @test ElectronPhonon._is_dense(gk) == (nk_b == 1)
+            eph_apply_rotations!(view(out, :, :, :, :, ik), gk,
                 ukqs, uphs, ws.tmp; g2_out = view(out_g2, :, :, :, :, ik), ωq)
         end
     end
@@ -444,6 +449,20 @@ end
         # nw*nmodes = 12 ≤ 24 → fused rotation, so the q-strided strip slice is allowed.
         # nk = 7, nk_b = 3 → strips of 3, 3, 1: the last one is partial.
         check_krkq_strip(CuArray; nw=3, nmodes=4, nk=7, nk_b=3, rtol=1e-13)
+        # nw*nmodes = 36 > 24 → nk_b is forced to 1 and the rotation is the cuBLAS two-GEMM branch,
+        # which needs an operand it can take a pointer to. This is the combination a full-band
+        # large-`nw` model ships with, and it is NOT the driver's nk_outer_batch_max = 1 clamp.
+        @test ElectronPhonon._krkq_strip_width(; nw=6, nbandk_max=6, nmodes=6, nk_batch_max=256) == 1
+        check_krkq_strip(CuArray; nw=6, nmodes=6, nk=3, nk_b=1, rtol=0, exact=true)
+        # Same operand at a PARTIAL final q-tile: dense is not enough for cuBLAS, the `reshape`
+        # that merges the band and mode axes must stay a device array (a `ReshapedArray` has no
+        # pointer). The shapes above only cover the full-width tile.
+        let nw = 6, nband = 6, nmodes = 6, nqmax = 5, nq = 3
+            g2d = CuArray(zeros(ComplexF64, nw*nband*nmodes, nqmax))
+            gk  = ElectronPhonon._strip_g_slice(g2d, reshape(g2d, nw, nband, nmodes, 1, nqmax), 1, 1:nq)
+            @test size(gk) == (nw, nband, nmodes, nq)
+            @test reshape(gk, nw, nband * nmodes, nq) isa CuArray
+        end
     end
 end
 
@@ -571,9 +590,12 @@ end
             nk_outer_batch_max=5, nq_batch_max=7, progress_print_step=10^9)
         @test maximum(abs, cg.g2 .- cbk.g2) < 1e-9 * scale
 
-        # nk_outer_batch_max = 1 clamps the kR→kq strip to nk_b = 1 (the auto-disable path the
-        # loop also takes at large ndata / above the fused-rotation threshold); the runs above use
-        # nk_b = _krkq_strip_width(...) > 1 for this model, so this covers both branches.
+        # nk_outer_batch_max = 1 clamps the kR→kq strip to nk_b = 1; the runs above use
+        # nk_b = _krkq_strip_width(...) > 1 for this model, so both strip widths are exercised at
+        # driver level. This is NOT the shape-derived auto-disable (large ndata / above the
+        # fused-rotation threshold): the clamp degenerates the k-batch too, so the phase tile is
+        # rebuilt per k and `ep_ekpR_all` is one k wide. That combination — nk_b = 1 with a full
+        # k-batch and the cuBLAS rotation — is covered by the `kR→kq GEMM strip` testset above.
         cb1 = _RecordCalcBatched()
         ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
             calculators=[cb1], symmetry=nothing, use_gpu=true,
@@ -1003,26 +1025,14 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
                                                nk_batch_max = 256) == 1   # nw·nmodes = 36 > 24
     end
 
-    @testset "kR→kq strip q-tile shrinkage warning (predicate + quiet plan_batch)" begin
-        # The loop warns when the strip more than halved a memory-bound q-tile. Its condition is the
-        # accountant asked twice, so pin it here on a shape where `ws.g` dominates `per_point`
-        # (small nr_ep, small ndata ⇒ large nk_b) — the driver's own shapes never reach it.
-        shape = (; nw = 3, nbandk_max = 1, nmodes = 4, nr_ep = 8, nk = 10, nkq = 500,
-                 nq_grid = 500, nk_batch_max = 64, calculators = [],
-                 ndata_epmat = 3 * 3 * 4 * 8, nr_epmat = 5, FT)
-        nk_b = ElectronPhonon._krkq_strip_width(; shape.nw, shape.nbandk_max, shape.nmodes,
-                                               shape.nk_batch_max)
-        @test nk_b == 11
-        per_point, committed = _outer_k_staging_bytes(; shape..., nk_b)
-        per_point_1, _       = _outer_k_staging_bytes(; shape..., nk_b = 1)
-        @test per_point > 2 * per_point_1
-        b = _StubBackend(committed + 20 * per_point)          # memory-bound q-tile
-        nq  = plan_batch(b, per_point,   committed, shape.nkq; warn = false)
-        nq1 = plan_batch(b, per_point_1, committed, shape.nkq; warn = false)
-        @test nq * 2 < nq1                                   # (14 vs 38) — the loop warns here
-        # A counterfactual query must not tell the user their batch was reduced.
-        @test_logs plan_batch(b, per_point, committed, shape.nkq; warn = false)
-        @test_logs (:warn,) plan_batch(b, per_point, committed, shape.nkq)
+    @testset "plan_batch memory-bound warning is opt-out" begin
+        # A batch narrowed by free memory tells the user; a counterfactual query ("how wide would
+        # the batch be at a different `per_point`?") must stay quiet.
+        per_point, committed, cap = 1000, 10^6, 500
+        b = _StubBackend(committed + 20 * per_point)          # memory-bound: 14 of the 500 asked
+        @test plan_batch(b, per_point, committed, cap; warn = false) == 14
+        @test_logs plan_batch(b, per_point, committed, cap; warn = false)
+        @test_logs (:warn,) plan_batch(b, per_point, committed, cap)
     end
 
     @testset "outer-q parity" begin

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -109,6 +109,93 @@ end
     check_eph_batched(identity, identity; rtol=1e-10)
 end
 
+"""
+`fourier_phase!` against a scalar `cispi(2 R·x)` reference, on the backend selected by `arr_dev`.
+"""
+function check_fourier_phase(arr_dev)
+    nr, nk = 37, 11
+    irvec = [Vec3(rand(-3:3, 3)...) for _ in 1:nr]
+    xks   = [Vec3(rand(3)...) for _ in 1:nk]
+    ref = [cispi(2 * (irvec[ir][1] * xks[ik][1] + irvec[ir][2] * xks[ik][2] +
+                      irvec[ir][3] * xks[ik][3])) for ir in 1:nr, ik in 1:nk]
+
+    irvec_mat = [Float64(irvec[ir][d]) for ir in 1:nr, d in 1:3]
+    xkmat = [xks[ik][d] for d in 1:3, ik in 1:nk]
+    phase = arr_dev(zeros(ComplexF64, nr, nk))
+    ElectronPhonon.fourier_phase!(phase, arr_dev(irvec_mat), arr_dev(xkmat))
+    # |phase| == 1, so an absolute bound is a relative bound.
+    @test maximum(abs, Array(phase) .- ref) <= 4 * eps(Float64)
+end
+
+@testset "fourier_phase! (CPU)" begin
+    check_fourier_phase(identity)
+end
+
+"""
+The two `get_eph_kR_to_kq_batched!` methods and the k+q convention of `get_eph_RR_to_kR_batched!`,
+on the backend given by `to_dev` / `arr_dev` (as in [`check_eph_batched`](@ref)).
+
+1. The phase-taking method fed `fourier_phase!(qs)` reproduces the interpolator+`qs` method exactly.
+2. Storing the kR intermediate in the k+q convention (`conj(exp(2πi R_p·x_k))`) and transforming at
+   `x_{k+q}` reproduces the q-convention result, for a (k, k+q) pair whose `q = x_{k+q} - x_k` needs
+   a mod-G reduction. This is the in-repo pin of the identity `exp(2πi R_p·q) =
+   exp(2πi R_p·x_{k+q}) · conj(exp(2πi R_p·x_k))` for integer `R_p`.
+"""
+function check_eph_kq_convention(to_dev, arr_dev; rtol)
+    nwe, nmodes, nr_el, nr_ep = 3, 4, 12, 15
+    nband, nq = nwe, 9
+    irvec_el = sort([Vec3(rand(-2:2, 3)...) for _ in 1:nr_el], by = x -> reverse(x))
+    irvec_ep = sort([Vec3(rand(-2:2, 3)...) for _ in 1:nr_ep], by = x -> reverse(x))
+    epmat_obj = to_dev(WannierObject(irvec_el, rand(ComplexF64, nwe^2*nmodes*nr_ep, nr_el);
+                                     irvec_next = irvec_ep))
+    itp_epmat = get_interpolator(epmat_obj; fourier_mode="batched", batch_size=1)
+
+    # x_k and x_{k+q} on a 20³ grid; q = (x_{k+q} - x_k) mod G is what the loop feeds today.
+    xk   = Vec3(0.75, -0.40, 0.35)
+    xkqs = [Vec3(rand(-10:10, 3) ./ 20...) for _ in 1:nq]
+    qs   = [Vec3(mod.(xkq .- xk, 1)...) for xkq in xkqs]
+    @test any(i -> qs[i] != xkqs[i] - xk, 1:nq)   # at least one pair needs the mod-G reduction
+
+    uk   = arr_dev(rand(ComplexF64, nwe, nband, 1))
+    uphs = arr_dev(cat([rand(ComplexF64, nmodes, nmodes) for _ in 1:nq]...; dims=3))
+    ukqs = arr_dev(cat([rand(ComplexF64, nwe, nband) for _ in 1:nq]...; dims=3))
+
+    irvecp_mat = ElectronPhonon._irvec_matrix(irvec_ep, epmat_obj, Float64)
+    ndata = nwe * nband * nmodes
+
+    # (a) reference: q convention, interpolator + qs method
+    ep_kR_q = arr_dev(zeros(ComplexF64, ndata, nr_ep, 1))
+    get_eph_RR_to_kR_batched!(ep_kR_q, itp_epmat, [xk], uk)
+    obj_q = to_dev(WannierObject(irvec_ep, Array(ep_kR_q)[:, :, 1]))
+    ref = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
+    get_eph_kR_to_kq_batched!(ref, get_interpolator(obj_q; fourier_mode="batched", batch_size=nq),
+                              qs, uphs, ukqs)
+
+    # (b) same phase, phase-taking method: must agree bit for bit
+    phase_q = arr_dev(zeros(ComplexF64, nr_ep, nq))
+    ElectronPhonon.fourier_phase!(phase_q, irvecp_mat,
+                                  arr_dev([q[d] for d in 1:3, q in qs]))
+    out_b = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
+    get_eph_kR_to_kq_batched!(out_b, view(ep_kR_q, :, :, 1), phase_q, uphs, ukqs)
+    @test Array(out_b) == Array(ref)
+
+    # (c) k+q convention: fold conj(exp(2πi R_p·x_k)) into the child, transform at x_{k+q}
+    P_k = arr_dev(zeros(ComplexF64, nr_ep, 1))
+    ElectronPhonon.fourier_phase!(P_k, irvecp_mat, arr_dev(reshape([xk[d] for d in 1:3], 3, 1)))
+    ep_kR_kq = arr_dev(zeros(ComplexF64, ndata, nr_ep, 1))
+    get_eph_RR_to_kR_batched!(ep_kR_kq, itp_epmat, [xk], uk; kq_convention_phase = P_k)
+    P_kq = arr_dev(zeros(ComplexF64, nr_ep, nq))
+    ElectronPhonon.fourier_phase!(P_kq, irvecp_mat,
+                                  arr_dev([xkq[d] for d in 1:3, xkq in xkqs]))
+    out_c = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
+    get_eph_kR_to_kq_batched!(out_c, view(ep_kR_kq, :, :, 1), P_kq, uphs, ukqs)
+    @test isapprox(Array(out_c), Array(ref); rtol)
+end
+
+@testset "k+q convention identity (CPU)" begin
+    check_eph_kq_convention(identity, identity; rtol=1e-13)
+end
+
 # Plumbing of the outer-q batched calculator payload (supports(_, EPDataKBatched) /
 # run_calculator!(_, ::EPDataKBatched, ctx)) used by `run_eph_over_q_and_k(...; use_gpu=true)`.
 # The per-q device lifecycle reuses the OuterIteration begin/end brackets (same as the CPU outer-q
@@ -239,6 +326,10 @@ end
 
         # electron-phonon batched drivers on the GPU vs the per-k/q CPU reference
         check_eph_batched(obj -> to_device(ElectronPhonon.gpu_backend(), obj), CuArray; rtol=1e-9)
+
+        # phase kernel and the k+q convention on the device
+        check_fourier_phase(CuArray)
+        check_eph_kq_convention(obj -> to_device(ElectronPhonon.gpu_backend(), obj), CuArray; rtol=1e-13)
     end
 end
 
@@ -782,19 +873,23 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
     calcs = [_ByteCalc(1234, 5678)]
 
     @testset "outer-k parity" begin
-        nw, nbandk_max, nmodes, nr_ep, nkq, nq_grid, nk_batch_max = 7, 5, 6, 137, 200, 64, 32
+        nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_grid, nk_batch_max = 7, 5, 6, 137, 90, 200, 64, 32
         ndata_epmat, nr_epmat = 2064, 43
-        per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nkq, nq_grid,
-            nk_batch_max, calculators = calcs, ndata_epmat, nr_epmat, FT)
-        # OLD formulas (ground truth), reproduced inline — pre-existing terms pinned as-is.
-        old_per_q = 72 * nw * nbandk_max * nmodes + 24 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 40 +
+        per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
+            nq_grid, nk_batch_max, calculators = calcs, ndata_epmat, nr_epmat, FT)
+        # Formulas reproduced inline (ground truth). The per-q term dropped the child interpolator
+        # (cached_results / rdotk / xkmat) and `ikqs_dev` when the k+q-convention phase hoist made
+        # them unnecessary; `24·nr_ep` (phase + rdotk) became `16·nr_ep` (the caller-owned P_kq tile).
+        exp_per_q = 56 * nw * nbandk_max * nmodes + 16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 +
             sum(ElectronPhonon.eph_batched_bytes_per_point(c, ElectronPhonon.EPDataQBatched; nw, nmodes) for c in calcs)
         old_committed = 16 * nw^2 * nkq + (16 * nmodes^2 + 8 * nmodes) * nq_grid +
             16 * nw * nbandk_max * (nmodes * nr_ep + 1) * nk_batch_max
-        # NEW term (2026-07-18): itp_epmat RR→kR interpolator Fourier scratch, asserted separately.
-        itp_epmat_term = (16 * ndata_epmat + 24 * nr_epmat + 24) * nk_batch_max
-        @test per_point == old_per_q
-        @test committed == old_committed + itp_epmat_term
+        # itp_epmat RR→kR interpolator Fourier scratch (2026-07-18), now rdotk-free.
+        itp_epmat_term = (16 * ndata_epmat + 16 * nr_epmat + 24) * nk_batch_max
+        # k+q-convention commitments: xk_dev + xkq_dev, the 1:nkq index vector, and P_k.
+        convention_term = 24 * (nk + nkq) + 8 * nkq + 16 * nr_ep * nk_batch_max
+        @test per_point == exp_per_q
+        @test committed == old_committed + itp_epmat_term + convention_term
     end
 
     @testset "outer-q parity" begin
@@ -802,8 +897,10 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
         for use_polar_eph in (false, true)
             per_point, committed = _outer_q_staging_bytes(; nw, nmodes, nr_el_ham, nr_ep_eRpq,
                 use_polar_eph, calculators = calcs, FT)
+            # `16·nr` (interpolator core phase); the `8·nr` rdotk scratch is gone with the fused
+            # `fourier_phase!` broadcast.
             old_per_k = 16 * nw^2 * (5 * nmodes + 8 + (use_polar_eph ? 1 : 0)) +
-                24 * (nr_el_ham + nr_ep_eRpq) +
+                16 * (nr_el_ham + nr_ep_eRpq) +
                 sum(ElectronPhonon.eph_batched_bytes_per_point(c, ElectronPhonon.EPDataKBatched; nw, nmodes) for c in calcs)
             @test per_point == old_per_k
             @test committed == 0   # k side streamed: no whole-run device stack

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -160,7 +160,7 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
     uphs = arr_dev(cat([rand(ComplexF64, nmodes, nmodes) for _ in 1:nq]...; dims=3))
     ukqs = arr_dev(cat([rand(ComplexF64, nwe, nband) for _ in 1:nq]...; dims=3))
 
-    irvecp_mat = ElectronPhonon._irvec_matrix(irvec_ep, epmat_obj, Float64)
+    irvecp_mat = ElectronPhonon._irvec_matrix_to_device(irvec_ep, epmat_obj, Float64)
     ndata = nwe * nband * nmodes
 
     # (a) reference: q convention, interpolator + qs method
@@ -183,7 +183,7 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
     P_k = arr_dev(zeros(ComplexF64, nr_ep, 1))
     ElectronPhonon.fourier_phase!(P_k, irvecp_mat, arr_dev(reshape([xk[d] for d in 1:3], 3, 1)))
     ep_kR_kq = arr_dev(zeros(ComplexF64, ndata, nr_ep, 1))
-    get_eph_RR_to_kR_batched!(ep_kR_kq, itp_epmat, [xk], uk; kq_convention_phase = P_k)
+    get_eph_RR_to_kR_batched!(ep_kR_kq, itp_epmat, [xk], uk; additional_phase = P_k)
     P_kq = arr_dev(zeros(ComplexF64, nr_ep, nq))
     ElectronPhonon.fourier_phase!(P_kq, irvecp_mat,
                                   arr_dev([xkq[d] for d in 1:3, xkq in xkqs]))

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -59,12 +59,12 @@ function check_eph_batched(to_dev, arr_dev; rtol)
 
     epmat_d = to_dev(epmat_obj)
 
-    # list-batched RR→kR over all k — check every column
-    ep_all = arr_dev(zeros(ComplexF64, nwe*nband*nmodes, nr_ep, nk2))
+    # list-batched RR→kR over all k — check every k slice (k is the MIDDLE axis)
+    ep_all = arr_dev(zeros(ComplexF64, nwe*nband*nmodes, nk2, nr_ep))
     get_eph_RR_to_kR_batched!(ep_all, get_interpolator(epmat_d; fourier_mode="batched", batch_size=nk2), ks, arr_dev(uks))
     ep_all_h = Array(ep_all)
     for ik in 1:nk2
-        @test isapprox(ep_all_h[:, :, ik], refs_RR[ik]; rtol)
+        @test isapprox(ep_all_h[:, ik, :], refs_RR[ik]; rtol)
     end
 
     # list-batched kR→kq over all q (fixed k = ks[1]) — check every slice
@@ -164,9 +164,9 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
     ndata = nwe * nband * nmodes
 
     # (a) reference: q convention, interpolator + qs method
-    ep_kR_q = arr_dev(zeros(ComplexF64, ndata, nr_ep, 1))
+    ep_kR_q = arr_dev(zeros(ComplexF64, ndata, 1, nr_ep))
     get_eph_RR_to_kR_batched!(ep_kR_q, itp_epmat, [xk], uk)
-    obj_q = to_dev(WannierObject(irvec_ep, Array(ep_kR_q)[:, :, 1]))
+    obj_q = to_dev(WannierObject(irvec_ep, Array(ep_kR_q)[:, 1, :]))
     ref = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
     get_eph_kR_to_kq_batched!(ref, get_interpolator(obj_q; fourier_mode="batched", batch_size=nq),
                               qs, uphs, ukqs)
@@ -176,19 +176,19 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
     ElectronPhonon.fourier_phase!(phase_q, irvecp_mat,
                                   arr_dev([q[d] for d in 1:3, q in qs]))
     out_b = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
-    get_eph_kR_to_kq_batched!(out_b, view(ep_kR_q, :, :, 1), phase_q, uphs, ukqs)
+    get_eph_kR_to_kq_batched!(out_b, view(ep_kR_q, :, 1, :), phase_q, uphs, ukqs)
     @test Array(out_b) == Array(ref)
 
     # (c) k+q convention: fold conj(exp(2πi R_p·x_k)) into the child, transform at x_{k+q}
     P_k = arr_dev(zeros(ComplexF64, nr_ep, 1))
     ElectronPhonon.fourier_phase!(P_k, irvecp_mat, arr_dev(reshape([xk[d] for d in 1:3], 3, 1)))
-    ep_kR_kq = arr_dev(zeros(ComplexF64, ndata, nr_ep, 1))
+    ep_kR_kq = arr_dev(zeros(ComplexF64, ndata, 1, nr_ep))
     get_eph_RR_to_kR_batched!(ep_kR_kq, itp_epmat, [xk], uk; kq_convention_phase = P_k)
     P_kq = arr_dev(zeros(ComplexF64, nr_ep, nq))
     ElectronPhonon.fourier_phase!(P_kq, irvecp_mat,
                                   arr_dev([xkq[d] for d in 1:3, xkq in xkqs]))
     out_c = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
-    get_eph_kR_to_kq_batched!(out_c, view(ep_kR_kq, :, :, 1), P_kq, uphs, ukqs)
+    get_eph_kR_to_kq_batched!(out_c, view(ep_kR_kq, :, 1, :), P_kq, uphs, ukqs)
     @test isapprox(Array(out_c), Array(ref); rtol)
 end
 
@@ -369,6 +369,85 @@ end
 end
 
 
+"""
+The kR→kq GEMM strip (`_krkq_strip_width`): stacking `nk_b` outer-k into one tall
+`eph_kR_to_kq_fourier!` and rotating each k off a q-strided slice of the result must reproduce the
+`nk_b` separate skinny per-k `get_eph_kR_to_kq_batched!` calls. `nk` is chosen so the last strip is
+partial, the case a `k`-batch that is not a multiple of `nk_b` produces in the loop.
+
+At `nk_b = 1` on the GPU the GEMM shape and the kernel are identical to the per-k path, so the
+result must be BITWISE equal (`exact`). At `nk_b > 1` it is not: a different `M` lets cuBLAS pick a
+different kernel and reduction order — the in-repo precedent for k-batching moving last bits. On
+the CPU even `nk_b = 1` moves last bits, because the strip hands the generic rotation a `SubArray`
+whose `reshape` is a `ReshapedArray` and so takes the generic `mul!` instead of BLAS `gemm!`.
+"""
+function check_krkq_strip(arr_dev; nw, nmodes, nk, nk_b, rtol, exact = false)
+    nband, nr_ep, nq = nw, 9, 11
+    ndata = nw * nband * nmodes
+    ep3   = arr_dev(rand(ComplexF64, ndata, nk, nr_ep))     # k in the middle: k-strips are row ranges
+    ep2d  = reshape(ep3, ndata * nk, nr_ep)
+    phase = arr_dev(rand(ComplexF64, nr_ep, nq))
+    uphs  = arr_dev(rand(ComplexF64, nmodes, nmodes, nq))
+    ukqs  = arr_dev(rand(ComplexF64, nw, nband, nq))
+    ωq    = arr_dev(rand(nmodes, nq) .+ 0.5)
+
+    # Reference: one skinny GEMM + rotation per k (the pre-strip code path).
+    ref    = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq, nk))
+    ref_g2 = arr_dev(zeros(nband, nband, nmodes, nq, nk))
+    ws1 = KRtoKQWorkspace(ep3, ndata, nband, nband, nmodes, nq)
+    for ik in 1:nk
+        get_eph_kR_to_kq_batched!(view(ref, :, :, :, :, ik), view(ep3, :, ik, :), phase, uphs, ukqs;
+            ws = ws1, g2_out = view(ref_g2, :, :, :, :, ik), ωq)
+    end
+
+    # Strip: one tall GEMM per strip of `nks ≤ nk_b` k, then the rotation per k.
+    out    = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq, nk))
+    out_g2 = arr_dev(zeros(nband, nband, nmodes, nq, nk))
+    ws = KRtoKQWorkspace(ep3, ndata, nband, nband, nmodes, nq; nk_b)
+    g5 = reshape(ws.g, nw, nband, nmodes, nk_b, nq)
+    for sstart in 1:nk_b:nk
+        nks  = min(nk_b, nk - sstart + 1)
+        rows = ndata * (sstart - 1) + 1 : ndata * (sstart - 1 + nks)
+        ElectronPhonon.eph_kR_to_kq_fourier!(view(ws.g, 1:ndata*nks, :), view(ep2d, rows, :), phase)
+        for ik in sstart:(sstart + nks - 1)
+            eph_apply_rotations!(view(out, :, :, :, :, ik), view(g5, :, :, :, ik - sstart + 1, :),
+                ukqs, uphs, ws.tmp; g2_out = view(out_g2, :, :, :, :, ik), ωq)
+        end
+    end
+
+    if exact
+        @test Array(out) == Array(ref)
+        @test Array(out_g2) == Array(ref_g2)
+    else
+        @test isapprox(Array(out), Array(ref); rtol)
+        @test isapprox(Array(out_g2), Array(ref_g2); rtol)
+    end
+end
+
+@testset "kR→kq GEMM strip" begin
+    # nk_b = 1 is the auto-disabled path (large ndata, or a k-batch of one).
+    check_krkq_strip(identity; nw=3, nmodes=4, nk=3, nk_b=1, rtol=1e-13)
+    # A strided per-k `g` is only readable by the CUDA fused kernel; the generic two-GEMM method
+    # must say so rather than silently reshaping into a `ReshapedArray`.
+    let nw = 3, nband = 3, nmodes = 4, nq = 5
+        g_strided = view(reshape(rand(ComplexF64, nw*nband*nmodes*2, nq), nw, nband, nmodes, 2, nq),
+                         :, :, :, 1, :)
+        @test_throws AssertionError eph_apply_rotations!(
+            zeros(ComplexF64, nband, nband, nmodes, nq), g_strided,
+            rand(ComplexF64, nw, nband, nq), rand(ComplexF64, nmodes, nmodes, nq),
+            zeros(ComplexF64, nband, nband * nmodes, nq))
+    end
+    if !GPU_AVAILABLE
+        @info "CUDA not available/functional — skipping GPU kR→kq strip test"
+    else
+        check_krkq_strip(CuArray; nw=3, nmodes=4, nk=3, nk_b=1, rtol=0, exact=true)
+        # nw*nmodes = 12 ≤ 24 → fused rotation, so the q-strided strip slice is allowed.
+        # nk = 7, nk_b = 3 → strips of 3, 3, 1: the last one is partial.
+        check_krkq_strip(CuArray; nw=3, nmodes=4, nk=7, nk_b=3, rtol=1e-13)
+    end
+end
+
+
 # A minimal AbstractCalculator that records the mode-resolved g2 and phonon frequency for
 # every (ik, ikq). It mirrors what MigdalEliashberg's EliashbergCalculator reads
 # (epstate.g2[m,n,imode], epstate.ph.e[imode]) but has no external dependency, so it can verify
@@ -491,6 +570,17 @@ end
             calculators=[cbk], symmetry=nothing, use_gpu=true,
             nk_outer_batch_max=5, nq_batch_max=7, progress_print_step=10^9)
         @test maximum(abs, cg.g2 .- cbk.g2) < 1e-9 * scale
+
+        # nk_outer_batch_max = 1 clamps the kR→kq strip to nk_b = 1 (the auto-disable path the
+        # loop also takes at large ndata / above the fused-rotation threshold); the runs above use
+        # nk_b = _krkq_strip_width(...) > 1 for this model, so this covers both branches.
+        cb1 = _RecordCalcBatched()
+        ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
+            calculators=[cb1], symmetry=nothing, use_gpu=true,
+            nk_outer_batch_max=1, progress_print_step=10^9)
+        @test maximum(abs, cg.g2 .- cb1.g2) < 1e-9 * scale
+        @test ElectronPhonon._krkq_strip_width(; nw = model.nw, nbandk_max = model.nw,
+                  nmodes = model.nmodes, nk_batch_max = 256) > 1
 
         # Fully-GPU policy: a non-batched calculator (does not support EPDataQBatched) must be
         # rejected, not silently run on the host path.
@@ -876,12 +966,13 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
     @testset "outer-k parity" begin
         nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_grid, nk_batch_max = 7, 5, 6, 137, 90, 200, 64, 32
         ndata_epmat, nr_epmat = 2064, 43
-        per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
-            nq_grid, nk_batch_max, calculators = calcs, ndata_epmat, nr_epmat, FT)
         # Formulas reproduced inline (ground truth). The per-q term dropped the child interpolator
         # (cached_results / rdotk / xkmat) and `ikqs_dev` when the k+q-convention phase hoist made
         # them unnecessary; `24·nr_ep` (phase + rdotk) became `16·nr_ep` (the caller-owned P_kq tile).
-        exp_per_q = 56 * nw * nbandk_max * nmodes + 16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 +
+        # `kRkq_ws.g` is the only term that carries the kR→kq strip width `nk_b`, so the `56` splits
+        # into `40 + 16·nk_b`.
+        exp_per_q(nk_b) = (40 + 16 * nk_b) * nw * nbandk_max * nmodes +
+            16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 +
             sum(ElectronPhonon.eph_batched_bytes_per_point(c, ElectronPhonon.EPDataQBatched; nw, nmodes) for c in calcs)
         old_committed = 16 * nw^2 * nkq + (16 * nmodes^2 + 8 * nmodes) * nq_grid +
             16 * nw * nbandk_max * (nmodes * nr_ep + 1) * nk_batch_max
@@ -889,8 +980,27 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
         itp_epmat_term = (16 * ndata_epmat + 16 * nr_epmat + 24) * nk_batch_max
         # k+q-convention commitments: xk_dev + xkq_dev, the 1:nkq index vector, and P_k.
         convention_term = 24 * (nk + nkq) + 8 * nkq + 16 * nr_ep * nk_batch_max
-        @test per_point == exp_per_q
-        @test committed == old_committed + itp_epmat_term + convention_term
+        for nk_b in (1, 4)
+            per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
+                nq_grid, nk_batch_max, calculators = calcs, ndata_epmat, nr_epmat, nk_b, FT)
+            @test per_point == exp_per_q(nk_b)
+            @test committed == old_committed + itp_epmat_term + convention_term
+        end
+        # `nk_b = 1` (the default) must reproduce the pre-strip formula exactly.
+        @test exp_per_q(1) == 56 * nw * nbandk_max * nmodes + 16 * nr_ep + 16 * nmodes^2 +
+            8 * nmodes + 8 +
+            sum(ElectronPhonon.eph_batched_bytes_per_point(c, ElectronPhonon.EPDataQBatched; nw, nmodes) for c in calcs)
+
+        # The strip width itself: shape-derived, auto-off at large ndata and above the fused-rotation
+        # threshold, and clamped by the outer-k batch width.
+        @test ElectronPhonon._krkq_strip_width(; nw = 7, nbandk_max = 1, nmodes = 3,
+                                               nk_batch_max = 256) == 7   # cld(128, 21)
+        @test ElectronPhonon._krkq_strip_width(; nw = 7, nbandk_max = 1, nmodes = 3,
+                                               nk_batch_max = 4) == 4     # clamped by the k-batch
+        @test ElectronPhonon._krkq_strip_width(; nw = 32, nbandk_max = 4, nmodes = 24,
+                                               nk_batch_max = 256) == 1   # ndata = 3072 > M_TARGET
+        @test ElectronPhonon._krkq_strip_width(; nw = 12, nbandk_max = 1, nmodes = 3,
+                                               nk_batch_max = 256) == 1   # nw·nmodes = 36 > 24
     end
 
     @testset "outer-q parity" begin

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -198,11 +198,11 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
     P_mk .= conj.(P_mk)
     ep_kR_kq = arr_dev(zeros(ComplexF64, ndata, nr_ep, 1))
     get_eph_RR_to_kR_batched!(ep_kR_kq, itp_epmat, [xk], uk; additional_phase = P_mk)
-    P_mkq = arr_dev(zeros(ComplexF64, nr_ep, nq))
-    ElectronPhonon.fourier_phase!(P_mkq, irvecp_mat,
+    P_kq = arr_dev(zeros(ComplexF64, nr_ep, nq))
+    ElectronPhonon.fourier_phase!(P_kq, irvecp_mat,
                                   arr_dev([xkq[d] for d in 1:3, xkq in xkqs]))
     out_c = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
-    get_eph_kR_to_kq_batched!(out_c, view(ep_kR_kq, :, :, 1), P_mkq, uphs, ukqs)
+    get_eph_kR_to_kq_batched!(out_c, view(ep_kR_kq, :, :, 1), P_kq, uphs, ukqs)
     @test isapprox(Array(out_c), Array(ref); rtol)
 end
 
@@ -934,7 +934,7 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
             nq_grid, nk_batch_max, calculators = calcs, ndata_epmat, nr_epmat, FT)
         # Formulas reproduced inline (ground truth). The per-q term dropped the child interpolator
         # (cached_results / rdotk / xkmat) and `ikqs_dev` when the k+q-convention phase hoist made
-        # them unnecessary; `24·nr_ep` (phase + rdotk) became `16·nr_ep` (the caller-owned P_mkq tile).
+        # them unnecessary; `24·nr_ep` (phase + rdotk) became `16·nr_ep` (the caller-owned P_kq tile).
         exp_per_q = 56 * nw * nbandk_max * nmodes + 16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 +
             sum(ElectronPhonon.eph_batched_bytes_per_point(c, ElectronPhonon.EPDataQBatched; nw, nmodes) for c in calcs)
         old_committed = 16 * nw^2 * nkq + (16 * nmodes^2 + 8 * nmodes) * nq_grid +

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -172,7 +172,7 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
     uphs = arr_dev(cat([rand(ComplexF64, nmodes, nmodes) for _ in 1:nq]...; dims=3))
     ukqs = arr_dev(cat([rand(ComplexF64, nwe, nband) for _ in 1:nq]...; dims=3))
 
-    irvecp_mat = ElectronPhonon._irvec_matrix_to_device(irvec_ep, epmat_obj, Float64)
+    irvecp_mat = ElectronPhonon._irvec_to_device_matrix(irvec_ep, epmat_obj, Float64)
     ndata = nwe * nband * nmodes
 
     # (a) reference: q convention, interpolator + qs method
@@ -191,9 +191,11 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
     get_eph_kR_to_kq_batched!(out_b, view(ep_kR_q, :, :, 1), phase_q, uphs, ukqs)
     @test Array(out_b) == Array(ref)
 
-    # (c) k+q convention: fold conj(exp(2πi R_p·x_k)) into the child, transform at x_{k+q}
+    # (c) k+q convention: fold conj(exp(2πi R_p·x_k)) into the child, transform at x_{k+q}.
+    # `get_eph_RR_to_kR_batched!` multiplies by whatever it is handed, so conjugate here.
     P_k = arr_dev(zeros(ComplexF64, nr_ep, 1))
     ElectronPhonon.fourier_phase!(P_k, irvecp_mat, arr_dev(reshape([xk[d] for d in 1:3], 3, 1)))
+    P_k .= conj.(P_k)
     ep_kR_kq = arr_dev(zeros(ComplexF64, ndata, nr_ep, 1))
     get_eph_RR_to_kR_batched!(ep_kR_kq, itp_epmat, [xk], uk; additional_phase = P_k)
     P_kq = arr_dev(zeros(ComplexF64, nr_ep, nq))

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -411,8 +411,9 @@ mutable struct _RecordCalcBatched <: ElectronPhonon.AbstractCalculator
 end
 ElectronPhonon.supports(::_RecordCalcBatched, ::Type{ElectronPhonon.OuterKLoop}) = true
 ElectronPhonon.supports(::_RecordCalcBatched, ::Type{ElectronPhonon.EPDataQBatched}) = true
-# Device-native (GPU outer-k): the loop fires per-k OuterIteration and per-batch OuterIterationBatch,
-# both in BatchedMode; this calculator needs nothing at either, so define explicit no-ops.
+# Device-native (GPU outer-k): that loop fires only the per-batch OuterIterationBatch bracket
+# (BatchedMode); this calculator needs nothing there, so define an explicit no-op. The
+# `OuterIteration` no-ops keep it usable under the CPU outer-k loop too, which does fire them.
 ElectronPhonon.calculator_begin!(::_RecordCalcBatched, ::ElectronPhonon.OuterIteration, ctx) = nothing
 ElectronPhonon.calculator_end!(::_RecordCalcBatched, ::ElectronPhonon.OuterIteration, ctx) = nothing
 ElectronPhonon.calculator_begin!(::_RecordCalcBatched, ::ElectronPhonon.OuterIterationBatch, ctx) = nothing

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -1006,10 +1006,10 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
         # Formulas reproduced inline (ground truth). The per-q term dropped the child interpolator
         # (cached_results / rdotk / xkmat) and `ikqs_dev` when the k+q-convention phase hoist made
         # them unnecessary; `24·nr_ep` (phase + rdotk) became `16·nr_ep` (the caller-owned P_kq tile).
-        # Two terms carry the kR→kq strip width `nk_b`: `kRkq_ws.g` (so the `56` splits into
-        # `40 + 16·nk_b`) and the `iq` index staging, which is one strip wide (`8·nk_b`).
+        # `kRkq_ws.g` is the only term that carries the kR→kq strip width `nk_b`, so the `56` splits
+        # into `40 + 16·nk_b`.
         exp_per_q(nk_b) = (40 + 16 * nk_b) * nw * nbandk_max * nmodes +
-            16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 * nk_b +
+            16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 +
             sum(ElectronPhonon.eph_batched_bytes_per_point(c, ElectronPhonon.EPDataQBatched; nw, nmodes) for c in calcs)
         old_committed = 16 * nw^2 * nkq + (16 * nmodes^2 + 8 * nmodes) * nq_grid +
             16 * nw * nbandk_max * (nmodes * nr_ep + 1) * nk_batch_max

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -956,6 +956,21 @@ end
             @test Array(g2g) == g2c                     # same integer indexing + copy ⇒ bit-identical
             @test Array(ωg) == ωc
         end
+
+        # The outer-k driver always hands a contiguous k+q tile, so `ikqs` reaches the kernel as a
+        # `UnitRange` (isbits, passed in the launch parameters) rather than a device array. Same
+        # values, same result — but it is a different argument type through `cudaconvert`.
+        rng_ikqs = 2:6
+        len = nm * n_i * n_f
+        g2c = zeros(FT, len); ωc = zeros(FT, len)
+        ElectronPhonon.eph_window_scatter!(g2c, ωc, g2vals, imap_i_col, imap_f, rng_ikqs, ωq,
+            nw, nbandk, nm, nqc, n_i, 0)
+        g2g = CUDA.zeros(FT, len); ωg = CUDA.zeros(FT, len)
+        ElectronPhonon.eph_window_scatter!(g2g, ωg, CUDA.CuArray(g2vals),
+            CUDA.CuArray(imap_i_col), CUDA.CuArray(imap_f), rng_ikqs, CUDA.CuArray(ωq),
+            nw, nbandk, nm, nqc, n_i, 0)
+        @test Array(g2g) == g2c
+        @test Array(ωg) == ωc
     end
 end
 
@@ -991,17 +1006,18 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
         # Formulas reproduced inline (ground truth). The per-q term dropped the child interpolator
         # (cached_results / rdotk / xkmat) and `ikqs_dev` when the k+q-convention phase hoist made
         # them unnecessary; `24·nr_ep` (phase + rdotk) became `16·nr_ep` (the caller-owned P_kq tile).
-        # `kRkq_ws.g` is the only term that carries the kR→kq strip width `nk_b`, so the `56` splits
-        # into `40 + 16·nk_b`.
+        # Two terms carry the kR→kq strip width `nk_b`: `kRkq_ws.g` (so the `56` splits into
+        # `40 + 16·nk_b`) and the `iq` index staging, which is one strip wide (`8·nk_b`).
         exp_per_q(nk_b) = (40 + 16 * nk_b) * nw * nbandk_max * nmodes +
-            16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 +
+            16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 * nk_b +
             sum(ElectronPhonon.eph_batched_bytes_per_point(c, ElectronPhonon.EPDataQBatched; nw, nmodes) for c in calcs)
         old_committed = 16 * nw^2 * nkq + (16 * nmodes^2 + 8 * nmodes) * nq_grid +
             16 * nw * nbandk_max * (nmodes * nr_ep + 1) * nk_batch_max
         # itp_epmat RR→kR interpolator Fourier scratch (2026-07-18), now rdotk-free.
         itp_epmat_term = (16 * ndata_epmat + 16 * nr_epmat + 24) * nk_batch_max
-        # k+q-convention commitments: xk_dev + xkq_dev, the 1:nkq index vector, and P_k.
-        convention_term = 24 * (nk + nkq) + 8 * nkq + 16 * nr_ep * nk_batch_max
+        # k+q-convention commitments: xk_dev + xkq_dev and P_k. The 1:nkq index vector is gone —
+        # the payload's `ikqs` is the tile's `UnitRange`, passed in the kernel launch parameters.
+        convention_term = 24 * (nk + nkq) + 16 * nr_ep * nk_batch_max
         for nk_b in (1, 4)
             per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
                 nq_grid, nk_batch_max, calculators = calcs, ndata_epmat, nr_epmat, nk_b, FT)

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -193,16 +193,16 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
 
     # (c) k+q convention: fold conj(exp(2πi R_p·x_k)) into the child, transform at x_{k+q}.
     # `get_eph_RR_to_kR_batched!` multiplies by whatever it is handed, so conjugate here.
-    P_k = arr_dev(zeros(ComplexF64, nr_ep, 1))
-    ElectronPhonon.fourier_phase!(P_k, irvecp_mat, arr_dev(reshape([xk[d] for d in 1:3], 3, 1)))
-    P_k .= conj.(P_k)
+    P_mk = arr_dev(zeros(ComplexF64, nr_ep, 1))
+    ElectronPhonon.fourier_phase!(P_mk, irvecp_mat, arr_dev(reshape([xk[d] for d in 1:3], 3, 1)))
+    P_mk .= conj.(P_mk)
     ep_kR_kq = arr_dev(zeros(ComplexF64, ndata, nr_ep, 1))
-    get_eph_RR_to_kR_batched!(ep_kR_kq, itp_epmat, [xk], uk; additional_phase = P_k)
-    P_kq = arr_dev(zeros(ComplexF64, nr_ep, nq))
-    ElectronPhonon.fourier_phase!(P_kq, irvecp_mat,
+    get_eph_RR_to_kR_batched!(ep_kR_kq, itp_epmat, [xk], uk; additional_phase = P_mk)
+    P_mkq = arr_dev(zeros(ComplexF64, nr_ep, nq))
+    ElectronPhonon.fourier_phase!(P_mkq, irvecp_mat,
                                   arr_dev([xkq[d] for d in 1:3, xkq in xkqs]))
     out_c = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
-    get_eph_kR_to_kq_batched!(out_c, view(ep_kR_kq, :, :, 1), P_kq, uphs, ukqs)
+    get_eph_kR_to_kq_batched!(out_c, view(ep_kR_kq, :, :, 1), P_mkq, uphs, ukqs)
     @test isapprox(Array(out_c), Array(ref); rtol)
 end
 
@@ -934,14 +934,14 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
             nq_grid, nk_batch_max, calculators = calcs, ndata_epmat, nr_epmat, FT)
         # Formulas reproduced inline (ground truth). The per-q term dropped the child interpolator
         # (cached_results / rdotk / xkmat) and `ikqs_dev` when the k+q-convention phase hoist made
-        # them unnecessary; `24·nr_ep` (phase + rdotk) became `16·nr_ep` (the caller-owned P_kq tile).
+        # them unnecessary; `24·nr_ep` (phase + rdotk) became `16·nr_ep` (the caller-owned P_mkq tile).
         exp_per_q = 56 * nw * nbandk_max * nmodes + 16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 +
             sum(ElectronPhonon.eph_batched_bytes_per_point(c, ElectronPhonon.EPDataQBatched; nw, nmodes) for c in calcs)
         old_committed = 16 * nw^2 * nkq + (16 * nmodes^2 + 8 * nmodes) * nq_grid +
             16 * nw * nbandk_max * (nmodes * nr_ep + 1) * nk_batch_max
         # itp_epmat RR→kR interpolator Fourier scratch (2026-07-18), now rdotk-free.
         itp_epmat_term = (16 * ndata_epmat + 16 * nr_epmat + 24) * nk_batch_max
-        # k+q-convention commitments: xk_dev + xkq_dev and P_k. The 1:nkq index vector is gone —
+        # k+q-convention commitments: xk_dev + xkq_dev and P_mk. The 1:nkq index vector is gone —
         # the payload's `ikqs` is the tile's `UnitRange`, passed in the kernel launch parameters.
         convention_term = 24 * (nk + nkq) + 16 * nr_ep * nk_batch_max
         @test per_point == exp_per_q

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -16,6 +16,18 @@ catch
     false
 end
 
+# `get_eph_kR_to_kq_batched!` takes the Fourier phase, not a q-list, because the driver builds one
+# phase and reuses it over many k. The tests mostly have a q-list instead, so this wrapper does the
+# phase build for them. It lives here rather than in `src` because no `src` caller needs it.
+# Requires an in-memory parent (it reads `parent.op_r`), so no `DiskWannierObject`.
+function kR_to_kq_from_qs!(ep_kq_all, itp_ep_ekpR, qs, u_phs, ukqs; ws = nothing,
+                           g2_out = nothing, ωq = nothing)
+    parent = itp_ep_ekpR.parent
+    phase = ElectronPhonon._build_phase!(itp_ep_ekpR.core, qs)
+    @views get_eph_kR_to_kq_batched!(ep_kq_all, parent.op_r[1:parent.ndata, :], phase, u_phs, ukqs;
+                                     ws, g2_out, ωq)
+end
+
 # A mis-dispatch (a device view falling back to the generic scalar `batched_gemm!` instead of the
 # GPU method) must fail loudly rather than silently limp — forbid scalar indexing on the device.
 GPU_AVAILABLE && CUDA.allowscalar(false)
@@ -70,7 +82,7 @@ function check_eph_batched(to_dev, arr_dev; rtol)
     # list-batched kR→kq over all q (fixed k = ks[1]) — check every slice
     obj_k1 = to_dev(WannierObject(irvec_ep, copy(refs_RR[1])))
     ep_kq_all = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq2))
-    get_eph_kR_to_kq_batched!(ep_kq_all, get_interpolator(obj_k1; fourier_mode="batched", batch_size=nq2), qs, arr_dev(uphs), arr_dev(ukqs))
+    kR_to_kq_from_qs!(ep_kq_all, get_interpolator(obj_k1; fourier_mode="batched", batch_size=nq2), qs, arr_dev(uphs), arr_dev(ukqs))
     ep_kq_h = Array(ep_kq_all)
     for iq in 1:nq2
         @test isapprox(ep_kq_h[:, :, :, iq], ep_ref[:, :, :, iq]; rtol)
@@ -99,7 +111,7 @@ function check_eph_batched(to_dev, arr_dev; rtol)
     ωq_g2  = rand(nmodes, nq2) .+ 0.5
     g2_out = arr_dev(zeros(nband, nband, nmodes, nq2))
     ep_g2  = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq2))
-    get_eph_kR_to_kq_batched!(ep_g2, get_interpolator(obj_k1; fourier_mode="batched", batch_size=nq2),
+    kR_to_kq_from_qs!(ep_g2, get_interpolator(obj_k1; fourier_mode="batched", batch_size=nq2),
         qs, arr_dev(uphs), arr_dev(ukqs); g2_out, ωq=arr_dev(ωq_g2))
     g2_ref = abs2.(ep_ref) ./ (2 .* reshape(ωq_g2, 1, 1, nmodes, nq2))
     @test isapprox(Array(g2_out), g2_ref; rtol)
@@ -168,7 +180,7 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
     get_eph_RR_to_kR_batched!(ep_kR_q, itp_epmat, [xk], uk)
     obj_q = to_dev(WannierObject(irvec_ep, Array(ep_kR_q)[:, :, 1]))
     ref = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
-    get_eph_kR_to_kq_batched!(ref, get_interpolator(obj_q; fourier_mode="batched", batch_size=nq),
+    kR_to_kq_from_qs!(ref, get_interpolator(obj_q; fourier_mode="batched", batch_size=nq),
                               qs, uphs, ukqs)
 
     # (b) same phase, phase-taking method: must agree bit for bit
@@ -349,11 +361,11 @@ function check_eph_partial_view(nw, nmodes; rtol)
     ws   = ElectronPhonon.KRtoKQWorkspace(obj.op_r, nw*nband*nmodes, nband, nband, nmodes, nq)
 
     full = CuArray(zeros(ComplexF64, nband, nband, nmodes, nq))
-    get_eph_kR_to_kq_batched!(full, get_interpolator(obj; fourier_mode="batched", batch_size=nq),
+    kR_to_kq_from_qs!(full, get_interpolator(obj; fourier_mode="batched", batch_size=nq),
                               qs, uphs, ukqs; ws)
     # Same call restricted to the first m q-points via views into the max-width buffers, reusing ws.
     part = CuArray(zeros(ComplexF64, nband, nband, nmodes, nq))
-    get_eph_kR_to_kq_batched!(view(part, :, :, :, 1:m),
+    kR_to_kq_from_qs!(view(part, :, :, :, 1:m),
         get_interpolator(obj; fourier_mode="batched", batch_size=nq),
         view(qs, 1:m), view(uphs, :, :, 1:m), view(ukqs, :, :, 1:m); ws)
     @test isapprox(Array(view(part, :, :, :, 1:m)), Array(view(full, :, :, :, 1:m)); rtol)

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -59,12 +59,12 @@ function check_eph_batched(to_dev, arr_dev; rtol)
 
     epmat_d = to_dev(epmat_obj)
 
-    # list-batched RR→kR over all k — check every k slice (k is the MIDDLE axis)
-    ep_all = arr_dev(zeros(ComplexF64, nwe*nband*nmodes, nk2, nr_ep))
+    # list-batched RR→kR over all k — check every column
+    ep_all = arr_dev(zeros(ComplexF64, nwe*nband*nmodes, nr_ep, nk2))
     get_eph_RR_to_kR_batched!(ep_all, get_interpolator(epmat_d; fourier_mode="batched", batch_size=nk2), ks, arr_dev(uks))
     ep_all_h = Array(ep_all)
     for ik in 1:nk2
-        @test isapprox(ep_all_h[:, ik, :], refs_RR[ik]; rtol)
+        @test isapprox(ep_all_h[:, :, ik], refs_RR[ik]; rtol)
     end
 
     # list-batched kR→kq over all q (fixed k = ks[1]) — check every slice
@@ -164,9 +164,9 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
     ndata = nwe * nband * nmodes
 
     # (a) reference: q convention, interpolator + qs method
-    ep_kR_q = arr_dev(zeros(ComplexF64, ndata, 1, nr_ep))
+    ep_kR_q = arr_dev(zeros(ComplexF64, ndata, nr_ep, 1))
     get_eph_RR_to_kR_batched!(ep_kR_q, itp_epmat, [xk], uk)
-    obj_q = to_dev(WannierObject(irvec_ep, Array(ep_kR_q)[:, 1, :]))
+    obj_q = to_dev(WannierObject(irvec_ep, Array(ep_kR_q)[:, :, 1]))
     ref = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
     get_eph_kR_to_kq_batched!(ref, get_interpolator(obj_q; fourier_mode="batched", batch_size=nq),
                               qs, uphs, ukqs)
@@ -176,19 +176,19 @@ function check_eph_kq_convention(to_dev, arr_dev; rtol)
     ElectronPhonon.fourier_phase!(phase_q, irvecp_mat,
                                   arr_dev([q[d] for d in 1:3, q in qs]))
     out_b = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
-    get_eph_kR_to_kq_batched!(out_b, view(ep_kR_q, :, 1, :), phase_q, uphs, ukqs)
+    get_eph_kR_to_kq_batched!(out_b, view(ep_kR_q, :, :, 1), phase_q, uphs, ukqs)
     @test Array(out_b) == Array(ref)
 
     # (c) k+q convention: fold conj(exp(2πi R_p·x_k)) into the child, transform at x_{k+q}
     P_k = arr_dev(zeros(ComplexF64, nr_ep, 1))
     ElectronPhonon.fourier_phase!(P_k, irvecp_mat, arr_dev(reshape([xk[d] for d in 1:3], 3, 1)))
-    ep_kR_kq = arr_dev(zeros(ComplexF64, ndata, 1, nr_ep))
+    ep_kR_kq = arr_dev(zeros(ComplexF64, ndata, nr_ep, 1))
     get_eph_RR_to_kR_batched!(ep_kR_kq, itp_epmat, [xk], uk; kq_convention_phase = P_k)
     P_kq = arr_dev(zeros(ComplexF64, nr_ep, nq))
     ElectronPhonon.fourier_phase!(P_kq, irvecp_mat,
                                   arr_dev([xkq[d] for d in 1:3, xkq in xkqs]))
     out_c = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq))
-    get_eph_kR_to_kq_batched!(out_c, view(ep_kR_kq, :, 1, :), P_kq, uphs, ukqs)
+    get_eph_kR_to_kq_batched!(out_c, view(ep_kR_kq, :, :, 1), P_kq, uphs, ukqs)
     @test isapprox(Array(out_c), Array(ref); rtol)
 end
 
@@ -369,100 +369,18 @@ end
 end
 
 
-"""
-The kR→kq GEMM strip (`_krkq_strip_width`): stacking `nk_b` outer-k into one tall
-`eph_kR_to_kq_fourier!` and rotating each k off a q-strided slice of the result must reproduce the
-`nk_b` separate skinny per-k `get_eph_kR_to_kq_batched!` calls. `nk` is chosen so the last strip is
-partial, the case a `k`-batch that is not a multiple of `nk_b` produces in the loop.
-
-At `nk_b = 1` on the GPU the GEMM shape and the kernel are identical to the per-k path, so the
-result must be BITWISE equal (`exact`). At `nk_b > 1` it is not: a different `M` lets cuBLAS pick a
-different kernel and reduction order — the in-repo precedent for k-batching moving last bits. On
-the CPU even `nk_b = 1` moves last bits, because the strip hands the generic rotation a `SubArray`
-whose `reshape` is a `ReshapedArray` and so takes the generic `mul!` instead of BLAS `gemm!`.
-"""
-function check_krkq_strip(arr_dev; nw, nmodes, nk, nk_b, rtol, exact = false)
-    nband, nr_ep, nq = nw, 9, 11
-    ndata = nw * nband * nmodes
-    ep3   = arr_dev(rand(ComplexF64, ndata, nk, nr_ep))     # k in the middle: k-strips are row ranges
-    ep2d  = reshape(ep3, ndata * nk, nr_ep)
-    phase = arr_dev(rand(ComplexF64, nr_ep, nq))
-    uphs  = arr_dev(rand(ComplexF64, nmodes, nmodes, nq))
-    ukqs  = arr_dev(rand(ComplexF64, nw, nband, nq))
-    ωq    = arr_dev(rand(nmodes, nq) .+ 0.5)
-
-    # Reference: one skinny GEMM + rotation per k (the pre-strip code path).
-    ref    = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq, nk))
-    ref_g2 = arr_dev(zeros(nband, nband, nmodes, nq, nk))
-    ws1 = KRtoKQWorkspace(ep3, ndata, nband, nband, nmodes, nq)
-    for ik in 1:nk
-        get_eph_kR_to_kq_batched!(view(ref, :, :, :, :, ik), view(ep3, :, ik, :), phase, uphs, ukqs;
-            ws = ws1, g2_out = view(ref_g2, :, :, :, :, ik), ωq)
-    end
-
-    # Strip: one tall GEMM per strip of `nks ≤ nk_b` k, then the rotation per k.
-    out    = arr_dev(zeros(ComplexF64, nband, nband, nmodes, nq, nk))
-    out_g2 = arr_dev(zeros(nband, nband, nmodes, nq, nk))
-    ws = KRtoKQWorkspace(ep3, ndata, nband, nband, nmodes, nq; nk_b)
-    g5 = reshape(ws.g, nw, nband, nmodes, nk_b, nq)
-    for sstart in 1:nk_b:nk
-        nks  = min(nk_b, nk - sstart + 1)
-        rows = ndata * (sstart - 1) + 1 : ndata * (sstart - 1 + nks)
-        ElectronPhonon.eph_kR_to_kq_fourier!(view(ws.g, 1:ndata*nks, :), view(ep2d, rows, :), phase)
-        for ik in sstart:(sstart + nks - 1)
-            # Build the rotation's operand exactly as the loop does. `nk_b = 1` must give a dense
-            # one — that is what lets a large-`nw` run, which has no fused kernel to fall back on,
-            # take the strip code path at all; `nk_b > 1` gives a q-strided one, fused-kernel only.
-            gk = ElectronPhonon._strip_g_slice(ws.g, g5, ik - sstart + 1, 1:nq)
-            @test ElectronPhonon._is_dense(gk) == (nk_b == 1)
-            eph_apply_rotations!(view(out, :, :, :, :, ik), gk,
-                ukqs, uphs, ws.tmp; g2_out = view(out_g2, :, :, :, :, ik), ωq)
-        end
-    end
-
-    if exact
-        @test Array(out) == Array(ref)
-        @test Array(out_g2) == Array(ref_g2)
-    else
-        @test isapprox(Array(out), Array(ref); rtol)
-        @test isapprox(Array(out_g2), Array(ref_g2); rtol)
-    end
-end
-
-@testset "kR→kq GEMM strip" begin
-    # nk_b = 1 is the auto-disabled path (large ndata, or a k-batch of one).
-    check_krkq_strip(identity; nw=3, nmodes=4, nk=3, nk_b=1, rtol=1e-13)
-    # A strided per-k `g` is only readable by the CUDA fused kernel; the generic two-GEMM method
-    # must say so rather than silently reshaping into a `ReshapedArray`.
+@testset "eph_apply_rotations! rejects a non-dense g" begin
+    # The two-GEMM rotation paths merge `g`'s band and mode axes with a `reshape`, so a strided `g`
+    # is only readable by the CUDA fused kernel. The generic method must say so rather than silently
+    # reshaping into a `ReshapedArray` the batched GEMMs cannot take a pointer to.
     let nw = 3, nband = 3, nmodes = 4, nq = 5
         g_strided = view(reshape(rand(ComplexF64, nw*nband*nmodes*2, nq), nw, nband, nmodes, 2, nq),
                          :, :, :, 1, :)
+        @test !ElectronPhonon._is_dense(g_strided)
         @test_throws AssertionError eph_apply_rotations!(
             zeros(ComplexF64, nband, nband, nmodes, nq), g_strided,
             rand(ComplexF64, nw, nband, nq), rand(ComplexF64, nmodes, nmodes, nq),
             zeros(ComplexF64, nband, nband * nmodes, nq))
-    end
-    if !GPU_AVAILABLE
-        @info "CUDA not available/functional — skipping GPU kR→kq strip test"
-    else
-        check_krkq_strip(CuArray; nw=3, nmodes=4, nk=3, nk_b=1, rtol=0, exact=true)
-        # nw*nmodes = 12 ≤ 24 → fused rotation, so the q-strided strip slice is allowed.
-        # nk = 7, nk_b = 3 → strips of 3, 3, 1: the last one is partial.
-        check_krkq_strip(CuArray; nw=3, nmodes=4, nk=7, nk_b=3, rtol=1e-13)
-        # nw*nmodes = 36 > 24 → nk_b is forced to 1 and the rotation is the cuBLAS two-GEMM branch,
-        # which needs an operand it can take a pointer to. This is the combination a full-band
-        # large-`nw` model ships with, and it is NOT the driver's nk_outer_batch_max = 1 clamp.
-        @test ElectronPhonon._krkq_strip_width(; nw=6, nbandk_max=6, nmodes=6, nk_batch_max=256) == 1
-        check_krkq_strip(CuArray; nw=6, nmodes=6, nk=3, nk_b=1, rtol=0, exact=true)
-        # Same operand at a PARTIAL final q-tile: dense is not enough for cuBLAS, the `reshape`
-        # that merges the band and mode axes must stay a device array (a `ReshapedArray` has no
-        # pointer). The shapes above only cover the full-width tile.
-        let nw = 6, nband = 6, nmodes = 6, nqmax = 5, nq = 3
-            g2d = CuArray(zeros(ComplexF64, nw*nband*nmodes, nqmax))
-            gk  = ElectronPhonon._strip_g_slice(g2d, reshape(g2d, nw, nband, nmodes, 1, nqmax), 1, 1:nq)
-            @test size(gk) == (nw, nband, nmodes, nq)
-            @test reshape(gk, nw, nband * nmodes, nq) isa CuArray
-        end
     end
 end
 
@@ -590,19 +508,14 @@ end
             nk_outer_batch_max=5, nq_batch_max=7, progress_print_step=10^9)
         @test maximum(abs, cg.g2 .- cbk.g2) < 1e-9 * scale
 
-        # nk_outer_batch_max = 1 clamps the kR→kq strip to nk_b = 1; the runs above use
-        # nk_b = _krkq_strip_width(...) > 1 for this model, so both strip widths are exercised at
-        # driver level. This is NOT the shape-derived auto-disable (large ndata / above the
-        # fused-rotation threshold): the clamp degenerates the k-batch too, so the phase tile is
-        # rebuilt per k and `ep_ekpR_all` is one k wide. That combination — nk_b = 1 with a full
-        # k-batch and the cuBLAS rotation — is covered by the `kR→kq GEMM strip` testset above.
+        # A degenerate outer-k batch (nk_outer_batch_max = 1) must agree too: the k+q-convention
+        # phase tile is then rebuilt per k and `ep_ekpR_all` is one k wide, i.e. the k-batch reuse
+        # factor the loop is built around drops to 1.
         cb1 = _RecordCalcBatched()
         ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
             calculators=[cb1], symmetry=nothing, use_gpu=true,
             nk_outer_batch_max=1, progress_print_step=10^9)
         @test maximum(abs, cg.g2 .- cb1.g2) < 1e-9 * scale
-        @test ElectronPhonon._krkq_strip_width(; nw = model.nw, nbandk_max = model.nw,
-                  nmodes = model.nmodes, nk_batch_max = 256) > 1
 
         # Fully-GPU policy: a non-batched calculator (does not support EPDataQBatched) must be
         # rejected, not silently run on the host path.
@@ -1003,13 +916,12 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
     @testset "outer-k parity" begin
         nw, nbandk_max, nmodes, nr_ep, nk, nkq, nq_grid, nk_batch_max = 7, 5, 6, 137, 90, 200, 64, 32
         ndata_epmat, nr_epmat = 2064, 43
+        per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
+            nq_grid, nk_batch_max, calculators = calcs, ndata_epmat, nr_epmat, FT)
         # Formulas reproduced inline (ground truth). The per-q term dropped the child interpolator
         # (cached_results / rdotk / xkmat) and `ikqs_dev` when the k+q-convention phase hoist made
         # them unnecessary; `24·nr_ep` (phase + rdotk) became `16·nr_ep` (the caller-owned P_kq tile).
-        # `kRkq_ws.g` is the only term that carries the kR→kq strip width `nk_b`, so the `56` splits
-        # into `40 + 16·nk_b`.
-        exp_per_q(nk_b) = (40 + 16 * nk_b) * nw * nbandk_max * nmodes +
-            16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 +
+        exp_per_q = 56 * nw * nbandk_max * nmodes + 16 * nr_ep + 16 * nmodes^2 + 8 * nmodes + 8 +
             sum(ElectronPhonon.eph_batched_bytes_per_point(c, ElectronPhonon.EPDataQBatched; nw, nmodes) for c in calcs)
         old_committed = 16 * nw^2 * nkq + (16 * nmodes^2 + 8 * nmodes) * nq_grid +
             16 * nw * nbandk_max * (nmodes * nr_ep + 1) * nk_batch_max
@@ -1018,27 +930,8 @@ ElectronPhonon.free_bytes(b::_StubBackend) = b.free
         # k+q-convention commitments: xk_dev + xkq_dev and P_k. The 1:nkq index vector is gone —
         # the payload's `ikqs` is the tile's `UnitRange`, passed in the kernel launch parameters.
         convention_term = 24 * (nk + nkq) + 16 * nr_ep * nk_batch_max
-        for nk_b in (1, 4)
-            per_point, committed = _outer_k_staging_bytes(; nw, nbandk_max, nmodes, nr_ep, nk, nkq,
-                nq_grid, nk_batch_max, calculators = calcs, ndata_epmat, nr_epmat, nk_b, FT)
-            @test per_point == exp_per_q(nk_b)
-            @test committed == old_committed + itp_epmat_term + convention_term
-        end
-        # `nk_b = 1` (the default) must reproduce the pre-strip formula exactly.
-        @test exp_per_q(1) == 56 * nw * nbandk_max * nmodes + 16 * nr_ep + 16 * nmodes^2 +
-            8 * nmodes + 8 +
-            sum(ElectronPhonon.eph_batched_bytes_per_point(c, ElectronPhonon.EPDataQBatched; nw, nmodes) for c in calcs)
-
-        # The strip width itself: shape-derived, auto-off at large ndata and above the fused-rotation
-        # threshold, and clamped by the outer-k batch width.
-        @test ElectronPhonon._krkq_strip_width(; nw = 7, nbandk_max = 1, nmodes = 3,
-                                               nk_batch_max = 256) == 7   # cld(128, 21)
-        @test ElectronPhonon._krkq_strip_width(; nw = 7, nbandk_max = 1, nmodes = 3,
-                                               nk_batch_max = 4) == 4     # clamped by the k-batch
-        @test ElectronPhonon._krkq_strip_width(; nw = 32, nbandk_max = 4, nmodes = 24,
-                                               nk_batch_max = 256) == 1   # ndata = 3072 > M_TARGET
-        @test ElectronPhonon._krkq_strip_width(; nw = 12, nbandk_max = 1, nmodes = 3,
-                                               nk_batch_max = 256) == 1   # nw·nmodes = 36 > 24
+        @test per_point == exp_per_q
+        @test committed == old_committed + itp_epmat_term + convention_term
     end
 
     @testset "plan_batch memory-bound warning is opt-out" begin

--- a/test/test_iq_build.jl
+++ b/test/test_iq_build.jl
@@ -1,14 +1,14 @@
 using Test
 using ElectronPhonon
 using Random
-using ElectronPhonon: Vec3, _grid_coords_reduced, _wrap_reduced, _fill_iqs_serial!
+using ElectronPhonon: Vec3, _grid_coords_reduced, _wrap_reduced, _fill_iqs!
 
-# The per-(k-strip, q-tile) `iq` index build of the GPU outer-k loop
-# (`_loop_eph_over_k_and_kq_gpu`). The loop hashes integer grid coordinates instead of calling
-# `xk_to_ik` per pair, so the whole correctness story is "the fast hash agrees with `xk_to_ik`".
+# The per-(k, q-tile) `iq` index build of the GPU outer-k loop (`_loop_eph_over_k_and_kq_gpu`). The
+# loop hashes integer grid coordinates instead of calling `xk_to_ik` per pair, so the whole
+# correctness story is "the fast hash agrees with `xk_to_ik`".
 # CPU-only: the build is host arithmetic and the loop it feeds is never reached on `CPUBackend`.
 
-# Everything the builder needs, assembled the way the loop's prologue assembles it. The outer k mesh
+# Everything the build needs, assembled the way the loop's prologue assembles it. The outer k mesh
 # is always unshifted — the loop's `xks_int` does not subtract a shift, so a shifted k would not
 # land on integer grid coordinates at all. `shift` shifts the k+q mesh, which is what gives `qpts`
 # a nonzero shift for the k+q side to subtract.
@@ -30,21 +30,22 @@ end
 # `xk_to_ik` on the actual difference vector — the independent oracle. It goes through the Float64
 # `_hash_xk` path, so agreeing with it also pins the integer shortcut's rounding.
 function _check_against_oracle(f, iks, nq)
-    stage = fill(-7, nq, length(iks))
-    _fill_iqs_serial!(stage, f.qpts, f.xkqs_int, f.xks_int, iks, 1, 1, nq)
+    iqs = fill(-7, nq)
     ok = true
-    for (kloc, ik) in enumerate(iks), j in 1:nq
-        ok &= stage[j, kloc] == xk_to_ik(f.kqpts.vectors[j] - f.kpts.vectors[ik], f.qpts)
+    for ik in iks
+        _fill_iqs!(iqs, f.qpts, f.xkqs_int, f.xks_int, ik, 1, nq)
+        for j in 1:nq
+            ok &= iqs[j] == xk_to_ik(f.kqpts.vectors[j] - f.kpts.vectors[ik], f.qpts)
+        end
+        ok &= all(1 .<= iqs .<= f.qpts.n)   # every pair resolved; no sentinel left behind
     end
-    (ok, stage)
+    ok
 end
 
 @testset "iq build" begin
-    @testset "serial builder == xk_to_ik oracle" begin
+    @testset "build == xk_to_ik oracle" begin
         f = _iq_build_fixture((4, 4, 4))
-        ok, stage = _check_against_oracle(f, 1:f.kpts.n, f.kqpts.n)
-        @test ok
-        @test all(1 .<= stage .<= f.qpts.n)   # every pair resolved; no sentinel left behind
+        @test _check_against_oracle(f, 1:f.kpts.n, f.kqpts.n)
     end
 
     @testset "non-cubic ngrid" begin
@@ -52,8 +53,7 @@ end
         # accident (the same reason `test_kpoints.jl` pins the dense table's layout on (2,3,4)).
         f = _iq_build_fixture((3, 4, 5))
         @test f.qpts.ngrid == (3, 4, 5)
-        ok, _ = _check_against_oracle(f, 1:f.kpts.n, f.kqpts.n)
-        @test ok
+        @test _check_against_oracle(f, 1:f.kpts.n, f.kqpts.n)
     end
 
     @testset "shifted grid" begin
@@ -61,8 +61,7 @@ end
         # for k+q, a zero shift for k), because q = x_{k+q} - x_k - shift.
         f = _iq_build_fixture((3, 4, 5); shift = (1//2, 0, 1//2))
         @test iszero(f.kpts.shift) && !iszero(f.qpts.shift)
-        ok, _ = _check_against_oracle(f, 1:f.kpts.n, f.kqpts.n)
-        @test ok
+        @test _check_against_oracle(f, 1:f.kpts.n, f.kqpts.n)
     end
 
     @testset "[0,ng) reduction is exact" begin
@@ -83,49 +82,32 @@ end
         @test _wrap_reduced(-3, 4) == 1 && _wrap_reduced(7, 4) == 3
     end
 
-    @testset "partial final tile and strip" begin
-        # The loop stages a whole kR->kq strip at once into an (nq_batch_max, nk_b) matrix. A
-        # partial final q-tile writes only the leading `nq` rows, and a partial final strip only the
-        # leading `nks` columns; everything else must be left alone (it is copied to the device
-        # along with the rest but never read).
+    @testset "partial final tile" begin
+        # The loop stages into an `nq_batch_max`-long buffer and a partial final q-tile writes only
+        # the leading `nq` entries; the tail must be left alone (the H2D copies only `1:nq`).
         f = _iq_build_fixture((4, 4, 4))
-        nq_max, nk_b = f.kqpts.n, 3
-        for (nq, nks) in ((nq_max, nk_b), (7, nk_b), (nq_max, 2), (7, 1))
-            stage = fill(-7, nq_max, nk_b)
-            _fill_iqs_serial!(stage, f.qpts, f.xkqs_int, f.xks_int, 2:(1 + nks), 1, 1, nq)
-            @test all(stage[1:nq, 1:nks] .>= 1)
-            @test all(stage[(nq + 1):end, :] .== -7)
-            @test all(stage[:, (nks + 1):end] .== -7)
+        nq_max = f.kqpts.n
+        for nq in (nq_max, 7, 1)
+            iqs = fill(-7, nq_max)
+            _fill_iqs!(iqs, f.qpts, f.xkqs_int, f.xks_int, 2, 1, nq)
+            @test all(iqs[1:nq] .>= 1)
+            @test all(iqs[(nq + 1):end] .== -7)
         end
-    end
-
-    @testset "per-k staging == per-strip staging" begin
-        # `kloc0` lets the builder fill one column at a time; the loop uses that only as the
-        # `nk_b == 1` degenerate case, but the two must agree column for column.
-        f = _iq_build_fixture((3, 4, 5))
-        nq, iks = f.kqpts.n, 3:6
-        strip = fill(-7, nq, length(iks))
-        perk  = fill(-7, nq, length(iks))
-        _fill_iqs_serial!(strip, f.qpts, f.xkqs_int, f.xks_int, iks, 1, 1, nq)
-        for (kloc, ik) in enumerate(iks)
-            _fill_iqs_serial!(perk, f.qpts, f.xkqs_int, f.xks_int, ik:ik, kloc, 1, nq)
-        end
-        @test strip == perk
     end
 
     @testset "q-tile offset" begin
         # `qstart` shifts which k+q the tile covers; tiling must reproduce the untiled build.
         f = _iq_build_fixture((4, 4, 4))
-        nkq, iks = f.kqpts.n, 5:7
-        whole = fill(-7, nkq, length(iks))
-        _fill_iqs_serial!(whole, f.qpts, f.xkqs_int, f.xks_int, iks, 1, 1, nkq)
-        tiled = fill(-7, nkq, length(iks))
+        nkq, ik = f.kqpts.n, 5
+        whole = fill(-7, nkq)
+        _fill_iqs!(whole, f.qpts, f.xkqs_int, f.xks_int, ik, 1, nkq)
+        tiled = fill(-7, nkq)
         qstart = 1
         while qstart <= nkq
             nq = min(25, nkq - qstart + 1)
-            part = fill(-7, nq, length(iks))
-            _fill_iqs_serial!(part, f.qpts, f.xkqs_int, f.xks_int, iks, 1, qstart, nq)
-            tiled[qstart:(qstart + nq - 1), :] .= part
+            part = fill(-7, nq)
+            _fill_iqs!(part, f.qpts, f.xkqs_int, f.xks_int, ik, qstart, nq)
+            tiled[qstart:(qstart + nq - 1)] .= part
             qstart += nq
         end
         @test whole == tiled
@@ -138,8 +120,7 @@ end
         f = _iq_build_fixture((4, 4, 4))
         one_q = GridKpoints(Kpoints(1, f.qpts.vectors[2:2], f.qpts.weights[2:2], f.qpts.ngrid),
                             f.qpts.ngrid)
-        stage = fill(-7, f.kqpts.n, 1)
-        @test_throws ArgumentError _fill_iqs_serial!(stage, one_q, f.xkqs_int, f.xks_int,
-                                                     1:1, 1, 1, f.kqpts.n)
+        iqs = fill(-7, f.kqpts.n)
+        @test_throws ArgumentError _fill_iqs!(iqs, one_q, f.xkqs_int, f.xks_int, 1, 1, f.kqpts.n)
     end
 end

--- a/test/test_iq_build.jl
+++ b/test/test_iq_build.jl
@@ -1,0 +1,145 @@
+using Test
+using ElectronPhonon
+using Random
+using ElectronPhonon: Vec3, _grid_coords_reduced, _wrap_reduced, _fill_iqs_serial!
+
+# The per-(k-strip, q-tile) `iq` index build of the GPU outer-k loop
+# (`_loop_eph_over_k_and_kq_gpu`). The loop hashes integer grid coordinates instead of calling
+# `xk_to_ik` per pair, so the whole correctness story is "the fast hash agrees with `xk_to_ik`".
+# CPU-only: the build is host arithmetic and the loop it feeds is never reached on `CPUBackend`.
+
+# Everything the builder needs, assembled the way the loop's prologue assembles it. The outer k mesh
+# is always unshifted — the loop's `xks_int` does not subtract a shift, so a shifted k would not
+# land on integer grid coordinates at all. `shift` shifts the k+q mesh, which is what gives `qpts`
+# a nonzero shift for the k+q side to subtract.
+function _iq_build_fixture(ngrid; shift = (0, 0, 0))
+    kpts  = GridKpoints(kpoints_grid(ngrid))
+    kqpts = GridKpoints(kpoints_grid(ngrid; shift))
+    qpts  = ElectronPhonon.combine_kpoint_grids(kqpts, kpts, -, ngrid)
+    xkqs_int = Matrix{Int}(undef, 3, kqpts.n)
+    xks_int  = Matrix{Int}(undef, 3, kpts.n)
+    for ikq in 1:kqpts.n
+        xkqs_int[:, ikq] .= _grid_coords_reduced(kqpts.vectors[ikq], qpts.ngrid, qpts.shift)
+    end
+    for ik in 1:kpts.n
+        xks_int[:, ik] .= _grid_coords_reduced(kpts.vectors[ik], qpts.ngrid, zero(Vec3{Float64}))
+    end
+    (; kpts, kqpts, qpts, xkqs_int, xks_int)
+end
+
+# `xk_to_ik` on the actual difference vector — the independent oracle. It goes through the Float64
+# `_hash_xk` path, so agreeing with it also pins the integer shortcut's rounding.
+function _check_against_oracle(f, iks, nq)
+    stage = fill(-7, nq, length(iks))
+    _fill_iqs_serial!(stage, f.qpts, f.xkqs_int, f.xks_int, iks, 1, 1, nq)
+    ok = true
+    for (kloc, ik) in enumerate(iks), j in 1:nq
+        ok &= stage[j, kloc] == xk_to_ik(f.kqpts.vectors[j] - f.kpts.vectors[ik], f.qpts)
+    end
+    (ok, stage)
+end
+
+@testset "iq build" begin
+    @testset "serial builder == xk_to_ik oracle" begin
+        f = _iq_build_fixture((4, 4, 4))
+        ok, stage = _check_against_oracle(f, 1:f.kpts.n, f.kqpts.n)
+        @test ok
+        @test all(1 .<= stage .<= f.qpts.n)   # every pair resolved; no sentinel left behind
+    end
+
+    @testset "non-cubic ngrid" begin
+        # Three distinct sizes, so a transposed `(c1*ng2 + c2)*ng3 + c3` packing cannot pass by
+        # accident (the same reason `test_kpoints.jl` pins the dense table's layout on (2,3,4)).
+        f = _iq_build_fixture((3, 4, 5))
+        @test f.qpts.ngrid == (3, 4, 5)
+        ok, _ = _check_against_oracle(f, 1:f.kpts.n, f.kqpts.n)
+        @test ok
+    end
+
+    @testset "shifted grid" begin
+        # The q-grid shift is subtracted on the k+q side only (`_grid_coords_reduced(..., qpts.shift)`
+        # for k+q, a zero shift for k), because q = x_{k+q} - x_k - shift.
+        f = _iq_build_fixture((3, 4, 5); shift = (1//2, 0, 1//2))
+        @test iszero(f.kpts.shift) && !iszero(f.qpts.shift)
+        ok, _ = _check_against_oracle(f, 1:f.kpts.n, f.kqpts.n)
+        @test ok
+    end
+
+    @testset "[0,ng) reduction is exact" begin
+        # `mod(a - b, ng) == _wrap_reduced(mod(a,ng) - mod(b,ng), ng)`, and `_wrap_reduced` also
+        # folds a SUM of two reduced coordinates (what `combine_kpoint_grids` would need).
+        Random.seed!(20260802)
+        for ng in (1, 2, 3, 5, 17, 150)
+            for _ in 1:400
+                a, b = rand(-3ng:3ng), rand(-3ng:3ng)
+                @test _wrap_reduced(mod(a, ng) - mod(b, ng), ng) == mod(a - b, ng)
+                @test _wrap_reduced(mod(a, ng) + mod(b, ng), ng) == mod(a + b, ng)
+            end
+        end
+        # And the array-level reduction it relies on.
+        for ng in ((3, 4, 5), (150, 150, 150))
+            b = Vec3(rand(-1000:1000, 3))
+            @test _grid_coords_reduced(b, ng) == Vec3(mod.(b.data, ng))
+        end
+    end
+
+    @testset "partial final tile and strip" begin
+        # The loop stages a whole kR->kq strip at once into an (nq_batch_max, nk_b) matrix. A
+        # partial final q-tile writes only the leading `nq` rows, and a partial final strip only the
+        # leading `nks` columns; everything else must be left alone (it is copied to the device
+        # along with the rest but never read).
+        f = _iq_build_fixture((4, 4, 4))
+        nq_max, nk_b = f.kqpts.n, 3
+        for (nq, nks) in ((nq_max, nk_b), (7, nk_b), (nq_max, 2), (7, 1))
+            stage = fill(-7, nq_max, nk_b)
+            _fill_iqs_serial!(stage, f.qpts, f.xkqs_int, f.xks_int, 2:(1 + nks), 1, 1, nq)
+            @test all(stage[1:nq, 1:nks] .>= 1)
+            @test all(stage[(nq + 1):end, :] .== -7)
+            @test all(stage[:, (nks + 1):end] .== -7)
+        end
+    end
+
+    @testset "per-k staging == per-strip staging" begin
+        # `kloc0` lets the builder fill one column at a time; the loop uses that only as the
+        # `nk_b == 1` degenerate case, but the two must agree column for column.
+        f = _iq_build_fixture((3, 4, 5))
+        nq, iks = f.kqpts.n, 3:6
+        strip = fill(-7, nq, length(iks))
+        perk  = fill(-7, nq, length(iks))
+        _fill_iqs_serial!(strip, f.qpts, f.xkqs_int, f.xks_int, iks, 1, 1, nq)
+        for (kloc, ik) in enumerate(iks)
+            _fill_iqs_serial!(perk, f.qpts, f.xkqs_int, f.xks_int, ik:ik, kloc, 1, nq)
+        end
+        @test strip == perk
+    end
+
+    @testset "q-tile offset" begin
+        # `qstart` shifts which k+q the tile covers; tiling must reproduce the untiled build.
+        f = _iq_build_fixture((4, 4, 4))
+        nkq, iks = f.kqpts.n, 5:7
+        whole = fill(-7, nkq, length(iks))
+        _fill_iqs_serial!(whole, f.qpts, f.xkqs_int, f.xks_int, iks, 1, 1, nkq)
+        tiled = fill(-7, nkq, length(iks))
+        qstart = 1
+        while qstart <= nkq
+            nq = min(25, nkq - qstart + 1)
+            part = fill(-7, nq, length(iks))
+            _fill_iqs_serial!(part, f.qpts, f.xkqs_int, f.xks_int, iks, 1, qstart, nq)
+            tiled[qstart:(qstart + nq - 1), :] .= part
+            qstart += nq
+        end
+        @test whole == tiled
+    end
+
+    @testset "a q point missing from qpts is rejected" begin
+        # `iq == 0` is unreachable for a `qpts` built by `combine_kpoint_grids` from the same lists
+        # the loop iterates (it is the complete deduplicated difference set), so the guard is
+        # provoked with a `qpts` holding only one of those q points.
+        f = _iq_build_fixture((4, 4, 4))
+        one_q = GridKpoints(Kpoints(1, f.qpts.vectors[2:2], f.qpts.weights[2:2], f.qpts.ngrid),
+                            f.qpts.ngrid)
+        stage = fill(-7, f.kqpts.n, 1)
+        @test_throws ArgumentError _fill_iqs_serial!(stage, one_q, f.xkqs_int, f.xks_int,
+                                                     1:1, 1, 1, f.kqpts.n)
+    end
+end

--- a/test/test_iq_build.jl
+++ b/test/test_iq_build.jl
@@ -76,11 +76,11 @@ end
                 @test _wrap_reduced(mod(a, ng) + mod(b, ng), ng) == mod(a + b, ng)
             end
         end
-        # And the array-level reduction it relies on.
-        for ng in ((3, 4, 5), (150, 150, 150))
-            b = Vec3(rand(-1000:1000, 3))
-            @test _grid_coords_reduced(b, ng) == Vec3(mod.(b.data, ng))
-        end
+        # Outside (-ng, 2ng) one fold cannot reduce into 0:ng-1, so the precondition is checked
+        # (and the pair loops elide the check with `@inbounds` once they have established it).
+        @test_throws ArgumentError _wrap_reduced(-8, 4)
+        @test_throws ArgumentError _wrap_reduced(8, 4)
+        @test _wrap_reduced(-3, 4) == 1 && _wrap_reduced(7, 4) == 3
     end
 
     @testset "partial final tile and strip" begin

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -123,10 +123,12 @@ end
     atoms = ["B" => [ones(3)/8], "N" => [-ones(3)/8]]
     symmetry = symmetry_operations(lattice, atoms)
 
-    # Reference `hash => ik` map, built independently of the production index: the packed grid
-    # index is re-derived here rather than obtained from `_hash_xk`, so the sweep below pins the
-    # hash convention as well as the lookup. Ascending `ik` with plain assignment, so a repeated
-    # point resolves to the last one — the documented tie-break.
+    # Reference `hash => ik` map, built independently of the *builder* the production index uses:
+    # the packing `(c1*ng2 + c2)*ng3 + c3` is re-derived here instead of calling `_hash_xk`, so a
+    # change to the packing (including a transposed table layout, which the non-cubic grid below
+    # makes visible) is caught. The coordinate normalization is deliberately the same expression as
+    # `_hash_xk`'s, so this does NOT independently check normalization. Ascending `ik` with plain
+    # assignment, so a repeated point resolves to the last one — the documented tie-break.
     function reference_hash_to_ik(kpts)
         ng1, ng2, ng3 = kpts.ngrid
         ref = Dict{Int,Int}()
@@ -138,13 +140,13 @@ end
     end
 
     # The index must agree with the reference over the WHOLE hash domain, hits and misses alike.
-    function test_index_equivalence(kpts)
-        # Exactly one of the two indices is populated.
-        @test isempty(kpts._xk_hash_to_ik) == !isempty(kpts._dense_hash_to_ik)
+    # `dense` pins which of the two indices is expected to be the live one, so a future change to
+    # the gate cannot silently move these grids onto the other path.
+    function test_index_equivalence(kpts; dense = true)
+        @test isempty(kpts._dense_hash_to_ik) == !dense
+        @test isempty(kpts._xk_hash_to_ik) == dense
         ref = reference_hash_to_ik(kpts)
-        for h in 0:prod(kpts.ngrid)-1
-            @test _ik_from_hash(kpts, h) == get(ref, h, 0)
-        end
+        @test count(h -> _ik_from_hash(kpts, h) != get(ref, h, 0), 0:prod(kpts.ngrid)-1) == 0
         @test all(xk_to_ik.(kpts.vectors, Ref(kpts)) .== 1:kpts.n)
     end
 
@@ -152,12 +154,24 @@ end
     full = GridKpoints(kpoints_grid((N, N, N)))
     shifted = GridKpoints(kpoints_grid((N, N, N); shift = (1//2, 1//2, 1//2) ./ N))
     subset = GridKpoints(get_filtered_kpoints(kpoints_grid((N, N, N)), rand(Bool, N^3)))
+    @test subset.n > 0   # the sweep below assumes a non-empty selection
     irr = GridKpoints(kpoints_grid((N, N, N); symmetry))
     combined = combine_kpoint_grids(GridKpoints(kpoints_grid((2, 2, 2))), full, +, (N, N, N))
     unfolded, _ = unfold_kpoints(irr, symmetry)
     folded, _ = fold_kpoints(full, symmetry)
     for kpts in (full, shifted, subset, irr, combined, unfolded, folded)
         test_index_equivalence(kpts)
+    end
+
+    # An empty GridKpoints has NEITHER index; it is the one case where "exactly one" does not hold.
+    # (The `GridKpoints{T}()` placeholder carries ngrid == (0,0,0), on which `_hash_xk` divides by
+    # zero, so lookups are only meaningful on the empty-with-a-real-grid form.)
+    @test isempty(GridKpoints{Float64}()._dense_hash_to_ik)
+    @test isempty(GridKpoints{Float64}()._xk_hash_to_ik)
+    let empty_kpts = GridKpoints(Kpoints{Float64}(0, Vec3{Float64}[], Float64[], (N, N, N)))
+        @test empty_kpts.n == 0
+        @test isempty(empty_kpts._dense_hash_to_ik) && isempty(empty_kpts._xk_hash_to_ik)
+        @test xk_to_ik(Vec3(0.0, 0.0, 0.0), empty_kpts) === nothing
     end
 
     # Gate: dense for a grid as dense as it gets, Dict for a huge grid holding few points.
@@ -171,12 +185,26 @@ end
     # multigrid/AMR grid takes).
     @test xk_to_ik(Vec3(1/1000, 0.0, 0.0), sparse_kpts) === nothing
 
-    # The Dict fallback must satisfy the same whole-domain equivalence. Its grid can never be small
-    # (the node floor makes every small grid dense), so sweep it in one reduction.
+    # The Dict fallback must satisfy the same whole-domain equivalence, and so must the paths that
+    # only it exercises: `unfold_kpoints`/`fold_kpoints` hand their own Dict to the constructor
+    # (discarded on a dense grid, so untested there) and `sort!` has a separate Dict branch. A
+    # Dict-path grid can never be small — the node floor makes every small grid dense — so these
+    # run on a (2,2,2) point set stamped with a (128,128,128) grid, the shape `filter.jl` and
+    # `band_states.jl` produce for AMR composite grids. Shift 0, as `unfold_kpoints` requires.
     dict_kpts = GridKpoints(kpoints_grid((2, 2, 2)), (128, 128, 128))
-    @test isempty(dict_kpts._dense_hash_to_ik) && !isempty(dict_kpts._xk_hash_to_ik)
-    let ref = reference_hash_to_ik(dict_kpts)
-        @test all(_ik_from_hash(dict_kpts, h) == get(ref, h, 0) for h in 0:prod(dict_kpts.ngrid)-1)
+    test_index_equivalence(dict_kpts; dense = false)
+
+    dict_unfolded, _ = unfold_kpoints(dict_kpts, symmetry)
+    test_index_equivalence(dict_unfolded; dense = false)          # `() -> sk_hash_dict` hand-through
+    dict_folded, _ = fold_kpoints(dict_unfolded, symmetry)
+    test_index_equivalence(dict_folded; dense = false)            # `() -> hash_dict_irr` hand-through
+
+    let inds = randperm(dict_kpts.n)                              # `sort!`'s Dict branch
+        mixed = GridKpoints(Kpoints(dict_kpts.n, dict_kpts.vectors[inds], dict_kpts.weights[inds],
+                                    dict_kpts.ngrid), dict_kpts.ngrid)
+        sort!(mixed)
+        test_index_equivalence(mixed; dense = false)
+        @test sortperm(mixed) == 1:mixed.n
     end
 
     # Gate policy at its boundaries. Small grids are always dense; a grid sparser than 8 nodes per
@@ -214,7 +242,8 @@ end
     shift_center!(centered, (0, 0, 0))
     test_index_equivalence(centered)
 
-    # sort! renumbers the points and must renumber both indices.
+    # sort! renumbers the points and must renumber the live index (dense branch here, Dict branch
+    # covered above).
     inds = randperm(full.n)
     mixed = GridKpoints(Kpoints(full.n, full.vectors[inds], full.weights[inds], full.ngrid))
     sort!(mixed)

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -344,7 +344,13 @@ end
     kpts = GridKpoints(kpoints_grid((2, 2, 2)))
     qpts = GridKpoints(kpoints_grid((2, 2, 2)))
     deprecated = @test_deprecated add_two_kpoint_grids(kpts, qpts, +, (2, 2, 2))
-    @test deprecated == combine_kpoint_grids(kpts, qpts, +, (2, 2, 2))
+    combined = combine_kpoint_grids(kpts, qpts, +, (2, 2, 2))
+    # `GridKpoints` has no `==` (the index maps are derived caches), so compare the fields.
+    @test deprecated.n == combined.n
+    @test deprecated.vectors == combined.vectors
+    @test deprecated.weights == combined.weights
+    @test deprecated.ngrid == combined.ngrid
+    @test deprecated.shift == combined.shift
 
     # ngrid_kq must be divisible by both input grids.
     kpts = GridKpoints(kpoints_grid((2, 2, 2)))

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -313,6 +313,26 @@ end
     test_combine(kpts, qpts, +, (4, 4, 4))
     test_combine(kpts, qpts, -, (4, 4, 4))
 
+    # Non-cubic ngrid, so a transposed table layout or a coordinate swap cannot pass by accident.
+    kpts = GridKpoints(kpoints_grid((3, 4, 5)))
+    qpts = GridKpoints(kpoints_grid((3, 4, 5)))
+    test_combine(kpts, qpts, +, (3, 4, 5))
+    test_combine(kpts, qpts, -, (3, 4, 5))
+
+    # Grids of different density in each direction, combined on the finer common grid.
+    kpts = GridKpoints(kpoints_grid((2, 4, 6)))
+    qpts = GridKpoints(kpoints_grid((1, 2, 3)))
+    test_combine(kpts, qpts, +, (2, 4, 6))
+    test_combine(kpts, qpts, -, (2, 4, 6))
+
+    # Subsets of a grid (what a windowed driver run actually passes), on a non-cubic grid.
+    let g = kpoints_grid((4, 5, 6))
+        Random.seed!(2026)
+        sel = sort(randperm(g.n)[1:(g.n ÷ 3)])
+        sub = GridKpoints(Kpoints(length(sel), g.vectors[sel], g.weights[sel], g.ngrid), g.ngrid)
+        test_combine(sub, GridKpoints(g), -, (4, 5, 6))
+    end
+
     # Shifted q grid, and plain Kpoints input (converted to GridKpoints internally).
     shift = (0, 1//2, 1//2) ./ 3
     kpts = kpoints_grid((3, 3, 3))            # plain Kpoints, no shift
@@ -334,20 +354,34 @@ end
     @test combine_kpoint_grids(kpts, qpts, +, (6, 6, 6)) isa GridKpoints       # divisible by both
 
     # The dense and the Dict de-duplication (selected by the size of the dense table) must return
-    # the same points in the same order. Only the dense one is reachable at these grid sizes, so
-    # call both directly on the same integer grid coordinates.
-    using ElectronPhonon: _combine_kq_dedup_dense, _combine_kq_dedup_dict
+    # the same SET of points: the dense path sweeps its table, so it emits them in grid order, while
+    # the Dict path has no table to sweep and emits them in order of first appearance.
+    # `combine_kpoint_grids` sorts the result either way. Only the dense one is reachable at these
+    # grid sizes, so call both directly on the same integer grid coordinates.
+    using ElectronPhonon: _combine_kq_dedup_dense, _combine_kq_dedup_dict, _grid_coords_reduced
     Random.seed!(333)
     ngrid_kq = (4, 6, 5)
     for sgn in (1, -1)
         # Coordinates repeat across pairs, so both paths must hit their "already seen" branch.
-        BkS = [Vec3(rand(-6:6, 3)) for _ in 1:20]
-        BqS = [Vec3(rand(-6:6, 3)) for _ in 1:20]
+        BkS = [_grid_coords_reduced(Vec3(rand(-6:6, 3)), ngrid_kq) for _ in 1:20]
+        BqS = [_grid_coords_reduced(Vec3(rand(-6:6, 3)), ngrid_kq) for _ in 1:20]
         shift_kq = Vec3(0.0, 1/12, 0.0)
         xkqs_dense = _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
         xkqs_dict = _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)
         @test 0 < length(xkqs_dense) < length(BkS) * length(BqS)  # de-duplication happened
-        @test xkqs_dense == xkqs_dict
+        @test sort(xkqs_dense) == sort(xkqs_dict)
+        @test issorted(xkqs_dense; by = x -> round.(Int, (x - shift_kq).data .* ngrid_kq))
+    end
+
+    # Both paths fold with `_wrap_reduced` and write their table under `@inbounds`, so an unreduced
+    # coordinate would be memory corruption rather than a wrong answer. The precondition is checked
+    # once per list at entry; without that check this call segfaults.
+    let ngrid_kq = (4, 6, 5), shift_kq = Vec3(0.0, 0.0, 0.0)
+        raw = [Vec3(7, -3, 11)]
+        ok = [Vec3(1, 2, 3)]
+        @test_throws ArgumentError _combine_kq_dedup_dense(raw, ok, -1, ngrid_kq, shift_kq)
+        @test_throws ArgumentError _combine_kq_dedup_dense(ok, raw, -1, ngrid_kq, shift_kq)
+        @test_throws ArgumentError _combine_kq_dedup_dict(raw, ok, 1, ngrid_kq, shift_kq)
     end
 
     # Overflow guard: prod(ngrid) must fit in Int (checked in the GridKpoints constructor).

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -123,11 +123,27 @@ end
     atoms = ["B" => [ones(3)/8], "N" => [-ones(3)/8]]
     symmetry = symmetry_operations(lattice, atoms)
 
-    # The dense table and the Dict must agree over the WHOLE hash domain, hits and misses alike.
+    # Reference `hash => ik` map, built independently of the production index: the packed grid
+    # index is re-derived here rather than obtained from `_hash_xk`, so the sweep below pins the
+    # hash convention as well as the lookup. Ascending `ik` with plain assignment, so a repeated
+    # point resolves to the last one — the documented tie-break.
+    function reference_hash_to_ik(kpts)
+        ng1, ng2, ng3 = kpts.ngrid
+        ref = Dict{Int,Int}()
+        for (ik, xk) in enumerate(kpts.vectors)
+            c1, c2, c3 = mod.(round.(Int, (xk - kpts.shift) .* kpts.ngrid), kpts.ngrid)
+            ref[(c1 * ng2 + c2) * ng3 + c3] = ik
+        end
+        ref
+    end
+
+    # The index must agree with the reference over the WHOLE hash domain, hits and misses alike.
     function test_index_equivalence(kpts)
-        @test !isempty(kpts._dense_hash_to_ik)
+        # Exactly one of the two indices is populated.
+        @test isempty(kpts._xk_hash_to_ik) == !isempty(kpts._dense_hash_to_ik)
+        ref = reference_hash_to_ik(kpts)
         for h in 0:prod(kpts.ngrid)-1
-            @test _ik_from_hash(kpts, h) == get(kpts._xk_hash_to_ik, h, 0)
+            @test _ik_from_hash(kpts, h) == get(ref, h, 0)
         end
         @test all(xk_to_ik.(kpts.vectors, Ref(kpts)) .== 1:kpts.n)
     end
@@ -149,10 +165,19 @@ end
     sparse_kpts = GridKpoints(kpoints_grid((2, 2, 2)), (1000, 1000, 1000))
     @test !_use_dense_index(sparse_kpts.n, sparse_kpts.ngrid)
     @test isempty(sparse_kpts._dense_hash_to_ik)
+    @test !isempty(sparse_kpts._xk_hash_to_ik)   # the Dict is the index here, not dead weight
     @test all(xk_to_ik.(sparse_kpts.vectors, Ref(sparse_kpts)) .== 1:sparse_kpts.n)
     # A grid node that holds no k point must miss on the Dict fallback (the branch every
     # multigrid/AMR grid takes).
     @test xk_to_ik(Vec3(1/1000, 0.0, 0.0), sparse_kpts) === nothing
+
+    # The Dict fallback must satisfy the same whole-domain equivalence. Its grid can never be small
+    # (the node floor makes every small grid dense), so sweep it in one reduction.
+    dict_kpts = GridKpoints(kpoints_grid((2, 2, 2)), (128, 128, 128))
+    @test isempty(dict_kpts._dense_hash_to_ik) && !isempty(dict_kpts._xk_hash_to_ik)
+    let ref = reference_hash_to_ik(dict_kpts)
+        @test all(_ik_from_hash(dict_kpts, h) == get(ref, h, 0) for h in 0:prod(dict_kpts.ngrid)-1)
+    end
 
     # Gate policy at its boundaries. Small grids are always dense; a grid sparser than 8 nodes per
     # point is not; and the size cap is waived only when the Dict would be the bigger of the two.
@@ -175,11 +200,14 @@ end
         @test table_3d[c[3]+1, c[2]+1, c[1]+1] == xk_to_ik(xk, noncubic)
     end
 
-    # A duplicated point resolves to the last index on both paths.
+    # A duplicated point resolves to the last index, matching the reference's tie-break.
     dup_vectors = push!(copy(full.vectors), full.vectors[3])
     dup = GridKpoints(Kpoints(length(dup_vectors), dup_vectors, ones(length(dup_vectors)) / N^3, (N, N, N)))
     @test _ik_from_hash(dup, _hash_xk(dup.vectors[3], dup)) == dup.n
-    @test _ik_from_hash(dup, _hash_xk(dup.vectors[3], dup)) == get(dup._xk_hash_to_ik, _hash_xk(dup.vectors[3], dup), 0)
+    # (not `test_index_equivalence`: the point-to-index identity it asserts cannot hold here)
+    let ref = reference_hash_to_ik(dup)
+        @test all(_ik_from_hash(dup, h) == get(ref, h, 0) for h in 0:prod(dup.ngrid)-1)
+    end
 
     # shift_center! folds by integer lattice vectors, which leaves every hash unchanged.
     centered = GridKpoints(kpoints_grid((N, N, N)))

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -116,7 +116,7 @@ end
 
 @testset "kpoints: dense inverse index" begin
     using ElectronPhonon: get_filtered_kpoints, kpoints_grid, combine_kpoint_grids, unfold_kpoints,
-        fold_kpoints, _hash_xk, _ik_from_hash, _use_dense_index, _DENSE_INDEX_MAX_BYTES
+        fold_kpoints, _hash_xk, _ik_from_hash, _use_dense_index
 
     Random.seed!(222)
     lattice = 2.0 * [[0 1 1.]; [1 0 1.]; [1 1 0.]]
@@ -187,23 +187,27 @@ end
 
     # The Dict fallback must satisfy the same whole-domain equivalence, and so must the paths that
     # only it exercises: `unfold_kpoints`/`fold_kpoints` hand their own Dict to the constructor
-    # (discarded on a dense grid, so untested there) and `sort!` has a separate Dict branch. A
-    # Dict-path grid can never be small — the node floor makes every small grid dense — so these
-    # run on a (2,2,2) point set stamped with a (128,128,128) grid, the shape `filter.jl` and
-    # `band_states.jl` produce for AMR composite grids. Shift 0, as `unfold_kpoints` requires.
-    dict_kpts = GridKpoints(kpoints_grid((2, 2, 2)), (128, 128, 128))
-    test_index_equivalence(dict_kpts; dense = false)
+    # (discarded on a dense grid, so untested there) and `sort!` has a separate Dict branch. The
+    # `index = :dict` override reaches the fallback on these same small grids, instead of depending
+    # on a grid shape sparse enough for the policy to pick the Dict by itself (`sparse_kpts` above
+    # is the one that pins the policy). Shift 0 on `irr`, as `unfold_kpoints` requires.
+    for kpts in (full, shifted, subset, irr)
+        test_index_equivalence(GridKpoints(Kpoints(kpts), kpts.ngrid; index = :dict); dense = false)
+    end
 
-    dict_unfolded, _ = unfold_kpoints(dict_kpts, symmetry)
+    dict_kpts = GridKpoints(Kpoints(irr), irr.ngrid; index = :dict)
+    dict_unfolded, _ = unfold_kpoints(dict_kpts, symmetry; index = :dict)
     test_index_equivalence(dict_unfolded; dense = false)          # `() -> sk_hash_dict` hand-through
-    dict_folded, _ = fold_kpoints(dict_unfolded, symmetry)
+    dict_folded, _ = fold_kpoints(dict_unfolded, symmetry; index = :dict)
     test_index_equivalence(dict_folded; dense = false)            # `() -> hash_dict_irr` hand-through
 
-    let inds = randperm(dict_kpts.n)                              # `sort!`'s Dict branch
-        mixed = GridKpoints(Kpoints(dict_kpts.n, dict_kpts.vectors[inds], dict_kpts.weights[inds],
-                                    dict_kpts.ngrid), dict_kpts.ngrid)
+    # Both branches of `sort!`'s index renumbering.
+    for index in (:dense, :dict)
+        inds = randperm(full.n)
+        mixed = GridKpoints(Kpoints(full.n, full.vectors[inds], full.weights[inds], full.ngrid),
+                            full.ngrid; index)
         sort!(mixed)
-        test_index_equivalence(mixed; dense = false)
+        test_index_equivalence(mixed; dense = index === :dense)
         @test sortperm(mixed) == 1:mixed.n
     end
 
@@ -212,20 +216,33 @@ end
     @test _use_dense_index(1, (100, 100, 100))            # below the node floor
     @test _use_dense_index(10^6, (200, 200, 200))         # 8 nodes per point, under the cap
     @test !_use_dense_index(10^6 - 1, (200, 200, 200))    # just over 8 nodes per point
-    nnode_over_cap = 2 * _DENSE_INDEX_MAX_BYTES ÷ sizeof(Int)
+    # The 256 MB cap is a local of `_use_dense_index` in src/common/kpoints.jl, so it is repeated
+    # here rather than imported; keep the two in sync.
+    dense_index_max_bytes = 256 * 1024^2
+    nnode_over_cap = 2 * dense_index_max_bytes ÷ sizeof(Int)
     @test !_use_dense_index(nnode_over_cap ÷ 8, (nnode_over_cap, 1, 1))  # cap binds
     @test _use_dense_index(nnode_over_cap ÷ 4, (nnode_over_cap, 1, 1))   # cap waived: Dict is bigger
 
-    # Layout: the flat table is a (ng3, ng2, ng1) array indexed by the integer grid coordinates,
-    # i.e. the linear index is exactly `hash + 1`. Flipping the dims would silently return wrong
-    # indices. The grid must have three distinct sizes, or a reshape to the wrong dims still fits.
+    # The `index` override wins over the policy in both directions, and rejects a bad value.
+    @test _use_dense_index(1, (1000, 1000, 1000); index = :dense)
+    @test !_use_dense_index(10^6, (100, 100, 100); index = :dict)
+    @test_throws ArgumentError _use_dense_index(1, (4, 4, 4); index = :nonsense)
+
+    # Layout: the table is a (ng3, ng2, ng1) array indexed by the integer grid coordinates, so that
+    # its linear index — how `_ik_from_hash` reads it — is exactly `hash + 1`. Flipping the dims
+    # would silently return wrong indices. The grid must have three distinct sizes, or the wrong
+    # dims would still be the right total length.
     noncubic = GridKpoints(kpoints_grid((2, 3, 4); shift = (1//4, 1//6, 1//8)))
     test_index_equivalence(noncubic)
     ng1, ng2, ng3 = noncubic.ngrid
-    table_3d = reshape(noncubic._dense_hash_to_ik, ng3, ng2, ng1)
+    table_3d = noncubic._dense_hash_to_ik
+    @test table_3d isa Array{Int,3}
+    @test size(table_3d) == (ng3, ng2, ng1)
     for xk in noncubic.vectors
         c = mod.(round.(Int, (xk - noncubic.shift) .* noncubic.ngrid), noncubic.ngrid)
         @test table_3d[c[3]+1, c[2]+1, c[1]+1] == xk_to_ik(xk, noncubic)
+        # The cartesian slot and the linear `hash + 1` slot are the same slot.
+        @test LinearIndices(table_3d)[c[3]+1, c[2]+1, c[1]+1] == _hash_xk(xk, noncubic) + 1
     end
 
     # A duplicated point resolves to the last index, matching the reference's tie-break.

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -358,13 +358,14 @@ end
     # the Dict path has no table to sweep and emits them in order of first appearance.
     # `combine_kpoint_grids` sorts the result either way. Only the dense one is reachable at these
     # grid sizes, so call both directly on the same integer grid coordinates.
-    using ElectronPhonon: _combine_kq_dedup_dense, _combine_kq_dedup_dict, _grid_coords_reduced
+    using ElectronPhonon: _combine_kq_dedup_dense, _combine_kq_dedup_dict
     Random.seed!(333)
     ngrid_kq = (4, 6, 5)
     for sgn in (1, -1)
         # Coordinates repeat across pairs, so both paths must hit their "already seen" branch.
-        BkS = [_grid_coords_reduced(Vec3(rand(-6:6, 3)), ngrid_kq) for _ in 1:20]
-        BqS = [_grid_coords_reduced(Vec3(rand(-6:6, 3)), ngrid_kq) for _ in 1:20]
+        # Both routines require their inputs already reduced into 0:ng-1.
+        BkS = [Vec3(mod.(rand(-6:6, 3), ngrid_kq)) for _ in 1:20]
+        BqS = [Vec3(mod.(rand(-6:6, 3), ngrid_kq)) for _ in 1:20]
         shift_kq = Vec3(0.0, 1/12, 0.0)
         xkqs_dense = _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
         xkqs_dict = _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -114,6 +114,86 @@ end
     @test all([k isa GridKpoints for k in kpts_split])
 end
 
+@testset "kpoints: dense inverse index" begin
+    using ElectronPhonon: get_filtered_kpoints, kpoints_grid, combine_kpoint_grids, unfold_kpoints,
+        fold_kpoints, _hash_xk, _ik_from_hash, _use_dense_index, _DENSE_INDEX_MAX_BYTES
+
+    Random.seed!(222)
+    lattice = 2.0 * [[0 1 1.]; [1 0 1.]; [1 1 0.]]
+    atoms = ["B" => [ones(3)/8], "N" => [-ones(3)/8]]
+    symmetry = symmetry_operations(lattice, atoms)
+
+    # The dense table and the Dict must agree over the WHOLE hash domain, hits and misses alike.
+    function test_index_equivalence(kpts)
+        @test !isempty(kpts._dense_hash_to_ik)
+        for h in 0:prod(kpts.ngrid)-1
+            @test _ik_from_hash(kpts, h) == get(kpts._xk_hash_to_ik, h, 0)
+        end
+        @test all(xk_to_ik.(kpts.vectors, Ref(kpts)) .== 1:kpts.n)
+    end
+
+    N = 4
+    full = GridKpoints(kpoints_grid((N, N, N)))
+    shifted = GridKpoints(kpoints_grid((N, N, N); shift = (1//2, 1//2, 1//2) ./ N))
+    subset = GridKpoints(get_filtered_kpoints(kpoints_grid((N, N, N)), rand(Bool, N^3)))
+    irr = GridKpoints(kpoints_grid((N, N, N); symmetry))
+    combined = combine_kpoint_grids(GridKpoints(kpoints_grid((2, 2, 2))), full, +, (N, N, N))
+    unfolded, _ = unfold_kpoints(irr, symmetry)
+    folded, _ = fold_kpoints(full, symmetry)
+    for kpts in (full, shifted, subset, irr, combined, unfolded, folded)
+        test_index_equivalence(kpts)
+    end
+
+    # Gate: dense for a grid as dense as it gets, Dict for a huge grid holding few points.
+    @test !isempty(full._dense_hash_to_ik)
+    sparse_kpts = GridKpoints(kpoints_grid((2, 2, 2)), (1000, 1000, 1000))
+    @test !_use_dense_index(sparse_kpts.n, sparse_kpts.ngrid)
+    @test isempty(sparse_kpts._dense_hash_to_ik)
+    @test all(xk_to_ik.(sparse_kpts.vectors, Ref(sparse_kpts)) .== 1:sparse_kpts.n)
+    # A grid node that holds no k point must miss on the Dict fallback (the branch every
+    # multigrid/AMR grid takes).
+    @test xk_to_ik(Vec3(1/1000, 0.0, 0.0), sparse_kpts) === nothing
+
+    # Gate policy at its boundaries. Small grids are always dense; a grid sparser than 8 nodes per
+    # point is not; and the size cap is waived only when the Dict would be the bigger of the two.
+    @test _use_dense_index(1, (100, 100, 100))            # below the node floor
+    @test _use_dense_index(10^6, (200, 200, 200))         # 8 nodes per point, under the cap
+    @test !_use_dense_index(10^6 - 1, (200, 200, 200))    # just over 8 nodes per point
+    nnode_over_cap = 2 * _DENSE_INDEX_MAX_BYTES ÷ sizeof(Int)
+    @test !_use_dense_index(nnode_over_cap ÷ 8, (nnode_over_cap, 1, 1))  # cap binds
+    @test _use_dense_index(nnode_over_cap ÷ 4, (nnode_over_cap, 1, 1))   # cap waived: Dict is bigger
+
+    # Layout: the flat table is a (ng3, ng2, ng1) array indexed by the integer grid coordinates,
+    # i.e. the linear index is exactly `hash + 1`. Flipping the dims would silently return wrong
+    # indices. The grid must have three distinct sizes, or a reshape to the wrong dims still fits.
+    noncubic = GridKpoints(kpoints_grid((2, 3, 4); shift = (1//4, 1//6, 1//8)))
+    test_index_equivalence(noncubic)
+    ng1, ng2, ng3 = noncubic.ngrid
+    table_3d = reshape(noncubic._dense_hash_to_ik, ng3, ng2, ng1)
+    for xk in noncubic.vectors
+        c = mod.(round.(Int, (xk - noncubic.shift) .* noncubic.ngrid), noncubic.ngrid)
+        @test table_3d[c[3]+1, c[2]+1, c[1]+1] == xk_to_ik(xk, noncubic)
+    end
+
+    # A duplicated point resolves to the last index on both paths.
+    dup_vectors = push!(copy(full.vectors), full.vectors[3])
+    dup = GridKpoints(Kpoints(length(dup_vectors), dup_vectors, ones(length(dup_vectors)) / N^3, (N, N, N)))
+    @test _ik_from_hash(dup, _hash_xk(dup.vectors[3], dup)) == dup.n
+    @test _ik_from_hash(dup, _hash_xk(dup.vectors[3], dup)) == get(dup._xk_hash_to_ik, _hash_xk(dup.vectors[3], dup), 0)
+
+    # shift_center! folds by integer lattice vectors, which leaves every hash unchanged.
+    centered = GridKpoints(kpoints_grid((N, N, N)))
+    shift_center!(centered, (0, 0, 0))
+    test_index_equivalence(centered)
+
+    # sort! renumbers the points and must renumber both indices.
+    inds = randperm(full.n)
+    mixed = GridKpoints(Kpoints(full.n, full.vectors[inds], full.weights[inds], full.ngrid))
+    sort!(mixed)
+    test_index_equivalence(mixed)
+    @test mixed.vectors ≈ full.vectors
+end
+
 @testset "kpoints: combine_kpoint_grids" begin
     using ElectronPhonon: kpoints_grid, combine_kpoint_grids, add_two_kpoint_grids
 
@@ -178,6 +258,23 @@ end
     @test_throws ArgumentError combine_kpoint_grids(kpts, qpts, +, (3, 3, 3))  # not divisible by kpts
     @test_throws ArgumentError combine_kpoint_grids(kpts, qpts, +, (2, 2, 2))  # not divisible by qpts
     @test combine_kpoint_grids(kpts, qpts, +, (6, 6, 6)) isa GridKpoints       # divisible by both
+
+    # The dense and the Dict de-duplication (selected by the size of the dense table) must return
+    # the same points in the same order. Only the dense one is reachable at these grid sizes, so
+    # call both directly on the same integer grid coordinates.
+    using ElectronPhonon: _combine_kq_dedup_dense, _combine_kq_dedup_dict
+    Random.seed!(333)
+    ngrid_kq = (4, 6, 5)
+    for sgn in (1, -1)
+        # Coordinates repeat across pairs, so both paths must hit their "already seen" branch.
+        BkS = [Vec3(rand(-6:6, 3)) for _ in 1:20]
+        BqS = [Vec3(rand(-6:6, 3)) for _ in 1:20]
+        shift_kq = Vec3(0.0, 1/12, 0.0)
+        xkqs_dense = _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
+        xkqs_dict = _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)
+        @test 0 < length(xkqs_dense) < length(BkS) * length(BqS)  # de-duplication happened
+        @test xkqs_dense == xkqs_dict
+    end
 
     # Overflow guard: prod(ngrid) must fit in Int (checked in the GridKpoints constructor).
     @test GridKpoints(kpoints_grid((1, 1, 1)), (1000, 1000, 1000)) isa GridKpoints

--- a/test/test_unfold.jl
+++ b/test/test_unfold.jl
@@ -1,5 +1,9 @@
 using Test
 using ElectronPhonon
+
+# `GridKpoints` has no `==`: the index maps are derived caches. Compare the defining fields.
+kpoints_fields_equal(a, b) = (a.n == b.n && a.vectors == b.vectors && a.weights == b.weights
+                              && a.ngrid == b.ngrid && a.shift == b.shift)
 using LinearAlgebra
 
 @testset "unfold" begin
@@ -18,7 +22,7 @@ using LinearAlgebra
         kpts = GridKpoints(kpoints_grid((nk, nk, nk); model.symmetry));
         kpts_unfold_ref = GridKpoints(kpoints_grid((nk, nk, nk)));
         kpts_unfold = unfold_kpoints(kpts, model.symmetry);
-        @test kpts_unfold == kpts_unfold_ref
+        @test kpoints_fields_equal(kpts_unfold, kpts_unfold_ref)
 
         # Unfolding of irreducible BZ inside given energy window to full BZ
         nk = 53
@@ -28,7 +32,7 @@ using LinearAlgebra
         kpts_unfold_ref = GridKpoints(filter_electron_states((nk, nk, nk), model.nw, model.el_ham, window;
             symmetry=nothing).kpts)
         kpts_unfold = unfold_kpoints(kpts, model.symmetry);
-        @test kpts_unfold == kpts_unfold_ref
+        @test kpoints_fields_equal(kpts_unfold, kpts_unfold_ref)
 
         # Test folding of kpoints (inverse of unfolding)
         kpts_by_folding, ik_to_ikirr_isym = fold_kpoints(kpts_unfold, model.symmetry)
@@ -125,7 +129,7 @@ using LinearAlgebra
         @test el_unfold.e2[inds] ≈ el_unfold_ref.e2
         @test el_unfold.ib_rng == el_unfold_ref.ib_rng
         @test el_unfold.nstates_base ≈ el_unfold_ref.nstates_base
-        @test el_unfold.kpts == el_unfold_ref.kpts
+        @test kpoints_fields_equal(el_unfold.kpts, el_unfold_ref.kpts)
 
         # Test constant RTA conductivity is the same with el and el_unfold.
         transport_params = ElectronTransportParams{Float64}(


### PR DESCRIPTION
## Motivation

The GPU outer-k e-ph loop (`_loop_eph_over_k_and_kq_gpu`) ran at **43% kernel-time utilization** on a realistic BTE run — the GPU idled while one host thread did per-pair index work. Two changes fix that, and both apply to every model. A third (a k-strip GEMM) was built, measured, and then **removed**: it was worth 1.23× but only for single-atom cells at a narrow window, which is not a class worth a permanent loop level.

Cu, nk=150, ±0.2 eV, symmetry, A100-SXM4-80GB (`workergpu053`, SW-capped 225 W), 16 threads:

| | loop wall | kernel-time util |
|---|---|---|
| `main` (`57a42b1`) | 101.44 s | 43% |
| + dense q-index (1.70×) | 59.7 s | |
| + k+q-convention phase hoist (1.89×) | 31.6 s | |
| **this branch** (`8e8b3cc`) | **30.89 s** | ~93% |

**3.28× end to end.** At nk=200 the loop is 177.1 s. `combine_kpoint_grids` in setup also went **76.86 → 2.69 s (28.5×)** at nk=200 (#12, merged into this branch).

## Change

**Dense q-index** (`src/common/kpoints.jl`). The per-pair `iq` lookup probed a 142.6 MB `Dict` for all nk×nkq = 1.11e9 pairs, plus a dependent random gather — both past L3. Replaced by a size-gated dense `Array{Int,3}` of dims `(ng3,ng2,ng1)` indexed `[c3+1,c2+1,c1+1]`, whose linear index is exactly `hash+1`. All lookups route through one `_ik_from_hash`, so the CPU e-ph / transport / screening paths get it free.

- The `qpts_is_full ? hash+1` fast path was **dead code and always had been** (`shift_center!` folds coords signed, `_hash_xk` applies `mod`) — verified false even on genuinely full 2³/3³/4³/6³ grids. Every run of this loop had always paid the `Dict`.
- `index = :auto/:dense/:dict` override on `GridKpoints` for testing the fallback.

**k+q-convention phase hoist** (`src/wannier_to_bloch_batched.jl`, `run_eph_over_k_and_kq.jl`). Uses
`exp(2πi R_p·q) = exp(2πi R_p·x_{k+q}) · conj(exp(2πi R_p·x_k))` (verified to 1.1e-14 including mod-G reduction) to store `g(k, R_p)` in the k+q convention, which makes the kR→kq phase **k-independent**:

- before: rebuild the `(nr_ep × nq)` phase per (k, q-tile) — 4918 × ntiles times
- after: build it once per q-tile, reuse for every k in the batch — 20 times

Loop reorders to **k-batch → q-tile → k** (+ q on device). Deletes the child `WannierObject`, the second interpolator, the per-k `update_op_r!`, `qs_batch` (a 66 MB dependent gather per pair), `ikqs_host`/`ikqs_dev`, and `rdotk` repo-wide.

**Contract break.** The batched outer-k loop no longer fires the per-k `OuterIteration` bracket — under the reorder a k's work only completes at the end of the k-batch, so the hook cannot mean what its name says. `BatchedMode` outer-k has `OuterIterationBatch` only. Pinned in `test_calculator_contract.jl`, documented in `docs/writing_a_calculator.md` and the README table. Both in-tree calculators already treated it as a no-op.

**`EPDataQBatched.ikqs` is a `UnitRange`** — `isbits`, so it rides in the kernel launch parameters instead of costing a device buffer and one global load per scatter thread.

## Measured, then removed

Two constructs were built, measured, and reverted. The numbers are kept so nobody redoes the experiments (full records in `GPU_PROGRESS.md`).

**k-strip kR→kq GEMM** — reverted in `8e8b3cc`, **−250 lines**. Stacked `nk_b` outer k into one tall GEMM. Real and re-measured at tip (Cu nk=200, shared setup, same binary via a `Ref` override, alternating arms):

| arm | reps (s) | median |
|---|---|---|
| `nk_b = 7` | 145.35 / 144.86 / 144.92 | 144.92 |
| `nk_b = 1` | 178.40 / 178.31 / 178.10 | 178.31 |

1.230×, 33.4 s, **18.7% of loop wall**. Removed anyway, because `_krkq_strip_width` has two gates and neither is escapable in practice:

| nw | nmodes | in-window bands | ndata | nk_b |
|---|---|---|---|---|
| 7 | 3 | 1 | 21 | 7 |
| 7 | 3 | 3 | 63 | 3 |
| 7 | 3 | 7 (full band) | 147 | **1** |
| 7 | 6 | 1 | 42 | **1** |
| 32 | 12 | 1 | 384 | **1** |

`nw*nmodes ≤ 24` is **model-only**, so no window choice rescues a multi-atom cell (nmodes=6 needs nw≤4; nmodes=12 needs nw≤2), and more in-window bands closes the `ndata < 128` gate independently. It engaged only for Cu at ±0.2 eV and Na. Removal also cut per-q device memory 5.1 → 3.6 kB/q, so q-tiles get bigger on exactly the large-`nw` models the strip never helped.

**Per-strip `iq` staging** — reverted in `f48b597`, −47 lines. Justified on "7× fewer stream drains", but a `:nocopy` probe measured that mechanism at **−0.64 s** (the blocking `copyto!` usefully throttles host look-ahead), and a `:null` arm replacing the build with a constant fill measured level with the shipped code — the host build is already free. Measured worth: 0.02% against 0.16–0.42 s of session drift.

## Test

`Sᵢ` is the correctness target throughout. `Sₒ` is **not** run-to-run reproducible (`CUDA.@atomic` fold, ~1e-14 relative), and `Base.hash` on a large array **samples elements**, so bitwise claims below use a full-array FNV fold.

- **`Sᵢ` bitwise identical** across: dense-vs-`Dict` index, 1-tile vs 4-tile emission order, both strip widths, and strip-present vs strip-removed (FNV over all 1.005e8 elements, `1224223090643646050` on both sides of `f48b597..8e8b3cc`).
- **Index equivalence** — `_ik_from_hash(kpts,h) == get(dict,h,0)` for **every** `h in 0:prod(ngrid)-1` across seven grid constructions.
- **Interpolation** — band energies, velocities, phonon ω and raw `H(k)`/`D(q)` bitwise identical before/after on a fixed 8³ grid, CPU and GPU. A 256-bit `BigFloat` reference puts both e-ph factorizations at ~1 ulp of `max|g|`.
- **CPU vs GPU** — `rdiff = 8.1e-16` on the in-tree driver comparisons.
- **Suites** — `test_gpu.jl` (incl. exact byte-accounting pins), `test_iq_build.jl`, `test_kpoints.jl`, `test_calculator_contract.jl`, `test_gpu_boltzmann_calculator.jl`: **5004 pass**. MigdalEliashberg 41/41 with GPU `EliashbergCalculator` 9/9 and GPU-vs-CPU `solve!` 4/4 *actually running* — CUDA is in ME's `[extras]`, so those two testsets silently skip unless the env carries both `Lehmann` and `CUDA`.

**Crash this branch shipped and fixed** (`4decfc3`, worth a look): `_krkq_strip_width` returned 1 exactly when `nw*nmodes > 24`, i.e. exactly when there is no fused rotation kernel, so those models took the cuBLAS two-GEMM branch — which reshapes `g`. The operand `view(g_strip5, :, :, :, kloc, rng_q)` *is* dense, but its `reshape` is a `ReshapedArray` with **no device pointer**, so every outer-k GPU run with `nw*nmodes > 24` aborted at the first rotation. Dense is necessary, not sufficient. No test caught it because no in-repo GPU model exceeds the threshold (Cu 7·3, Pb 4·3). Moot now that the strip is gone, but the `_is_dense` guard and the `nw=6, nmodes=6` two-GEMM coverage remain.

Measurement notes for anyone re-running: `nvidia-smi utilization.gpu` marks an interval busy if *any* kernel ran in it and reads 91–94% here, so the table uses kernel time. This host's A100 is SW-capped at 225 W — sustained FP64 drops the SM clock 1275 → 870 MHz, so kernel durations are **not** comparable between runs at different occupancy.

## Known pre-existing, not addressed

- `xk_to_ik` on the `GridKpoints{T}()` placeholder throws `DivideError` (`ngrid == (0,0,0)` → `mod(·, 0)`). Predates this branch, affects both index paths.
- `plan_batch`'s `warn = false` kwarg was orphaned by `4decfc3`; it has a test and is a general opt-out, so it is left in place.
- Companion commit `31933f0` on MigdalEliashberg.jl `gpubte-opt` (comment-only, calculator brackets) — that repo has no git remote, so it is local-only and not reviewable here.
