### PR TITLE
perf(kpoints): 26x faster k+q grid de-duplication (mark-then-collect, threaded, pre-reduced)

### DIFF
--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -278,12 +278,13 @@ that a sweep over consecutive `c3` walks the table sequentially. With those dims
 of a slot is exactly `hash + 1` for the `(c1*ng2 + c2)*ng3 + c3` packing, so this table and
 `GridKpoints._dense_hash_to_ik` share one layout.
 
-Two passes rather than one. Pass 1 only MARKS which slots occur, in a `Vector{UInt8}` instead of
-the `Array{Int,3}` of indices the single-pass version needed: the pair loop's access into the table
-is a random probe, so at 8 B per node it missed cache on nearly every pair, and 1 B per node is 8×
-more of the grid resident (8 MB vs 64 MB at 200³). Marking is also idempotent — every writer stores
-the same 1 — which is what lets the pass be threaded with no synchronization. (A `BitArray` would
-be smaller still but its writes race at word granularity.)
+Two passes rather than one. Pass 1 only MARKS which slots occur, in an `Array{Bool}` instead of the
+`Array{Int}` of indices the single-pass version needed: the pair loop's access into the table is a
+random probe, so at 8 B per node it missed cache on nearly every pair, and `Bool` is 1 B per node,
+putting 8× more of the grid in cache (8 MB vs 64 MB at 200³). Marking is also idempotent — every
+writer stores the same `true` — which is what lets the pass be threaded with no synchronization.
+(A `BitArray` would be smaller still but its writes race at word granularity; `Array{Bool}` stores
+one byte per element, so its writes do not.)
 Pass 2 sweeps the table in index order and emits the points. That discards first-appearance order,
 which is safe because `combine_kpoint_grids` sorts the result on the integer grid coordinates — a
 total order, the points being distinct — and `sort!(::GridKpoints)` renumbers the index afterwards.
@@ -291,13 +292,13 @@ total order, the points being distinct — and `sort!(::GridKpoints)` renumbers 
 function _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) where {T}
     ng1, ng2, ng3 = ngrid_kq
     _check_reduced_coords(BkS, BqS, ngrid_kq)
-    seen = zeros(UInt8, ng3, ng2, ng1)
+    seen = zeros(Bool, ng3, ng2, ng1)
     _mark_kq_pairs!(seen, BkS, BqS, sgn, ng1, ng2, ng3)
 
-    xkqs = Vector{Vec3{T}}(undef, count(!iszero, seen))
+    xkqs = Vector{Vec3{T}}(undef, count(seen))
     ikq = 0
-    @inbounds for c1 in 0:(ng1 - 1), c2 in 0:(ng2 - 1), c3 in 0:(ng3 - 1)
-        iszero(seen[c3 + 1, c2 + 1, c1 + 1]) && continue
+    for c1 in 0:(ng1 - 1), c2 in 0:(ng2 - 1), c3 in 0:(ng3 - 1)
+        seen[c3 + 1, c2 + 1, c1 + 1] || continue
         ikq += 1
         xkqs[ikq] = Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq
     end
@@ -320,9 +321,14 @@ end
 # typed arguments rather than `Core.Box`. Partitioned over `BqS` (the longer list in the k+q use),
 # each chunk sweeping the whole `BkS` — chunks share `seen` but only ever write the same value into
 # a slot, so no synchronization is needed and the result does not depend on the partition.
-function _mark_kq_pairs!(seen::Array{UInt8,3}, BkS::Vector{Vec3{Int}}, BqS::Vector{Vec3{Int}},
+function _mark_kq_pairs!(seen::Array{Bool,3}, BkS::Vector{Vec3{Int}}, BqS::Vector{Vec3{Int}},
                          sgn::Int, ng1::Int, ng2::Int, ng3::Int)
     @threads for iq in eachindex(BqS)
+        # `@inbounds` here is load-bearing for performance, not tidiness: this block runs
+        # nk*nkq ~ 1e9 times. It is safe because `_check_reduced_coords` has already established
+        # `0 <= b < ng` for every entry of both lists, so `_wrap_reduced` returns a value in
+        # `0:ng-1` on all three axes and every index below is in range. It also elides
+        # `_wrap_reduced`'s own `@boundscheck`, whose precondition that guard is what establishes.
         @inbounds begin
             bq = BqS[iq]
             q1, q2, q3 = sgn * bq[1], sgn * bq[2], sgn * bq[3]
@@ -330,7 +336,7 @@ function _mark_kq_pairs!(seen::Array{UInt8,3}, BkS::Vector{Vec3{Int}}, BqS::Vect
                 c1 = _wrap_reduced(bk[1] + q1, ng1)
                 c2 = _wrap_reduced(bk[2] + q2, ng2)
                 c3 = _wrap_reduced(bk[3] + q3, ng3)
-                seen[c3 + 1, c2 + 1, c1 + 1] = 0x01
+                seen[c3 + 1, c2 + 1, c1 + 1] = true
             end
         end
     end
@@ -406,24 +412,13 @@ function combine_kpoint_grids(kpts, qpts, op, ngrid_kq)
     shift_kq = op(shift_k, shift_q)
     sgn = Symbol(op) === :+ ? 1 : -1
 
-    # Work in integer grid coordinates on the common ngrid_kq grid. Each input point is exactly
-    # `shift + b / ngrid` with integer `b = round((xk - shift) * ngrid)`; rescaled onto ngrid_kq
-    # (an integer multiple of both input grids, checked above) the coordinate is `b * (ngrid_kq ÷
-    # ngrid)`. Then `op(k, q)` folded into the cell is plain integer arithmetic
-    #   c = mod(b_k ± b_q, ngrid_kq)  ∈ [0, ngrid_kq),
-    # which is exact and gcd-free (the old Rational arithmetic was the bottleneck), and recomputing
-    # `b` once per point (not per pair) avoids O(nk·nkq) redundant work. `c` identifies the k+q
-    # point uniquely, so it is also the de-duplication key: the Dict path packs it as
-    # `(c1*ng2 + c2)*ng3 + c3` (which happens to equal `_hash_xk(xkq)`), the dense path indexes an
-    # array by it directly.
-    # Both lists are reduced into `0:ng-1` here, once per point, so that the O(nk·nkq) fold is
-    # `_wrap_reduced` (a compare-and-add) rather than three runtime 64-bit integer divisions.
-    fk = ngrid_kq .÷ kpts.ngrid
-    fq = ngrid_kq .÷ qpts.ngrid
-    BkS = [_grid_coords_reduced(Vec3(round.(Int, (xk - shift_k).data .* kpts.ngrid) .* fk), ngrid_kq)
-           for xk in kpts.vectors]
-    BqS = [_grid_coords_reduced(Vec3(round.(Int, (xq - shift_q).data .* qpts.ngrid) .* fq), ngrid_kq)
-           for xq in qpts.vectors]
+    # Integer coordinates on the common grid, in `0:ng-1`. Every input point sits on ngrid_kq exactly
+    # (it is a multiple of both input grids, checked above), so `op(k, q)` is integer arithmetic —
+    # exact, and the reduced operands let the O(nk·nkq) fold be `_wrap_reduced` rather than `mod`.
+    # These coordinates are also the de-duplication key: `_combine_kq_dedup_dict` packs them as
+    # `(c1*ng2 + c2)*ng3 + c3` (which equals `_hash_xk(xkq)`), the dense path indexes by them.
+    BkS = [_grid_coords_reduced(xk, ngrid_kq, shift_k) for xk in kpts.vectors]
+    BqS = [_grid_coords_reduced(xq, ngrid_kq, shift_q) for xq in qpts.vectors]
 
     # Dense lookup table while it fits in the transient budget, Dict above it. The budget is loose
     # because the table lives only until this function returns. `Int128` because `prod(ngrid_kq)`
@@ -613,16 +608,17 @@ mpi_gather_and_scatter(k::GridKpoints, comm::Nothing) = k
     mod(round(Int, (xk[2] - shift[2]) * ngrid[2]), ngrid[2]),
     mod(round(Int, (xk[3] - shift[3]) * ngrid[3]), ngrid[3]))
 
-# Same reduction for coordinates that are already integers on `ngrid` — the `b` lists
-# `combine_kpoint_grids` builds are in that form.
-@inline _grid_coords_reduced(b::Vec3{Int}, ngrid) =
-    Vec3(mod(b[1], ngrid[1]), mod(b[2], ngrid[2]), mod(b[3], ngrid[3]))
-
-# Fold `d` into `0:ng-1` given `-ng < d < 2ng`, which the sum or the difference of two coordinates
-# already reduced by `_grid_coords_reduced` always satisfies. Two compares (cmov) instead of a
-# 64-bit integer division; worth naming only because the per-(k, k+q) pair loops of the GPU drivers
-# run it ~1e9 times per run.
-@inline _wrap_reduced(d::Int, ng::Int) = ifelse(d < 0, d + ng, ifelse(d >= ng, d - ng, d))
+# Fold `d` into `0:ng-1` given `-ng < d < 2ng`, which the sum or difference of two already-reduced
+# coordinates satisfies. Two compares instead of a 64-bit division, worth naming because the pair
+# loops run it ~1e9 times. Outside that range one fold does not reach `0:ng-1` and the result then
+# indexes out of bounds, so it is checked — in a `@boundscheck`, so callers that have established
+# the precondition another way (`_check_reduced_coords`) can say `@inbounds` and pay nothing.
+@inline function _wrap_reduced(d::Int, ng::Int)
+    @boundscheck -ng < d < 2ng || throw(ArgumentError(
+        "_wrap_reduced($d, $ng): argument outside (-ng, 2ng), so one fold cannot reduce it into " *
+        "0:ng-1; reduce both operands with _grid_coords_reduced before folding"))
+    ifelse(d < 0, d + ng, ifelse(d >= ng, d - ng, d))
+end
 
 function _hash_xk(xk::Vec3, ngrid, shift)
     c = _grid_coords_reduced(xk, ngrid, shift)

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -319,8 +319,9 @@ end
 
 # Pass 1 of `_combine_kq_dedup_dense`, as a standalone function so the threaded chunks capture
 # typed arguments rather than `Core.Box`. Partitioned over `BqS` (the longer list in the k+q use),
-# each chunk sweeping the whole `BkS` — chunks share `seen` but only ever write the same value into
-# a slot, so no synchronization is needed and the result does not depend on the partition.
+# each chunk sweeping the whole `BkS`. Chunks share `seen` without synchronization: `Bool` is one
+# byte, so a mark is a lone `store i8 1` — no read-modify-write to lose a neighbour's byte, and
+# same-slot writers store the same value. (A `BitArray` would be a word RMW, hence unsafe.)
 function _mark_kq_pairs!(seen::Array{Bool,3}, BkS::Vector{Vec3{Int}}, BqS::Vector{Vec3{Int}},
                          sgn::Int, ng1::Int, ng2::Int, ng3::Int)
     @threads for iq in eachindex(BqS)

--- a/src/common/kpoints.jl
+++ b/src/common/kpoints.jl
@@ -1,6 +1,7 @@
 # Data and functions for k points
 using MPI
 using Printf
+using Base.Threads: @threads
 
 export Kpoints
 export kpoints_grid
@@ -267,54 +268,96 @@ end
 """
     _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
 De-duplicate `k + sgn * q` over all (k, q) pairs with a dense `prod(ngrid_kq)` table indexed by the
-integer grid coordinates. Returns the unique k+q points in order of first appearance.
+integer grid coordinates. Returns the unique k+q points, in grid order.
 - `BkS`, `BqS`: integer grid coordinates of the k and of the q points on the common `ngrid_kq`
-    grid, i.e. the `b` of `xk = shift + b ./ ngrid_kq`. Built by `combine_kpoint_grids`.
+    grid, i.e. the `b` of `xk = shift + b ./ ngrid_kq`, each already reduced into `0:ng-1` by
+    `combine_kpoint_grids` so that `bk + sgn*bq` needs only `_wrap_reduced`.
 
 The table is `(ng3, ng2, ng1)` indexed `[c3+1, c2+1, c1+1]`, making `c3` the unit-stride index so
 that a sweep over consecutive `c3` walks the table sequentially. With those dims the linear index
 of a slot is exactly `hash + 1` for the `(c1*ng2 + c2)*ng3 + c3` packing, so this table and
 `GridKpoints._dense_hash_to_ik` share one layout.
+
+Two passes rather than one. Pass 1 only MARKS which slots occur, in a `Vector{UInt8}` instead of
+the `Array{Int,3}` of indices the single-pass version needed: the pair loop's access into the table
+is a random probe, so at 8 B per node it missed cache on nearly every pair, and 1 B per node is 8×
+more of the grid resident (8 MB vs 64 MB at 200³). Marking is also idempotent — every writer stores
+the same 1 — which is what lets the pass be threaded with no synchronization. (A `BitArray` would
+be smaller still but its writes race at word granularity.)
+Pass 2 sweeps the table in index order and emits the points. That discards first-appearance order,
+which is safe because `combine_kpoint_grids` sorts the result on the integer grid coordinates — a
+total order, the points being distinct — and `sort!(::GridKpoints)` renumbers the index afterwards.
 """
 function _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) where {T}
     ng1, ng2, ng3 = ngrid_kq
-    xkqs = Vector{Vec3{T}}()
-    xkq_hash_to_ikq = zeros(Int, ng3, ng2, ng1)
-    ikq = 0
-    for bq in BqS
-        for bk in BkS
-            c1 = mod(bk[1] + sgn * bq[1], ng1)
-            c2 = mod(bk[2] + sgn * bq[2], ng2)
-            c3 = mod(bk[3] + sgn * bq[3], ng3)
+    _check_reduced_coords(BkS, BqS, ngrid_kq)
+    seen = zeros(UInt8, ng3, ng2, ng1)
+    _mark_kq_pairs!(seen, BkS, BqS, sgn, ng1, ng2, ng3)
 
-            # Find new k+q points, append to xkq_hash_to_ikq and xkqs
-            if xkq_hash_to_ikq[c3 + 1, c2 + 1, c1 + 1] == 0
-                ikq += 1
-                xkq_hash_to_ikq[c3 + 1, c2 + 1, c1 + 1] = ikq
-                push!(xkqs, Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq)
+    xkqs = Vector{Vec3{T}}(undef, count(!iszero, seen))
+    ikq = 0
+    @inbounds for c1 in 0:(ng1 - 1), c2 in 0:(ng2 - 1), c3 in 0:(ng3 - 1)
+        iszero(seen[c3 + 1, c2 + 1, c1 + 1]) && continue
+        ikq += 1
+        xkqs[ikq] = Vec3(c1 / ng1, c2 / ng2, c3 / ng3) + shift_kq
+    end
+    xkqs
+end
+
+# The `0:ng-1` precondition of the two de-duplication routines, enforced once over the two lists
+# (O(nk + nkq), microseconds) rather than per pair. Not optional politeness: the pair loops fold
+# with `_wrap_reduced` and write the table under `@inbounds`, so an unreduced coordinate is a
+# segfault rather than a wrong answer.
+function _check_reduced_coords(BkS, BqS, ngrid)
+    for (name, B) in (("BkS", BkS), ("BqS", BqS)), b in B
+        all(0 .<= b.data .< ngrid) || throw(ArgumentError(
+            "$name entry $b is not reduced into 0:ngrid-1 for ngrid = $ngrid; " *
+            "call _grid_coords_reduced on the integer grid coordinates first"))
+    end
+end
+
+# Pass 1 of `_combine_kq_dedup_dense`, as a standalone function so the threaded chunks capture
+# typed arguments rather than `Core.Box`. Partitioned over `BqS` (the longer list in the k+q use),
+# each chunk sweeping the whole `BkS` — chunks share `seen` but only ever write the same value into
+# a slot, so no synchronization is needed and the result does not depend on the partition.
+function _mark_kq_pairs!(seen::Array{UInt8,3}, BkS::Vector{Vec3{Int}}, BqS::Vector{Vec3{Int}},
+                         sgn::Int, ng1::Int, ng2::Int, ng3::Int)
+    @threads for iq in eachindex(BqS)
+        @inbounds begin
+            bq = BqS[iq]
+            q1, q2, q3 = sgn * bq[1], sgn * bq[2], sgn * bq[3]
+            for bk in BkS
+                c1 = _wrap_reduced(bk[1] + q1, ng1)
+                c2 = _wrap_reduced(bk[2] + q2, ng2)
+                c3 = _wrap_reduced(bk[3] + q3, ng3)
+                seen[c3 + 1, c2 + 1, c1 + 1] = 0x01
             end
         end
     end
-    xkqs
+    seen
 end
 
 """
     _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)
 Same map as `_combine_kq_dedup_dense`, keyed by the packed hash in a `Dict` so the memory is
 O(number of unique points) instead of O(prod(ngrid_kq)). Used when the dense table would exceed the
-transient memory budget in `combine_kpoint_grids`.
+transient memory budget in `combine_kpoint_grids`. Same reduced-coordinate precondition, and it
+returns the points in order of FIRST APPEARANCE (a `Dict` has no order to sweep), where the dense
+path returns them in grid order — `combine_kpoint_grids` sorts either, so the two agree as sets.
 """
 function _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq::Vec3{T}) where {T}
     ng1, ng2, ng3 = ngrid_kq
+    _check_reduced_coords(BkS, BqS, ngrid_kq)
     xkqs = Vector{Vec3{T}}()
     cs = Vector{NTuple{3,Int}}()  # integer coords per stored point, for the collision guard
     xkq_hash_to_ikq = Dict{Int, Int}()
     ikq = 0
     for bq in BqS
+        q1, q2, q3 = sgn * bq[1], sgn * bq[2], sgn * bq[3]
         for bk in BkS
-            c1 = mod(bk[1] + sgn * bq[1], ng1)
-            c2 = mod(bk[2] + sgn * bq[2], ng2)
-            c3 = mod(bk[3] + sgn * bq[3], ng3)
+            c1 = _wrap_reduced(bk[1] + q1, ng1)
+            c2 = _wrap_reduced(bk[2] + q2, ng2)
+            c3 = _wrap_reduced(bk[3] + q3, ng3)
             xk_hash_value = (c1 * ng2 + c2) * ng3 + c3
 
             # Find new k+q points, append to xkq_hash_to_ikq and xkqs
@@ -373,10 +416,14 @@ function combine_kpoint_grids(kpts, qpts, op, ngrid_kq)
     # point uniquely, so it is also the de-duplication key: the Dict path packs it as
     # `(c1*ng2 + c2)*ng3 + c3` (which happens to equal `_hash_xk(xkq)`), the dense path indexes an
     # array by it directly.
+    # Both lists are reduced into `0:ng-1` here, once per point, so that the O(nk·nkq) fold is
+    # `_wrap_reduced` (a compare-and-add) rather than three runtime 64-bit integer divisions.
     fk = ngrid_kq .÷ kpts.ngrid
     fq = ngrid_kq .÷ qpts.ngrid
-    BkS = [Vec3(round.(Int, (xk - shift_k).data .* kpts.ngrid) .* fk) for xk in kpts.vectors]
-    BqS = [Vec3(round.(Int, (xq - shift_q).data .* qpts.ngrid) .* fq) for xq in qpts.vectors]
+    BkS = [_grid_coords_reduced(Vec3(round.(Int, (xk - shift_k).data .* kpts.ngrid) .* fk), ngrid_kq)
+           for xk in kpts.vectors]
+    BqS = [_grid_coords_reduced(Vec3(round.(Int, (xq - shift_q).data .* qpts.ngrid) .* fq), ngrid_kq)
+           for xq in qpts.vectors]
 
     # Dense lookup table while it fits in the transient budget, Dict above it. The budget is loose
     # because the table lives only until this function returns. `Int128` because `prod(ngrid_kq)`

--- a/test/test_iq_build.jl
+++ b/test/test_iq_build.jl
@@ -76,11 +76,11 @@ end
                 @test _wrap_reduced(mod(a, ng) + mod(b, ng), ng) == mod(a + b, ng)
             end
         end
-        # And the array-level reduction it relies on.
-        for ng in ((3, 4, 5), (150, 150, 150))
-            b = Vec3(rand(-1000:1000, 3))
-            @test _grid_coords_reduced(b, ng) == Vec3(mod.(b.data, ng))
-        end
+        # Outside (-ng, 2ng) one fold cannot reduce into 0:ng-1, so the precondition is checked
+        # (and the pair loops elide the check with `@inbounds` once they have established it).
+        @test_throws ArgumentError _wrap_reduced(-8, 4)
+        @test_throws ArgumentError _wrap_reduced(8, 4)
+        @test _wrap_reduced(-3, 4) == 1 && _wrap_reduced(7, 4) == 3
     end
 
     @testset "partial final tile and strip" begin

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -313,6 +313,26 @@ end
     test_combine(kpts, qpts, +, (4, 4, 4))
     test_combine(kpts, qpts, -, (4, 4, 4))
 
+    # Non-cubic ngrid, so a transposed table layout or a coordinate swap cannot pass by accident.
+    kpts = GridKpoints(kpoints_grid((3, 4, 5)))
+    qpts = GridKpoints(kpoints_grid((3, 4, 5)))
+    test_combine(kpts, qpts, +, (3, 4, 5))
+    test_combine(kpts, qpts, -, (3, 4, 5))
+
+    # Grids of different density in each direction, combined on the finer common grid.
+    kpts = GridKpoints(kpoints_grid((2, 4, 6)))
+    qpts = GridKpoints(kpoints_grid((1, 2, 3)))
+    test_combine(kpts, qpts, +, (2, 4, 6))
+    test_combine(kpts, qpts, -, (2, 4, 6))
+
+    # Subsets of a grid (what a windowed driver run actually passes), on a non-cubic grid.
+    let g = kpoints_grid((4, 5, 6))
+        Random.seed!(2026)
+        sel = sort(randperm(g.n)[1:(g.n ÷ 3)])
+        sub = GridKpoints(Kpoints(length(sel), g.vectors[sel], g.weights[sel], g.ngrid), g.ngrid)
+        test_combine(sub, GridKpoints(g), -, (4, 5, 6))
+    end
+
     # Shifted q grid, and plain Kpoints input (converted to GridKpoints internally).
     shift = (0, 1//2, 1//2) ./ 3
     kpts = kpoints_grid((3, 3, 3))            # plain Kpoints, no shift
@@ -334,20 +354,34 @@ end
     @test combine_kpoint_grids(kpts, qpts, +, (6, 6, 6)) isa GridKpoints       # divisible by both
 
     # The dense and the Dict de-duplication (selected by the size of the dense table) must return
-    # the same points in the same order. Only the dense one is reachable at these grid sizes, so
-    # call both directly on the same integer grid coordinates.
-    using ElectronPhonon: _combine_kq_dedup_dense, _combine_kq_dedup_dict
+    # the same SET of points: the dense path sweeps its table, so it emits them in grid order, while
+    # the Dict path has no table to sweep and emits them in order of first appearance.
+    # `combine_kpoint_grids` sorts the result either way. Only the dense one is reachable at these
+    # grid sizes, so call both directly on the same integer grid coordinates.
+    using ElectronPhonon: _combine_kq_dedup_dense, _combine_kq_dedup_dict, _grid_coords_reduced
     Random.seed!(333)
     ngrid_kq = (4, 6, 5)
     for sgn in (1, -1)
         # Coordinates repeat across pairs, so both paths must hit their "already seen" branch.
-        BkS = [Vec3(rand(-6:6, 3)) for _ in 1:20]
-        BqS = [Vec3(rand(-6:6, 3)) for _ in 1:20]
+        BkS = [_grid_coords_reduced(Vec3(rand(-6:6, 3)), ngrid_kq) for _ in 1:20]
+        BqS = [_grid_coords_reduced(Vec3(rand(-6:6, 3)), ngrid_kq) for _ in 1:20]
         shift_kq = Vec3(0.0, 1/12, 0.0)
         xkqs_dense = _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
         xkqs_dict = _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)
         @test 0 < length(xkqs_dense) < length(BkS) * length(BqS)  # de-duplication happened
-        @test xkqs_dense == xkqs_dict
+        @test sort(xkqs_dense) == sort(xkqs_dict)
+        @test issorted(xkqs_dense; by = x -> round.(Int, (x - shift_kq).data .* ngrid_kq))
+    end
+
+    # Both paths fold with `_wrap_reduced` and write their table under `@inbounds`, so an unreduced
+    # coordinate would be memory corruption rather than a wrong answer. The precondition is checked
+    # once per list at entry; without that check this call segfaults.
+    let ngrid_kq = (4, 6, 5), shift_kq = Vec3(0.0, 0.0, 0.0)
+        raw = [Vec3(7, -3, 11)]
+        ok = [Vec3(1, 2, 3)]
+        @test_throws ArgumentError _combine_kq_dedup_dense(raw, ok, -1, ngrid_kq, shift_kq)
+        @test_throws ArgumentError _combine_kq_dedup_dense(ok, raw, -1, ngrid_kq, shift_kq)
+        @test_throws ArgumentError _combine_kq_dedup_dict(raw, ok, 1, ngrid_kq, shift_kq)
     end
 
     # Overflow guard: prod(ngrid) must fit in Int (checked in the GridKpoints constructor).

--- a/test/test_kpoints.jl
+++ b/test/test_kpoints.jl
@@ -358,13 +358,14 @@ end
     # the Dict path has no table to sweep and emits them in order of first appearance.
     # `combine_kpoint_grids` sorts the result either way. Only the dense one is reachable at these
     # grid sizes, so call both directly on the same integer grid coordinates.
-    using ElectronPhonon: _combine_kq_dedup_dense, _combine_kq_dedup_dict, _grid_coords_reduced
+    using ElectronPhonon: _combine_kq_dedup_dense, _combine_kq_dedup_dict
     Random.seed!(333)
     ngrid_kq = (4, 6, 5)
     for sgn in (1, -1)
         # Coordinates repeat across pairs, so both paths must hit their "already seen" branch.
-        BkS = [_grid_coords_reduced(Vec3(rand(-6:6, 3)), ngrid_kq) for _ in 1:20]
-        BqS = [_grid_coords_reduced(Vec3(rand(-6:6, 3)), ngrid_kq) for _ in 1:20]
+        # Both routines require their inputs already reduced into 0:ng-1.
+        BkS = [Vec3(mod.(rand(-6:6, 3), ngrid_kq)) for _ in 1:20]
+        BqS = [Vec3(mod.(rand(-6:6, 3), ngrid_kq)) for _ in 1:20]
         shift_kq = Vec3(0.0, 1/12, 0.0)
         xkqs_dense = _combine_kq_dedup_dense(BkS, BqS, sgn, ngrid_kq, shift_kq)
         xkqs_dict = _combine_kq_dedup_dict(BkS, BqS, sgn, ngrid_kq, shift_kq)


### PR DESCRIPTION
Speeds up `combine_kpoint_grids` by **28.5×** at Cu nk=200: **76.86 → 2.69 s**.

Re-baselined on `workergpu053` (A100-SXM4-80GB, Xeon Platinum 8358, 16 threads) with the pre-change implementation and the new one alternating **in one session off a single model load**, so the ratio is not taken across sittings or hosts. Real grids: `kpts.n = 11525`, `kqpts.n = 535998`, 6.18e9 pairs, `qpts.n = 6870740`; the two results compare equal on vectors, weights, `ngrid` and `shift`.

This is CPU-only host work in *setup*, so it benefits non-GPU runs equally. It was found while profiling a GPU BTE run: at nk=200 it was the single largest setup cost, larger than either electron-state filter.

### Base branch

Stacked on `gpubte-opt` (#11), not `main` — the pre-reduction helpers `_grid_coords_reduced` / `_wrap_reduced` are introduced there by the outer-k `iq` build, and this commit reuses them in 12 places. The diff shown here is only the k-point work. Merge #11 first.

### Where the time went

`combine_kpoint_grids` ran nk × nkq = **6.18e9 pairs**, each doing three `mod`s and a random probe into a `prod(ngrid)` table. Measured split before the change (nk=150): pair loop 11.65 s, everything else 0.66 s.

Three levers, all on the pair loop. Per-lever times below are at nk=150 on `workergpu069` (also A100-80GB) — a different sitting from the nk=200 headline, so read the ratios, not the absolutes:

| step | time | ns/pair |
|---|---|---|
| baseline (`Int` table, `mod`) | 11.66 s | 10.47 |
| + pre-reduce coords, fold with `_wrap_reduced` | 4.30 s | 3.87 |
| + mark-then-collect into an `Array{Bool}` | 2.97 s | 2.67 |
| + `@threads` over `BqS` (16 threads) | 0.25 s | 0.22 |

Pre-reducing was the biggest single lever (2.7×) — bigger than the cache-footprint cut (1.45×), which is the reverse of what was expected going in.

- **Pre-reduce** `BkS`/`BqS` into `[0, ngrid)` once per point, so `bk + sgn*bq` lands in `(-ng, 2ng)` and needs only a compare-and-add rather than a runtime 64-bit integer division.
- **Mark-then-collect.** Pass 1 only marks occupied slots, in an `Array{Bool}` (one byte per element) rather than an `Array{Int}` of indices — the probe is random-access, so 8× less table (8 MB vs 64 MB at 200³, against a 48 MB L3) is 8× more of it cache-resident. Pass 2 sweeps in index order and emits the points, which also sizes `xkqs` up front instead of growing it.
- **Thread pass 1.** Legal because marking is idempotent (every writer stores the same `true`, so no synchronization) and because collect order is discarded downstream: `combine_kpoint_grids` sorts on integer grid coordinates — a total order over distinct points — and renumbers the index.

### Correctness

The returned `GridKpoints` is **exactly equal** — vectors, weights, `ngrid`, `shift`, and the populated index — over 275 randomized cases spanning both ops, non-cubic grids, differing input densities, random shifts and random grid subsets. Pass 2 rebuilds each point with the same `Vec3(c1/ng1, c2/ng2, c3/ng3) + shift_kq` expression on the same integers, so no rounding moves.

Verified independently of the author: `test_kpoints.jl` + `test_iq_build.jl` = **21422 tests passing**, and the 28.5× re-measured from scratch against the pre-change implementation on the real grids, as described at the top.

### Review round — `a4a5a07`

- **`fk`/`fq` gone.** `ngrid_kq` is a multiple of both input grids, so `_grid_coords_reduced(xk, ngrid_kq, shift)` reaches the common-grid coordinates in one step. Consequence: it rounds at `ngrid_kq` rather than at the coarser input grid, needing each point on-grid to `0.5/ngrid_kq` instead of `0.5/ngrid` — 13 orders of margin at 1e-16 relative error against `ngrid_kq = 200`. This left `_grid_coords_reduced(::Vec3{Int}, ngrid)` with no caller, so it is deleted.
- **Mark table is `Array{Bool}`**, not `Array{UInt8}` of `0x01`. `Bool` is one byte, so the footprint and the race-free byte stores are identical; `BitArray` is what would race, and the docstring now says so.
- **`@inbounds` audited, and measured rather than assumed.** Kept in `_mark_kq_pairs!` — worth **1.43×** on that pass (1.048 vs 1.498 s), ~17% of the function — with the justification written next to it. Dropped from the pass-2 sweep, where it cost nothing measurable.
- **`_wrap_reduced` now checks its range in a `@boundscheck`.** Outside `(-ng, 2ng)` it silently returned an out-of-range value, which under `@inbounds` is a segfault rather than a wrong answer. The `Dict` path and any future caller get the check; the hot loops elide it on the strength of `_check_reduced_coords`.

### Sharp edge worth reviewing

The precondition behind the kept `@inbounds` is what makes it safe, so it is worth checking that layering directly: `_check_reduced_coords` runs once per list at entry (O(nk+nkq), unmeasurable) and establishes `0 <= b < ng` for every entry; `_wrap_reduced` then cannot leave `0:ng-1`. It is not theoretical — the pre-existing `test_kpoints.jl` dedup test passed raw `rand(-6:6,3)` coordinates and killed the Julia process before the guard existed. Reviewers should satisfy themselves that no caller can reach the folds without passing that guard.

### Known behaviour change

The `Dict` fallback gets the pre-reduction only — its insert cannot be threaded and it has no table to sweep — so it now returns **first-appearance order** where the dense path returns **grid order**. The two still agree as sets, which is what the caller's `sort!` needs, and the test asserts set equality rather than order for that path.

### Follow-up, not in this PR

The trailing `sort!` now dominates: at nk=200 the split is coords / pair loop / `GridKpoints`+`shift_center!`+`sort!` ≈ 0.09 / 1.14 / 1.76 s. That is where any further work on this function goes.

