### PR TITLE
Split use_gpu into backend + batched, and make the batched e-ph loop runnable on CPUBackend

### DIFF
--- a/README_GPU.md
+++ b/README_GPU.md
@@ -158,9 +158,13 @@ to a `mul!` loop, and `plan_batch` returns the requested cap verbatim (`free_byt
 `typemax(Int)`, so pass a small `nq_batch_max`) — but it is what lets the batched path, the tiling
 brackets and the calculators' batched hooks be tested with no CUDA present. It does **not** cover the
 CUDA kernels (`_bte_window_accumulate_kernel!`, `_window_scatter_kernel!`, the fused rotation kernel,
-`CUBLAS.gemm_strided_batched!`, the cuSOLVER batched eigensolve): those still need the GPU box. The CPU loop and per-(k,q) CPU e-ph functions are unchanged. The GPU
-outer-k loop processes a batch of outer k with one list-batched `get_eph_RR_to_kR_batched!` and
-batches the inner `ikq` loop (in tiles of `nq_batch_max`) through one `get_eph_kR_to_kq_batched!`.
+`CUBLAS.gemm_strided_batched!`, the cuSOLVER batched eigensolve): those still need the GPU box.
+
+The per-point loop and the per-(k,q) host e-ph functions are unchanged. The batched outer-k loop
+processes a batch of outer k with one list-batched `get_eph_RR_to_kR_batched!` and batches the inner
+`ikq` loop (in tiles of `nq_batch_max`) through one `get_eph_kR_to_kq_batched!`. Note the two caps
+tile different axes: `nq_batch_max` the inner per-q staging, `nk_outer_batch_max` the outer-k axis
+that a calculator's `TiledDeviceOutput` output tile follows.
 
 Its nesting is `k-batch -> q-tile -> k -> q(device)`: the q-tile loop sits **outside** the per-k
 loop. `get_eph_RR_to_kR_batched!` stores the kR intermediate in the **k+q convention**

--- a/README_GPU.md
+++ b/README_GPU.md
@@ -14,7 +14,7 @@ On the GPU:
 - Batched band eigenvalues/eigenvectors — `src/wannier_to_bloch_batched.jl`.
 - e-ph interpolation `get_eph_RR_to_kR!` / `get_eph_kR_to_kq!` (per-k/q and list-batched
   forms) — `src/wannier_to_bloch_batched.jl`.
-- The e-ph calculator loop `run_eph_over_k_and_kq` via a `use_gpu` branch, including a
+- The e-ph calculator loop `run_eph_over_k_and_kq` via a `batched` branch, including a
   device-native calculator hook.
 
 Deliberately **not** on the GPU (stays on the CPU per-k path):
@@ -141,11 +141,24 @@ ctx::LoopContext)` has one method per payload type. The full spec is in the docs
 `src/calculator/AbstractCalculator.jl`, and `docs/writing_a_calculator.md` is the tutorial (start
 there for a CPU-only calculator). This section covers only the GPU side.
 
-`run_eph_over_k_and_kq` / `run_eph_over_q_and_k` take a `use_gpu` keyword (with `nq_batch_max` /
-`nk_outer_batch_max` for outer-k, `nk_batch_max` for outer-q) that branches to a backend-generic
-device loop. `use_gpu` is the only user-facing switch; below the driver entry a `backend` object
-(`CPUBackend()` / `GPUBackend(proto)`) is resolved once, uploaded `to_device(model.epmat)` once,
-and carried in `LoopContext`. The CPU loop and per-(k,q) CPU e-ph functions are unchanged. The GPU
+`run_eph_over_k_and_kq` / `run_eph_over_q_and_k` take two orthogonal keywords (plus `nq_batch_max` /
+`nk_outer_batch_max` for outer-k, `nk_batch_max` for outer-q):
+
+- `backend :: AbstractBackend = CPUBackend()` — where arrays live. Pass
+  `backend = ElectronPhonon.gpu_backend()` for a GPU run; it is uploaded `to_device(model.epmat)`
+  once and carried in `LoopContext` as `ctx.backend`.
+- `batched :: Union{Nothing, Bool} = nothing` — which payload/loop shape runs, carried as `ctx.mode`.
+  `nothing` derives it from the backend, so a **production GPU run passes `backend` alone** and a
+  production CPU run passes neither. An explicit `batched = false` on a GPU backend is an
+  `ArgumentError`.
+
+Because the batched loop holds no device-specific code, `batched = true` on a `CPUBackend` runs it on
+host arrays. That is a **validation configuration only** — serial k-batches, `batched_gemm!` degrades
+to a `mul!` loop, and `plan_batch` returns the requested cap verbatim (`free_bytes(::CPUBackend)` is
+`typemax(Int)`, so pass a small `nq_batch_max`) — but it is what lets the batched path, the tiling
+brackets and the calculators' batched hooks be tested with no CUDA present. It does **not** cover the
+CUDA kernels (`_bte_window_accumulate_kernel!`, `_window_scatter_kernel!`, the fused rotation kernel,
+`CUBLAS.gemm_strided_batched!`, the cuSOLVER batched eigensolve): those still need the GPU box. The CPU loop and per-(k,q) CPU e-ph functions are unchanged. The GPU
 outer-k loop processes a batch of outer k with one list-batched `get_eph_RR_to_kR_batched!` and
 batches the inner `ikq` loop (in tiles of `nq_batch_max`) through one `get_eph_kR_to_kq_batched!`.
 
@@ -243,11 +256,13 @@ unchanged). No window handling is needed in the calculator beyond addressing its
   correctness component, so benchmark it on its own before adopting.
 - **Energy window and long-range/polar on the GPU** — left on the CPU per-k path for now.
 - **MPI / multi-GPU** for the GPU loop — not in this foundation.
-- **Backend as a type parameter instead of a `use_gpu` keyword (future).** The backend is
-  currently selected by the `use_gpu` keyword + `to_device`. A cleaner long-term design might
-  carry it as a type (e.g. dispatch the loop on the array backend). Note a `ModelGPU` that puts
-  the whole `Model` on the device is *not* obviously right: `Model` is large, and one may want
-  it resident on the CPU while only the calculation runs on the GPU.
+- **Backend as a type parameter instead of a backend object (future).** The `use_gpu` keyword is
+  gone: the backend is now the user-facing `backend::AbstractBackend` argument, and the loop shape
+  is the separate `batched` keyword. Renaming `GPUBackend(proto)` to a DFTK-style `GPU{AT}` was
+  considered and **decided against**: `similar(proto, ...)` propagates CUDA.jl 6's memory-type
+  parameter where a bare type constructor would not, and nothing dispatches on `AT`. Note a
+  `ModelGPU` that puts the whole `Model` on the device is *not* obviously right either: `Model` is
+  large, and one may want it resident on the CPU while only the calculation runs on the GPU.
 - **Keep `el_kq_save` (k+q electron states) on the device (future).** The GPU loop already hoists
   every k+q eigenvector onto the device once (`ukqs_all_dev`); keeping the `el_kq_save` states
   themselves device-resident would avoid the host staging entirely, but needs a states refactor.
@@ -288,9 +303,9 @@ unchanged). No window handling is needed in the calculator beyond addressing its
 - `ext/ElectronPhononCUDAExt.jl` — `to_device(::WannierObject)`, `eigvals_batched`/
   `eigen_batched` (`heevjBatched!`), `batched_gemm!` (`gemm_strided_batched!`), and the fused
   rotation / window-scatter kernels.
-- `src/calculator/run_eph_over_k_and_kq.jl` — `use_gpu` / `nq_batch_max` / `nk_outer_batch_max`
-  keywords; backend-generic `_loop_eph_over_k_and_kq_gpu` and the device-native calculator payload.
-  CPU path unchanged.
+- `src/calculator/run_eph_over_k_and_kq.jl` — `backend` / `batched` / `nq_batch_max` / `nk_outer_batch_max`
+  keywords; backend-generic `_loop_eph_over_k_and_kq_batched` and the batched calculator payload.
+  Per-point path unchanged.
 - `benchmark/bench_el_eigen_gpu.jl`, `benchmark/bench_eph_gpu.jl`,
   `benchmark/bench_eliashberg_loop_gpu.jl` — CPU-vs-GPU benchmarks.
 - `test/test_gpu.jl` — GPU-guarded tests (skip when CUDA is unavailable or the Pb data dir is

--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,7 @@
   `tile_offset` / `tile_length`, used by `BoltzmannCalculator`'s batched path).
 
 - [ ] Unify the CPU/GPU e-ph loop signatures (`_loop_eph_over_k_and_kq` vs
-  `_loop_eph_over_k_and_kq_gpu`, `src/calculator/run_eph_over_k_and_kq.jl`). Decided direction (JML,
+  `_loop_eph_over_k_and_kq_batched`, `src/calculator/run_eph_over_k_and_kq.jl`). Decided direction (JML,
   PR #9): keep **two functions with different names**, but give them the **identical positional
   argument list** and push the path-specific data into **keyword arguments** — CPU kwargs
   `(epstates, ep_ekpRs, epmat, ep_ekpR_obj, dyn_threads, epmat_R, epobj_ekpR_R, ep_ekpR_Rs)`, GPU
@@ -31,17 +31,22 @@
   destructure any NamedTuple into locals at the top before `@threads`, never index it inside the
   threaded closure.
 
-- [ ] Reconsider whether `backend` should be built inside `_loop_eph_over_k_and_kq_gpu` rather than in
-  `_setup_eph_over_k_and_kq`. It currently lives in `_setup` because `_setup_calculators!` runs there
-  and passes `backend` into `setup_calculator!`, and because `backend` wraps the once-uploaded
-  `epmat_dev.op_r` as its allocation prototype (the loop reuses that device object). Moving it into
-  the loop would re-plumb where `setup_calculator!` gets its backend.
+- [x] ~~Reconsider whether `backend` should be built inside `_loop_eph_over_k_and_kq_batched` rather
+  than in `_setup_eph_over_k_and_kq`.~~ Subsumed: `backend` is now a user-facing driver keyword, so it
+  is built by the caller and nothing inside the package resolves it. (The item's stated rationale was
+  also wrong: `gpu_backend()` builds an EMPTY prototype, `GPUBackend(CuArray{ComplexF64}(undef, 0))`
+  — it never wrapped `epmat_dev.op_r`.)
 
-- [ ] Clean up `calculator_begin!` for `BoltzmannCalculator`: `tile_begin!` (the batched
-  `OuterIterationBatch` bracket) is not needed on the CPU path, so limit its context — restrict the
-  batched begin/end brackets to the GPU path rather than defining CPU no-ops.
+- [x] ~~Clean up `calculator_begin!` for `BoltzmannCalculator`~~ — done, but not as written. There
+  were no CPU no-op brackets to restrict: the `OuterIterationBatch` brackets were already correctly
+  keyed on the loop MODE (`LoopContext{<:AbstractBackend, BatchedMode}`) and are backend-agnostic,
+  which is exactly right now that batched-on-`CPUBackend` is a supported configuration. The real
+  defect was the flag: `calc.on_gpu = backend isa GPUBackend` inferred the loop shape from the
+  backend, which builds the wrong buffers under CPU+batched. It is now `calc.batched = mode isa
+  BatchedMode`, from the `mode::LoopMode` keyword the drivers pass to `setup_calculator!`.
 
-- [ ] Clean up the `LoopContext` construction at the batch/per-k scope
+- [ ] Clean up the `LoopContext` construction at the batch/per-k scope (deferred out of the
+  `backend`/`batched` PR as an independent follow-up)
   (`src/calculator/run_eph_over_k_and_kq.jl` ~L713/L728). The batch-scope `ctx_batch` and per-k
   `ctx_k` are built from positional constructors that are disambiguated by whether the argument is an
   `Integer` outer index (`ik`) or a `UnitRange` batch (`iks_batch`) — flagged as flaky in review.

--- a/benchmark/bench_bte_gpu.jl
+++ b/benchmark/bench_bte_gpu.jl
@@ -5,7 +5,7 @@
 # `bte_scattering_increments` core, so CPU and GPU compute the same scattering (to round-off).
 #
 #   CPU : fourier_mode="gridopt", capped to 12 threads (nchunks_threads=12)
-#   GPU : use_gpu=true, device-native batched calculator + device-resident Sₒ/Sᵢ scatter
+#   GPU : backend=EP.gpu_backend(), device-native batched calculator + device-resident Sₒ/Sᵢ scatter
 #
 # Methodology (see GPU_PROGRESS.md): benchmark with a realistic *energy window* around E_F
 # (production transport uses an fsthick window). For large grids (a run > ~60 s) warm up on a
@@ -61,7 +61,7 @@ run_cpu(g, win) = (c = newcalc(); EP.run_eph_over_k_and_kq(model, (g,g,g), (g,g,
 
 run_gpu(g, win) = (c = newcalc(); EP.run_eph_over_k_and_kq(model, (g,g,g), (g,g,g); calculators=[c],
     symmetry=nothing, window_k=win, window_kq=win,
-    use_gpu=true, progress_print_step=10^9); c)
+    backend=EP.gpu_backend(), progress_print_step=10^9); c)
 
 # Max relative error of the SERTA scattering-out Sₒ (γ_{nk}) between two runs.
 function relerr_So(cc, cg)

--- a/benchmark/bench_eliashberg_loop_gpu.jl
+++ b/benchmark/bench_eliashberg_loop_gpu.jl
@@ -3,7 +3,7 @@
 # work targets — it exercises RR->kR, kR->kq, and the device-native g2 scatter / host-streaming.
 #
 #   CPU : fourier_mode="gridopt", capped to 12 threads (nchunks_threads=12)
-#   GPU : use_gpu=true, device-native batched calculator + host-streamed g2
+#   GPU : backend=EP.gpu_backend(), device-native batched calculator + host-streamed g2
 #
 # Methodology (see GPU_PROGRESS.md): benchmark with a realistic *energy window* around E_F
 # (production runs use an fsthick window). For large grids (a run > ~60 s) warm up on a coarse
@@ -52,7 +52,7 @@ run_cpu(g, win) = (c = newcalc(); EP.run_eph_over_k_and_kq(model, (g,g,g), (g,g,
 
 run_gpu(g, win) = (c = newcalc(); EP.run_eph_over_k_and_kq(model, (g,g,g), (g,g,g); calculators=[c],
     symmetry=nothing, window_k=win, window_kq=win,
-    use_gpu=true, progress_print_step=10^9); c)
+    backend=EP.gpu_backend(), progress_print_step=10^9); c)
 
 function main()
     # Warm up compilation on a coarse 4^3 grid. Use full band (-Inf,Inf) so the coarse grid is

--- a/docs/writing_a_calculator.md
+++ b/docs/writing_a_calculator.md
@@ -14,7 +14,8 @@ rot.
 
 A calculator must implement:
 
-- `setup_calculator!(calc, kpts, qpts, el_states; kwargs...)` — run once, before the loop.
+- `setup_calculator!(calc, backend, mode, kpts, qpts, el_states; kwargs...)` — run once, before the
+  loop. `backend` and `mode` are positional; see "What `setup_calculator!` receives" below.
 - `run_calculator!(calc, payload, ctx)` — one method per payload *type* the calculator consumes.
   The host per-(k,q) payload is `EPData`; the batched payloads (`EPDataQBatched` / `EPDataKBatched`)
   are for the batched path — normally a GPU run (see "Migrating to the GPU" below).
@@ -57,7 +58,7 @@ ElectronPhonon.supports(::EphG2SumCalculator, ::Type{EPData}) = true
 
 # Run once before the loop. `nchunks_threads` is the number of thread chunks the inner loop uses;
 # allocate one partial-sum slot per chunk so concurrent calls never touch the same slot.
-function ElectronPhonon.setup_calculator!(c::EphG2SumCalculator, kpts, qpts, el_states;
+function ElectronPhonon.setup_calculator!(c::EphG2SumCalculator, backend, mode, kpts, qpts, el_states;
         nchunks_threads, kwargs...)
     c.per_k = zeros(kpts.n)
     c.chunk = zeros(nchunks_threads)
@@ -124,22 +125,33 @@ rather than trivial — if you need many tiny operations, batch them inside the 
 
 ## What `setup_calculator!` receives
 
-`setup_calculator!(calc, kpts, qpts, el_states; kwargs...)` is called with the outer k-points
-`kpts`, the q-points `qpts` (may be `nothing` when phonons are computed on the fly), the electron
-states at k `el_states`, and these keyword arguments (splat the rest with `kwargs...`):
+`setup_calculator!(calc, backend, mode, kpts, qpts, el_states; kwargs...)` is called with the run's
+`backend::AbstractBackend` and loop-shape `mode::LoopMode` (both POSITIONAL, so they can be dispatched
+on and cannot be silently absorbed by `kwargs...`), then the outer k-points `kpts`, the q-points `qpts`
+(may be `nothing` when phonons are computed on the fly), the electron states at k `el_states`, and
+these keyword arguments (splat the rest with `kwargs...`):
 
 - `nw`, `nmodes` — number of Wannier bands / phonon modes.
 - `rng_band` — the in-window band range at k.
 - `el_states_kq`, `kqpts` — electron states / k-points at k+q (may be `nothing`).
 - `nelec_below_window_k`, `nelec_below_window_kq` — carrier counts below the window.
 - `nchunks_threads` — number of inner-loop thread chunks (size per-chunk buffers to this).
-- `verbosity`, `backend` — printing verbosity and the compute backend (`CPUBackend()` /
-  `GPUBackend(proto)`). A CPU-only calculator ignores `backend`.
+- `verbosity` — printing verbosity.
+
+The two positional arguments:
+
+- `backend :: AbstractBackend` — the compute backend (`CPUBackend()` / `GPUBackend(proto)`), i.e. where
+  arrays live. A CPU-only calculator ignores it.
 - `mode :: LoopMode` — the loop SHAPE this run will use: `SingleMode()` (the driver will hand you
-  per-(k,q) `EPData`) or `BatchedMode()` (it will hand you a batched payload). This is what to branch
-  on when deciding which buffers to build, NOT `backend`: the two axes are independent, and
+  per-(k,q) `EPData`) or `BatchedMode()` (it will hand you a batched payload). This is what to dispatch
+  or branch on when deciding which buffers to build, NOT `backend`: the two axes are independent, and
   batched-on-`CPUBackend` is a supported validation configuration. A per-point-only calculator ignores
-  it.
+  it. Being positional, both can be dispatched on:
+  `setup_calculator!(c::MyCalc, backend, ::BatchedMode, kpts, qpts, el_states; kwargs...)`.
+
+Leaving them untyped (`backend, mode`) is fine and is the normal spelling — the erroring
+`AbstractCalculator` fallback deliberately leaves them untyped too, so your method wins on the
+calculator type without needing annotations.
 
 If your calculator only reads eigenvalues/eigenvectors of the outer-k states (not velocity or
 position), override `required_el_k_quantities(calc) = ["eigenvalue", "eigenvector"]` so the outer-q
@@ -165,13 +177,13 @@ To add a GPU path to an existing CPU calculator:
    `p.ωqs`, batch indices …). Write it backend-generically — only `alloc(ctx.backend, T, dims...)`,
    `similar`, `copyto!`, broadcasting, `mul!`, and scatter-assignment — so the same method runs on
    CPU arrays and `CuArray`s and adds no CUDA dependency of its own.
-3. Manage device buffers. `setup_calculator!` is passed both the run's `backend` and its `mode`, so
-   build whole-run device buffers (index maps, band energies, weights — anything intrinsic to the
-   state sets) there with `alloc(backend, …)` / `to_device(backend, …)`, gated on
-   `mode isa BatchedMode`. Do **not** gate on `backend isa GPUBackend`: that builds the wrong buffers
-   under the CPU+batched validation configuration (the bug this guide used to recommend). The alloc
-   helpers are backend-generic, so on a `CPUBackend` they yield host arrays and the same code path
-   works. Use the brackets only for per-iteration state, and mind **which brackets the loop you are
+3. Manage device buffers. `setup_calculator!` receives the run's `backend` and `mode` as its first two
+   arguments, so build whole-run device buffers (index maps, band energies, weights — anything
+   intrinsic to the state sets) there with `alloc(backend, …)` / `to_device(backend, …)`, dispatched or
+   gated on `mode isa BatchedMode`. Do **not** key on `backend isa GPUBackend`: that builds the wrong
+   buffers under the CPU+batched validation configuration (the bug this guide used to recommend). The
+   alloc helpers are backend-generic, so on a `CPUBackend` they yield host arrays and the same code
+   path works. Use the brackets only for per-iteration state, and mind **which brackets the loop you are
    targeting actually fires**:
 
    | loop | brackets fired |
@@ -228,8 +240,8 @@ Band energies, integration weights, and state-index maps are intrinsic to the st
 one loop iteration, so build them once in `setup_calculator!` from the `backend` it is handed (they
 would otherwise pollute `LoopContext`, which describes only the current iteration). Upload arrays
 with `to_device(backend, host_array)` and build the device state-index map with
-`_indmap_to_device(backend, states, nw)`. Gate this on the **loop shape**, not the backend:
-`setup_calculator!` also receives a `mode::LoopMode` keyword, so build these buffers when
+`_indmap_to_device(backend, states, nw)`. Key this on the **loop shape**, not the backend:
+`setup_calculator!` also receives `mode::LoopMode` positionally, so build these buffers when
 `mode isa BatchedMode` (the per-point path uses the `EPData` method and needs no such buffers). Do
 not test `backend isa GPUBackend` — that would build the wrong buffers under the CPU+batched
 validation configuration. All three helpers are backend-generic, so on a `CPUBackend` they simply

--- a/docs/writing_a_calculator.md
+++ b/docs/writing_a_calculator.md
@@ -16,8 +16,8 @@ A calculator must implement:
 
 - `setup_calculator!(calc, kpts, qpts, el_states; kwargs...)` — run once, before the loop.
 - `run_calculator!(calc, payload, ctx)` — one method per payload *type* the calculator consumes.
-  The host per-(k,q) payload is `EPData`; the device-batched payloads (`EPDataQBatched`
-  / `EPDataKBatched`) are only for the GPU path (see "Migrating to the GPU" below).
+  The host per-(k,q) payload is `EPData`; the batched payloads (`EPDataQBatched` / `EPDataKBatched`)
+  are for the batched path — normally a GPU run (see "Migrating to the GPU" below).
 - `postprocess_calculator!(calc; kwargs...)` — run once, after the loop.
 - `supports(calc, ::Type{T})` — declare the driver loop shapes (`OuterKLoop` / `OuterQLoop`) and
   the payload types the calculator handles. The default is `false`; the second argument must be a
@@ -135,6 +135,11 @@ states at k `el_states`, and these keyword arguments (splat the rest with `kwarg
 - `nchunks_threads` — number of inner-loop thread chunks (size per-chunk buffers to this).
 - `verbosity`, `backend` — printing verbosity and the compute backend (`CPUBackend()` /
   `GPUBackend(proto)`). A CPU-only calculator ignores `backend`.
+- `mode :: LoopMode` — the loop SHAPE this run will use: `SingleMode()` (the driver will hand you
+  per-(k,q) `EPData`) or `BatchedMode()` (it will hand you a batched payload). This is what to branch
+  on when deciding which buffers to build, NOT `backend`: the two axes are independent, and
+  batched-on-`CPUBackend` is a supported validation configuration. A per-point-only calculator ignores
+  it.
 
 If your calculator only reads eigenvalues/eigenvectors of the outer-k states (not velocity or
 position), override `required_el_k_quantities(calc) = ["eigenvalue", "eigenvector"]` so the outer-q
@@ -142,11 +147,14 @@ driver skips the velocity/position interpolation (the default is the full list).
 
 ## Migrating a calculator to the GPU
 
-The GPU path is an explicit opt-in with no silent fallback: `run_eph_over_k_and_kq(...;
-use_gpu=true)` (or `run_eph_over_q_and_k(...; use_gpu=true)`) requires **every** calculator to
-support the corresponding device-batched payload, and a calculator that does not opt in errors
-loudly. `use_gpu` is the only user-facing switch; internally the driver resolves a `backend` object
-carried in `ctx.backend`.
+The batched path is an explicit opt-in with no silent fallback: `run_eph_over_k_and_kq(...;
+backend = ElectronPhonon.gpu_backend())` (or `run_eph_over_q_and_k(...; backend = ...)`) requires
+**every** calculator to support the corresponding batched payload, and a calculator that does not opt
+in errors loudly. Two orthogonal keywords control this: `backend` says where arrays live and is
+carried in `ctx.backend`, while `batched` says which payload/loop shape runs and is carried in
+`ctx.mode` (`SingleMode()` / `BatchedMode()`). `batched` defaults from `backend`, so a GPU run passes
+`backend` alone; passing `batched = true` on a `CPUBackend` runs the batched loop on host arrays,
+which is how the batched path is tested without CUDA.
 
 To add a GPU path to an existing CPU calculator:
 
@@ -157,19 +165,22 @@ To add a GPU path to an existing CPU calculator:
    `p.ωqs`, batch indices …). Write it backend-generically — only `alloc(ctx.backend, T, dims...)`,
    `similar`, `copyto!`, broadcasting, `mul!`, and scatter-assignment — so the same method runs on
    CPU arrays and `CuArray`s and adds no CUDA dependency of its own.
-3. Manage device buffers. `setup_calculator!` is passed the run's `backend`, so build whole-run
-   device buffers (index maps, band energies, weights — anything intrinsic to the state sets) there
-   with `alloc(backend, …)` / `to_device(backend, …)` (only when `backend isa GPUBackend`). Use the
-   brackets only for per-iteration state, and mind **which brackets the loop you are targeting
-   actually fires**:
+3. Manage device buffers. `setup_calculator!` is passed both the run's `backend` and its `mode`, so
+   build whole-run device buffers (index maps, band energies, weights — anything intrinsic to the
+   state sets) there with `alloc(backend, …)` / `to_device(backend, …)`, gated on
+   `mode isa BatchedMode`. Do **not** gate on `backend isa GPUBackend`: that builds the wrong buffers
+   under the CPU+batched validation configuration (the bug this guide used to recommend). The alloc
+   helpers are backend-generic, so on a `CPUBackend` they yield host arrays and the same code path
+   works. Use the brackets only for per-iteration state, and mind **which brackets the loop you are
+   targeting actually fires**:
 
    | loop | brackets fired |
    |---|---|
-   | CPU outer-k / outer-q (`SingleMode`) | `OuterIteration` per k / per q |
-   | GPU outer-q (`BatchedMode`) | `OuterIteration` per q |
-   | **GPU outer-k (`BatchedMode`)** | **`OuterIterationBatch` only — no per-k bracket** |
+   | per-point outer-k / outer-q (`SingleMode`) | `OuterIteration` per k / per q |
+   | batched outer-q (`BatchedMode`) | `OuterIteration` per q |
+   | **batched outer-k (`BatchedMode`)** | **`OuterIterationBatch` only — no per-k bracket** |
 
-   The GPU outer-k loop runs its q-tile loop *outside* the k loop (one Fourier phase tile is reused
+   The batched outer-k loop runs its q-tile loop *outside* the k loop (one Fourier phase tile is reused
    by every k of the batch), so a single k's work is spread over the whole batch and has no
    begin/end point. A per-k device reduction there must move to `OuterIterationBatch`; a
    `calculator_begin!(calc, OuterIteration(), ctx)` method written for that loop would simply never
@@ -217,8 +228,12 @@ Band energies, integration weights, and state-index maps are intrinsic to the st
 one loop iteration, so build them once in `setup_calculator!` from the `backend` it is handed (they
 would otherwise pollute `LoopContext`, which describes only the current iteration). Upload arrays
 with `to_device(backend, host_array)` and build the device state-index map with
-`_indmap_to_device(backend, states, nw)`. Do this only for `backend isa GPUBackend` (the CPU path
-uses the per-point `EPData` method and needs no device buffers).
+`_indmap_to_device(backend, states, nw)`. Gate this on the **loop shape**, not the backend:
+`setup_calculator!` also receives a `mode::LoopMode` keyword, so build these buffers when
+`mode isa BatchedMode` (the per-point path uses the `EPData` method and needs no such buffers). Do
+not test `backend isa GPUBackend` — that would build the wrong buffers under the CPU+batched
+validation configuration. All three helpers are backend-generic, so on a `CPUBackend` they simply
+yield host arrays.
 
 `BoltzmannCalculator` (`src/boltzmann/boltzmann_calculator.jl`) and `EliashbergCalculator`
 (MigdalEliashberg.jl) are worked references: each has both a CPU `EPData` method and a GPU

--- a/examples/bte_gpu_taas.jl
+++ b/examples/bte_gpu_taas.jl
@@ -2,10 +2,10 @@
 #
 # Demonstrates the full flow with `BoltzmannCalculator`:
 #   1. extract the scattering matrices Sₒ (SERTA lifetime) and Sᵢ (scattering-in) in ONE GPU pass
-#      of `run_eph_over_k_and_kq` (use_gpu = true), then
+#      of `run_eph_over_k_and_kq` (backend = EP.gpu_backend()), then
 #   2. solve the linearized BTE with `solve_electron_bte` (now BandStates-aware) to get σ.
 #
-# The same calculator runs on the CPU (use_gpu = false) for validation. Uses IBZ symmetry
+# The same calculator runs on the CPU (backend = EP.CPUBackend()) for validation. Uses IBZ symmetry
 # (`symmetry = model.symmetry`, `el_kq_from_unfolding = false`) — the outer k-grid is reduced to
 # the irreducible BZ, the dominant transport speedup. FermiDirac occupation + Gaussian smearing.
 
@@ -37,19 +37,19 @@ occupation_params() = ElectronOccupationParams(;
 σ_to_SI(σ) = σ .* EP.e2 / (unit_to_aru(:A) / unit_to_aru(:V) / unit_to_aru(:cm))
 
 """
-    run_bte_gpu(model, nk; η, window, occ, method=5, use_gpu=true, symmetry=model.symmetry)
+    run_bte_gpu(model, nk; η, window, occ, method=5, backend=EP.gpu_backend(), symmetry=model.symmetry)
 
 Run one BTE transport calculation on an `nk³` grid and return the SERTA and full-BTE
 conductivity tensors (SI, `(Ω·cm)⁻¹`, shape `(3,3,nT)`) plus the calculator. `method` is the
 occupation-factor convention 1..6 (see `bte_scattering_increments`).
 """
 function run_bte_gpu(model, nk; η, window, occ, method = 5,
-        use_gpu = true, symmetry = model.symmetry)
+        backend = EP.gpu_backend(), symmetry = model.symmetry)
     calc = BoltzmannCalculator{Float64}(; occ, smearing = [(:Gaussian, η) for _ in 1:length(occ)],
         occupation_method = method)
     EP.run_eph_over_k_and_kq(model, (nk, nk, nk), (nk, nk, nk);
         calculators = [calc], symmetry, el_kq_from_unfolding = false,
-        window_k = window, window_kq = window, use_gpu,
+        window_k = window, window_kq = window, backend,
         nchunks_threads = Threads.nthreads(), progress_print_step = 200)
     res = EP.solve_electron_bte(calc.el_i, calc.el_f, calc.Sᵢ, stack(calc.Sₒ), occ, symmetry)
     (; σ_serta_SI = σ_to_SI(res.σ_serta), σ_bte_SI = σ_to_SI(res.σ), res, calc)
@@ -59,7 +59,7 @@ end
 nk = 16
 η  = 10.0 * meV
 occ = occupation_params()
-out = run_bte_gpu(model, nk; η, window, occ, method = :Method5, use_gpu = true)
+out = run_bte_gpu(model, nk; η, window, occ, method = :Method5, backend = EP.gpu_backend())
 
 println("\nTaAs σ (GPU BTE), trace/3, per temperature:")
 for (iT, T) in enumerate(occ.Tlist)

--- a/examples/bte_multigrid.jl
+++ b/examples/bte_multigrid.jl
@@ -51,7 +51,7 @@ occupation_params() = ElectronOccupationParams(;
 
 """
     run_bte_multigrid(model, nk_narrow, nk_wide; η, window_narrow, window_wide, occ,
-                      method, use_gpu, symmetry)
+                      method, backend, symmetry)
 
 Run one multigrid BTE transport calculation and return the SERTA and full-BTE conductivity
 tensors (SI, `(Ω·cm)⁻¹`, shape `(3,3,nT)`) plus the calculator. `nk_narrow` must be a multiple of
@@ -59,10 +59,10 @@ tensors (SI, `(Ω·cm)⁻¹`, shape `(3,3,nT)`) plus the calculator. `nk_narrow`
 unfold).
 """
 function run_bte_multigrid(model, nk_narrow, nk_wide; η, window_narrow, window_wide, occ,
-        method = 5, use_gpu = true, symmetry = model.symmetry)
+        method = 5, backend = EP.gpu_backend(), symmetry = model.symmetry)
     sel_k = EP.filter_electron_states_multigrid(
         (nk_narrow, nk_narrow, nk_narrow), (nk_wide, nk_wide, nk_wide),
-        window_narrow, window_wide, model.nw, model.el_ham; symmetry, use_gpu)
+        window_narrow, window_wide, model.nw, model.el_ham; symmetry, backend)
     sel_kq = EP.unfold_band_states(sel_k, symmetry)   # explicit full-BZ k+q selection
 
     calc = BoltzmannCalculator{Float64}(; occ,
@@ -70,7 +70,7 @@ function run_bte_multigrid(model, nk_narrow, nk_wide; η, window_narrow, window_
         occupation_method = method)
     EP.run_eph_over_k_and_kq(model, sel_k, sel_kq;
         calculators = [calc], symmetry, el_kq_from_unfolding = false,
-        window_k = window_wide, window_kq = window_wide, use_gpu,
+        window_k = window_wide, window_kq = window_wide, backend,
         nchunks_threads = Threads.nthreads(), progress_print_step = 200)
 
     # interpolate=false: exact unfold-only δf feedback on the shared multigrid spec.
@@ -85,7 +85,7 @@ nk_wide = 50
 η   = 5.0 * meV
 occ = occupation_params()
 out = run_bte_multigrid(model, nk_narrow, nk_wide; η, window_narrow, window_wide, occ,
-                        method = 5, use_gpu = true)
+                        method = 5, backend = EP.gpu_backend())
 
 println("\nmultigrid: fine $(nk_narrow)³/±0.1eV + coarse $(nk_wide)³/±0.4eV")
 println("  el_i.n = $(out.calc.el_i.n)   el_f.n = $(out.calc.el_f.n)")

--- a/src/EPData.jl
+++ b/src/EPData.jl
@@ -40,13 +40,14 @@ end
 """
     EPDataQBatched{AT4C, AT4R, AT2, VI} <: AbstractElPhPayload
 
-Device payload of the GPU outer-k loop (`run_eph_over_k_and_kq`, `use_gpu`): one outer k-point with a
-batch of its k+q points. Runs on the backend of `eps` (CPU or GPU); consumers stay backend-generic
-(`similar`, `copyto!`, broadcasting, scatter) so no CUDA dependency leaks in.
+Batched payload of the outer-k loop (`run_eph_over_k_and_kq`, `batched = true`; production spelling
+`backend = gpu_backend()`): one outer k-point with a batch of its k+q points. Runs on the backend of
+`eps` (CPU or GPU); consumers stay backend-generic (`similar`, `copyto!`, broadcasting, scatter) so no
+CUDA dependency leaks in.
 
 The batched fields carry a batch of quantities (the trailing axis is the k+q batch), so they take the
 plural names `eps`/`g2s`/`ωqs` (cf. `ikqs`). This payload differs from [`EPDataKBatched`](@ref)
-because the two GPU loops feed different consumers: this outer-k loop pre-fuses `g2s` in its kernel
+because the two batched loops feed different consumers: this outer-k loop pre-fuses `g2s` in its kernel
 (what the BTE scatter needs), whereas the outer-q loop hands eigenvectors and lets the consumer form
 its own contraction (so `EPDataKBatched` carries `uk`/`ukq` and no `g2s`).
 
@@ -74,8 +75,9 @@ end
 """
     EPDataKBatched{AT4, AT3, AT2, AT1, VK} <: AbstractElPhPayload
 
-Device payload of the GPU outer-q loop (`run_eph_over_q_and_k`, `use_gpu`): one phonon momentum q with
-a batch of outer k-points. Runs on the backend of `eps`; consumers stay backend-generic.
+Batched payload of the outer-q loop (`run_eph_over_q_and_k`, `batched = true`; production spelling
+`backend = gpu_backend()`): one phonon momentum q with a batch of outer k-points. Runs on the backend
+of `eps`; consumers stay backend-generic.
 
 Unlike [`EPDataQBatched`](@ref) it carries no fused `g2s`: the outer-q loop hands the raw e-ph
 matrices `eps` plus the eigenvectors `uk`/`ukq`, and the consumer forms its own contraction (that is

--- a/src/boltzmann/boltzmann_calculator.jl
+++ b/src/boltzmann/boltzmann_calculator.jl
@@ -3,18 +3,19 @@
 # imap addressing; rather than copying g2/ωq it folds the temperature-dependent occupation physics
 # into Sₒ/Sᵢ via the shared `bte_scattering_increments` (see src/boltzmann/bte_scattering_core.jl).
 #
-# One calculator, both backends: the same calculator instance is used on CPU or GPU — the backend is
-# chosen by `run_eph_over_k_and_kq`'s `use_gpu`, which dispatches `run_calculator!` on the payload
-# type: `EPData` (host loop, per (ik,iq,ikq)) or `EPDataQBatched` (device, per k-batch).
-# Both fold the identical `bte_scattering_increments`, so they compute the same scattering (to
-# round-off); the CPU path also serves as the validation reference for the GPU path.
+# One calculator, both loop shapes: the same calculator instance serves the per-point and the batched
+# path. `run_eph_over_k_and_kq`'s `batched` selects which payload `run_calculator!` is dispatched on:
+# `EPData` (host loop, per (ik,iq,ikq)) or `EPDataQBatched` (batched, per k-batch), and `backend`
+# selects where its arrays live. Both fold the identical `bte_scattering_increments`, so they compute
+# the same scattering (to round-off); the per-point path serves as the validation reference for the
+# batched one.
 #
 # Output layout is what the transport solver (`solve_electron_bte` / `solve_thermoelectric_bte`)
 # consumes unchanged:
 #   Sₒ :: Vector{Vector}  — Sₒ[iT][i]      (inverse SERTA lifetime γ_{nk})
 #   Sᵢ :: Vector{Matrix}  — Sᵢ[iT][i, f]   (scattering-in kernel)
 #
-# GPU device memory (Sᵢ): the scattering-in matrix Sᵢ (n_i·n_f·nT) is the large object. On the GPU it
+# Device memory (Sᵢ): the scattering-in matrix Sᵢ (n_i·n_f·nT) is the large object. On the GPU it
 # is never held whole on the device — it is tiled over outer k, each tile filled by one k-batch and
 # streamed to the host (OuterIterationBatch begin/end brackets), so only one tile (≈ one k-batch of rows)
 # is device-resident. This bounds device memory to the tile regardless of grid size at no measurable
@@ -30,7 +31,7 @@ export BoltzmannCalculator
 # (k) vs final/inner (k+q). The Latin `ᵢ` in `Sᵢ` looks like the `_i` suffix but means "in", not
 # "initial".
 
-# Device buffers for the GPU batched path, built once in `setup_calculator!` (GPU backend only) from
+# Device buffers for the batched path, built once in `setup_calculator!` (batched runs only) from
 # `alloc(backend, …)` / `to_device(backend, …)`. Held behind `dev::Union{Nothing, …}` on the
 # calculator; touched only at hook granularity (one kernel launch per call), so the function boundary
 # keeps the hot code type-stable. The tiled Sᵢ output lives in `calc.tiled` (a `TiledDeviceOutput`).
@@ -66,7 +67,7 @@ Base.@kwdef mutable struct BoltzmannCalculator{FT} <: AbstractCalculator
     # Physical-band range (iband_min:iband_max) spanning the in-window bands; set at setup. The CPU
     # per-chunk Sₒ/Sᵢ buffers are OffsetArrays indexed over this band range. (1:0 = not set yet.)
     rng_band::UnitRange{Int} = 1:0
-    # Full (Wannier) band count (= model.nw); set at setup. GPU path only: sizes the physical-band
+    # Full (Wannier) band count (= model.nw); set at setup. Batched path only: sizes the physical-band
     # device index maps built in the first OuterIterationBatch begin. (0 = not set yet.)
     nw::Int = 0
 
@@ -80,22 +81,23 @@ Base.@kwdef mutable struct BoltzmannCalculator{FT} <: AbstractCalculator
     Sₒ::Vector{Vector{FT}} = Vector{Vector{FT}}()         # per iT, length n_i
     Sᵢ::Vector{Matrix{FT}} = Vector{Matrix{FT}}()         # per iT, (n_i, n_f)
 
-    # --- CPU-path thread buffers (run_calculator!) ---
-    # Built eagerly in `setup_calculator!` on the CPU path (behind `!on_gpu`); the GPU path never
-    # allocates them (Sᵢ_buffer would be nchunks·nT·rng_band·n_f — prohibitive on production grids).
+    # --- Per-point-path thread buffers (run_calculator!) ---
+    # Built eagerly in `setup_calculator!` on the per-point path (behind `!batched`); the batched path
+    # never allocates them (Sᵢ_buffer would be nchunks·nT·rng_band·n_f — prohibitive on production grids).
     Sₒ_buffer::Vector{Vector{OffsetVector{FT, Vector{FT}}}} = Vector{Vector{OffsetVector{FT, Vector{FT}}}}()
     Sᵢ_buffer::Vector{Vector{OffsetMatrix{FT, Matrix{FT}}}} = Vector{Vector{OffsetMatrix{FT, Matrix{FT}}}}()
 
-    # Run mode, set at setup from the backend: `true` on a GPU run. The explicit flag is the
-    # authoritative CPU-vs-GPU discriminator (do not infer the run mode from `dev`/`tiled` being set).
-    on_gpu::Bool = false
+    # Loop shape, set at setup from the driver's `mode`: `true` on a batched run (on either backend).
+    # The explicit flag is the authoritative per-point-vs-batched discriminator (do not infer the run
+    # shape from the backend, nor from `dev`/`tiled` being set).
+    batched::Bool = false
 
-    # --- Device buffers (GPU batched path) ---
-    # Built once in `setup_calculator!` for a GPU backend; `nothing` on the CPU path. See
+    # --- Device buffers (batched path) ---
+    # Built once in `setup_calculator!` on a batched run; `nothing` on the per-point path. See
     # `BoltzmannDeviceBuffers`.
     dev::Union{Nothing, BoltzmannDeviceBuffers} = nothing
 
-    # --- Tiled Sᵢ device output (GPU batched path) ---
+    # --- Tiled Sᵢ device output (batched path) ---
     # Sᵢ is never held whole on the device: `TiledDeviceOutput` (always block mode) keeps one outer-k
     # tile (i-extent = the largest k-batch) resident and streams it to `calc.Sᵢ` per batch. Built at
     # setup; device buffers allocated lazily on the first batch.
@@ -112,7 +114,7 @@ supports(::BoltzmannCalculator, ::Type{EPDataQBatched}) = true
 
 function setup_calculator!(calc::BoltzmannCalculator{FT}, kpts, qpts, el_states;
         el_states_kq, kqpts, sel_k, sel_kq, nchunks_threads, rng_band,
-        nw, backend, kwargs...) where {FT}
+        nw, backend, mode, kwargs...) where {FT}
     mpi_isroot() && println("Setting up BoltzmannCalculator")
     calc.done &&
         throw(ArgumentError("this BoltzmannCalculator has already been run; reconstruct the " *
@@ -155,16 +157,17 @@ function setup_calculator!(calc::BoltzmannCalculator{FT}, kpts, qpts, el_states;
     calc.Sᵢ = [zeros(FT, n_i, n_f) for _ in 1:nT]
     # Tiled Sᵢ device output: shape (n_i, n_f, nT), tiled over the outer-k state axis (axis 1), always
     # block mode (there is deliberately no full-device-resident Sᵢ path). Metadata only at setup; the
-    # device/host tile buffers are lazy in `tile_begin!` (GPU only, first batch), so this is cheap on
-    # the CPU path where `tile_begin!` never runs.
+    # device/host tile buffers are lazy in `tile_begin!` (batched runs only, first batch), so this is
+    # cheap on the per-point path where `tile_begin!` never runs.
     calc.tiled = TiledDeviceOutput{FT}((n_i, n_f, nT), 1, calc.el_i; narr = 1, force_block = true)
 
-    # GPU path: build the whole-run device buffers now (backend is available here). The band
+    # Batched path: build the whole-run device buffers now (backend is available here). The band
     # energies/weights/index maps are intrinsic to the state sets and temperatures, so they are set
-    # up once here rather than lazily during the loop. On the CPU backend nothing is built (`dev`
-    # stays `nothing`; the CPU path uses the per-point `run_calculator!(::EPData)` loop instead).
-    calc.on_gpu = backend isa GPUBackend
-    if calc.on_gpu
+    # up once here rather than lazily during the loop. `alloc`/`to_device`/`_indmap_to_device` are
+    # backend-generic, so on a `CPUBackend` these are host arrays. On the per-point path nothing is
+    # built (`dev` stays `nothing`; it uses the `run_calculator!(::EPData)` loop instead).
+    calc.batched = mode isa BatchedMode
+    if calc.batched
         calc.dev = BoltzmannDeviceBuffers(
             fill!(alloc(backend, FT, n_i, nT), zero(FT)),                       # Sₒ
             _indmap_to_device(backend, calc.el_i, calc.nw),                     # imap_i
@@ -177,9 +180,9 @@ function setup_calculator!(calc::BoltzmannCalculator{FT}, kpts, qpts, el_states;
             to_device(backend, calc.smearing_list),                             # smearing (one per T)
         )
     else
-        # CPU path: build the per-chunk thread buffers here (mirror of the eager device buffers
-        # above). Guarded by `!on_gpu` because they are large (nchunks·nT·rng_band·n_f) and the GPU
-        # path must not allocate them. `calculator_begin!` only zeros them per outer k.
+        # Per-point path: build the per-chunk thread buffers here (mirror of the eager device buffers
+        # above). Guarded by `!batched` because they are large (nchunks·nT·rng_band·n_f) and the
+        # batched path must not allocate them. `calculator_begin!` only zeros them per outer k.
         rb = calc.rng_band
         calc.Sₒ_buffer = [[OffsetArray(zeros(FT, length(rb)), rb) for _ in 1:nT] for _ in 1:calc.nchunks]
         calc.Sᵢ_buffer = [[OffsetArray(zeros(FT, length(rb), n_f), rb, :) for _ in 1:nT] for _ in 1:calc.nchunks]
@@ -187,9 +190,9 @@ function setup_calculator!(calc::BoltzmannCalculator{FT}, kpts, qpts, el_states;
     calc
 end
 
-# --- CPU (non-batched, EPData) path --------------------------------------------------
+# --- Per-point (non-batched, EPData) path --------------------------------------------
 
-# CPU path: zero the per-chunk thread buffers for the new outer k (the buffers are allocated in
+# Per-point path: zero the per-chunk thread buffers for the new outer k (the buffers are allocated in
 # `setup_calculator!`). Dispatched on `SingleMode`; the batched outer-k loop fires no per-k
 # `OuterIteration` bracket at all — its device lifecycle lives in the OuterIterationBatch brackets.
 function calculator_begin!(calc::BoltzmannCalculator{FT}, ::OuterIteration,
@@ -201,9 +204,9 @@ function calculator_begin!(calc::BoltzmannCalculator{FT}, ::OuterIteration,
     calc
 end
 
-# CPU path: called per (ik, iq, ikq) by the host e-ph loop; accumulates into the per-chunk thread
+# Per-point path: called per (ik, iq, ikq) by the host e-ph loop; accumulates into the per-chunk thread
 # buffers, reduced into Sₒ/Sᵢ by the OuterIteration end bracket. The `(m, n, iT, imode)` loop below
-# mirrors, term for term (`ek`/`ekq`/`ωq`/`sₒ_ν`/`sᵢ_ν`/`sₒ`/`sᵢ`), the device work in
+# mirrors, term for term (`ek`/`ekq`/`ωq`/`sₒ_ν`/`sᵢ_ν`/`sₒ`/`sᵢ`), the work in
 # `bte_window_accumulate!` (the EPDataQBatched path); both fold the identical `bte_scattering_increments`.
 function run_calculator!(calc::BoltzmannCalculator{FT}, p::EPData, ctx::LoopContext{CPUBackend, SingleMode}) where {FT}
     (; epstate, ikq, id_chunk) = p
@@ -241,7 +244,7 @@ function run_calculator!(calc::BoltzmannCalculator{FT}, p::EPData, ctx::LoopCont
     calc
 end
 
-# CPU path: reduce the per-chunk buffers into the global Sₒ/Sᵢ. Dispatched on `SingleMode`; the
+# Per-point path: reduce the per-chunk buffers into the global Sₒ/Sᵢ. Dispatched on `SingleMode`; the
 # batched loop (`BatchedMode`) runs the default no-op.
 function calculator_end!(calc::BoltzmannCalculator, ::OuterIteration,
         ctx::LoopContext{CPUBackend, SingleMode})
@@ -259,9 +262,9 @@ function calculator_end!(calc::BoltzmannCalculator, ::OuterIteration,
     calc
 end
 
-# --- GPU batched path (EPDataQBatched) -----------------------------------------------
+# --- Batched path (EPDataQBatched) ---------------------------------------------------
 
-# Batched path: called by the GPU e-ph loop once per outer-k batch, before its k iterations. The
+# Batched path: called by the batched e-ph loop once per outer-k batch, before its k iterations. The
 # run's device buffers (`calc.dev`) were built once in `setup_calculator!`; here it only records this
 # batch's Sᵢ tile range and zeros the tile's active region (via `calc.tiled`). The `BatchedMode`
 # annotation records the only mode this scope is ever fired in (`OuterIterationBatch`/`SingleMode`
@@ -382,11 +385,11 @@ end
 
 function postprocess_calculator!(calc::BoltzmannCalculator{FT}; kwargs...) where {FT}
     calc.done = true    # single-use: `setup_calculator!` errors on a re-run
-    # CPU run: no device buffers to stream/free. On the GPU no-batch corner (this rank owns no outer
-    # k: empty MPI slice / empty window) `dev.Sₒ` is still the setup zeros, so streaming it below
-    # leaves Sₒ zero as intended.
-    calc.on_gpu || return calc
-    # GPU path: Sₒ is kept device-resident, so stream it to the host here. (Sᵢ was already streamed
+    # Per-point run: no device buffers to stream/free. On the batched no-batch corner (this rank owns
+    # no outer k: empty MPI slice / empty window) `dev.Sₒ` is still the setup zeros, so streaming it
+    # below leaves Sₒ zero as intended.
+    calc.batched || return calc
+    # Batched path: Sₒ is kept in `dev`, so copy it to the host output here. (Sᵢ was already streamed
     # one tile per outer-k batch in the OuterIterationBatch end bracket.)
     Sₒ_host = Array(calc.dev.Sₒ)        # (n_i, nT)
     @inbounds for iT in 1:length(calc.occ)

--- a/src/boltzmann/boltzmann_calculator.jl
+++ b/src/boltzmann/boltzmann_calculator.jl
@@ -112,9 +112,10 @@ supports(::BoltzmannCalculator, ::Type{OuterKLoop}) = true
 supports(::BoltzmannCalculator, ::Type{EPData}) = true
 supports(::BoltzmannCalculator, ::Type{EPDataQBatched}) = true
 
-function setup_calculator!(calc::BoltzmannCalculator{FT}, kpts, qpts, el_states;
+function setup_calculator!(calc::BoltzmannCalculator{FT}, backend::AbstractBackend, mode::LoopMode,
+        kpts, qpts, el_states;
         el_states_kq, kqpts, sel_k, sel_kq, nchunks_threads, rng_band,
-        nw, backend, mode, kwargs...) where {FT}
+        nw, kwargs...) where {FT}
     mpi_isroot() && println("Setting up BoltzmannCalculator")
     calc.done &&
         throw(ArgumentError("this BoltzmannCalculator has already been run; reconstruct the " *
@@ -161,11 +162,12 @@ function setup_calculator!(calc::BoltzmannCalculator{FT}, kpts, qpts, el_states;
     # cheap on the per-point path where `tile_begin!` never runs.
     calc.tiled = TiledDeviceOutput{FT}((n_i, n_f, nT), 1, calc.el_i; narr = 1, force_block = true)
 
-    # Batched path: build the whole-run device buffers now (backend is available here). The band
-    # energies/weights/index maps are intrinsic to the state sets and temperatures, so they are set
-    # up once here rather than lazily during the loop. `alloc`/`to_device`/`_indmap_to_device` are
+    # Batched path: build the whole-run device buffers now (backend is a positional argument here). The
+    # band energies/weights/index maps are intrinsic to the state sets and temperatures, so they are
+    # set up once here rather than lazily during the loop. `alloc`/`to_device`/`_indmap_to_device` are
     # backend-generic, so on a `CPUBackend` these are host arrays. On the per-point path nothing is
-    # built (`dev` stays `nothing`; it uses the `run_calculator!(::EPData)` loop instead).
+    # built (`dev` stays `nothing`; it uses the `run_calculator!(::EPData)` loop instead). Keyed on
+    # `mode`, NOT on `backend isa GPUBackend` — see the `AbstractCalculator` docstring.
     calc.batched = mode isa BatchedMode
     if calc.batched
         calc.dev = BoltzmannDeviceBuffers(

--- a/src/boltzmann/boltzmann_calculator.jl
+++ b/src/boltzmann/boltzmann_calculator.jl
@@ -312,18 +312,53 @@ device-resident work of `run_calculator!(::BoltzmannCalculator, ::EPDataQBatched
     outer-k batch, so `Sᵢ_out` is the current tile and the row is the tile-local `i - i0`.
 
 `imap_i_at_k` is `imap_i[:, ik]` — the outer-state indices at the batch's fixed outer k `ik`.
-`i0` is the global-i offset of the current `Sᵢ` tile. Only the CUDA extension provides a method
-(`CuArray` kernel): the CPU BoltzmannCalculator never batches — it accumulates per (k, q) via the
-`run_calculator!(::EPData)` host loop above — so a generic CPU method would be dead code (a silent
-fallback risk), and is deliberately not defined. The physics lives entirely in
-`bte_scattering_increments`, so the device kernel agrees with the CPU host loop (validated
-end-to-end in `test/boltzmann/test_gpu_boltzmann_calculator.jl`).
-"""
-function bte_window_accumulate! end
+`i0` is the global-i offset of the current `Sᵢ` tile.
 
-# GPU path: called once per outer-k batch by the device e-ph loop; scatters into the device Sₒ and the
-# current Sᵢ tile via `bte_window_accumulate!` (the device analogue of the CPU EPData loop above —
-# same `bte_scattering_increments`). No per-chunk reduction: the scatter writes the global buffers.
+The generic method below serves the CPU+batched validation configuration
+(`run_eph_over_k_and_kq(...; batched = true)` on a `CPUBackend`), where the whole batched loop runs
+on host arrays; the CUDA extension provides a `CuArray` kernel. Dispatch is on
+`Sₒ_out::CuArray, Sᵢ_out::CuArray`, so a GPU run can only reach the generic method if `calc.dev` was
+itself built on a `CPUBackend`, i.e. only in that deliberate configuration (and
+`CUDA.allowscalar(false)` turns any accidental host/device mixing into a hard error). The physics
+lives entirely in `bte_scattering_increments`, so both methods and the per-(k,q) host loop above
+compute the same scattering (validated in `test/boltzmann/test_gpu_boltzmann_calculator.jl`).
+`eph_window_scatter!` (src/calculator/calculator_utils.jl) ships the same generic + `CuArray` pair.
+
+The generic method adds into `Sₒ_out` with a plain `+=` where the device kernel needs an atomic: the
+batched loop is single-threaded over its (k, q-tile) iterations, so there is no host counterpart to
+the kernel's concurrent writes.
+"""
+function bte_window_accumulate!(Sₒ_out, Sᵢ_out, g2vals, ωqmat, imap_i_at_k, imap_f, ikqs,
+        e_i, e_f, wf, μs, Ts, ηs, method::Int, ω_cutoff,
+        nbandkq::Int, nbandk::Int, nmodes::Int, nq_batch::Int, i0::Int)
+    nT = length(μs)
+    @inbounds for iq_batch in 1:nq_batch, n in 1:nbandk, m in 1:nbandkq
+        i = imap_i_at_k[n]         # outer (k) state index; 0 = out of window → skip
+        i > 0 || continue
+        f = imap_f[m, ikqs[iq_batch]]   # inner (k+q) state index; 0 = out of window → skip
+        f > 0 || continue
+        ek = e_i[i]; ekq = e_f[f]; wtq = wf[f]   # per-final-state weight
+        il = i - i0                # tile-local outer row (i0 = the current Sᵢ tile's global offset)
+        for iT in 1:nT             # one entry per temperature
+            μ = μs[iT]; T = Ts[iT]; η = ηs[iT]
+            sₒ = zero(eltype(Sₒ_out)); sᵢ = sₒ
+            for ν in 1:nmodes
+                ωq = ωqmat[ν, iq_batch]
+                ωq < ω_cutoff && continue
+                sₒ_ν, sᵢ_ν = bte_scattering_increments(method, ek, ekq, ωq,
+                    g2vals[m, n, ν, iq_batch], wtq, μ, T, η)
+                sₒ += sₒ_ν; sᵢ += sᵢ_ν
+            end
+            Sₒ_out[i, iT] += sₒ
+            Sᵢ_out[il, f, iT] = sᵢ
+        end
+    end
+    nothing
+end
+
+# Batched path: called once per outer-k batch by the batched e-ph loop; scatters into `dev.Sₒ` and the
+# current Sᵢ tile via `bte_window_accumulate!` (the batched analogue of the per-point EPData loop
+# above — same `bte_scattering_increments`). No per-chunk reduction: the scatter writes the global buffers.
 function run_calculator!(calc::BoltzmannCalculator{FT}, p::EPDataQBatched, ctx) where {FT}
     (; g2s, ωqs, ik, ikqs, ibandk_offset) = p
     dev = calc.dev

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -7,7 +7,12 @@ phonon states and the e-ph matrix elements are formed, the driver hands them to 
 **payload** (a subtype of [`AbstractElPhPayload`]) together with a [`LoopContext`].
 
 Users subtype `AbstractCalculator` and implement:
-* `setup_calculator!(calc, kpts, qpts, el_states; kwargs...)` — run once, before the loop.
+* `setup_calculator!(calc, kpts, qpts, el_states; kwargs...)` — run once, before the loop. Among its
+  keywords, two describe the run itself: `backend::AbstractBackend` (where arrays live) and
+  `mode::LoopMode` (`SingleMode()` / `BatchedMode()`, which loop shape will run). **Gate device-buffer
+  construction on `mode`, never on `backend isa GPUBackend`** — the two are independent, and the
+  batched loop also runs on a `CPUBackend` (a validation configuration), where a backend test builds
+  the wrong buffers while still compiling and running. Splat everything else with `kwargs...`.
 * `run_calculator!(calc, payload::AbstractElPhPayload, ctx::LoopContext)` — one method per payload
   type the calculator consumes (host per-(k,q), or one of the device-batched payloads).
 * `postprocess_calculator!(calc; kwargs...)` — run once, after the loop.
@@ -18,29 +23,29 @@ Users subtype `AbstractCalculator` and implement:
   around one outer iteration (`OuterIteration()`) or one batch of outer iterations
   (`OuterIterationBatch()`). There is NO default: a calculator must define these for every
   (scope, loop-mode) combination its supported loops fire, even as an explicit no-op (`= nothing`);
-  a missing method is a loud error, not a silent skip. The GPU outer-k loop fires only
+  a missing method is a loud error, not a silent skip. The batched outer-k loop fires only
   `OuterIterationBatch` (see the bracket comment below).
 
 Optionally:
 * `eph_batched_bytes_per_point(calc, PayloadType; nw, nmodes)` — per-point device scratch (bytes)
-  the calculator holds, so the GPU loops' memory-adaptive batch sizing can account for it.
+  the calculator holds, so the batched loops' memory-adaptive batch sizing can account for it.
 * `allowed_eph_phonon_basis(calc)` — phonon bases the calculator accepts.
 * `required_el_k_quantities(calc)` — outer-k electron-state quantities the calculator needs (the
   outer-q driver computes the union; override to skip velocity/position).
 
-See `docs/writing_a_calculator.md` for a worked example. The public (unexported) calculator API,
-reachable as `ElectronPhonon.<name>`, is: `AbstractCalculator`, `supports`, `setup_calculator!`,
-`run_calculator!`, `postprocess_calculator!`, `calculator_begin!`, `calculator_end!`, the loop tags
-`OuterKLoop` / `OuterQLoop`, the scope tags `OuterIteration` / `OuterIterationBatch`, the payloads
-`AbstractElPhPayload` / `EPData` / `EPDataQBatched` / `EPDataKBatched`,
-`LoopContext` with the loop modes `SingleMode` / `BatchedMode`, the backends `CPUBackend` /
-`GPUBackend` with `alloc` / `free_bytes` /
-`synchronize`, `eph_window_scatter!`, `eph_batched_bytes_per_point`, `allowed_eph_phonon_basis`,
-`required_el_k_quantities`, `_indmap_to_device`, the tiled
-device-output helper `TiledDeviceOutput` (with `tile_begin!` / `tile_download!` / `tile_free!` /
-`device_array` / `host_array` / `tile_offset` / `tile_length` / `tile_stride` / `is_block` /
-`is_allocated`), the device-memory batch-sizing helpers `plan_batch` / `estimate_device_memory`, and
-`to_device`.
+See `docs/writing_a_calculator.md` for a worked example.
+
+The public (unexported) calculator API is the `public` declaration at the bottom of this file — that
+declaration is the single authoritative list, deliberately not restated here (two copies drifted apart
+once already). Query it at the REPL rather than trusting prose:
+
+```julia
+filter(n -> Base.ispublic(ElectronPhonon, n), names(ElectronPhonon; all = true))
+```
+
+Every name in it is reachable as `ElectronPhonon.<name>`. Broadly it covers the hooks and traits above,
+the loop/scope tags, the payload types, `LoopContext` with its `LoopMode`s, the backend primitives, the
+`TiledDeviceOutput` helper, and the device-memory batch-sizing helpers.
 """
 abstract type AbstractCalculator end
 
@@ -152,6 +157,10 @@ conservative full list.
 """
 required_el_k_quantities(::AbstractCalculator) = ["eigenvalue", "eigenvector", "velocity", "position"]
 
+# Mandatory hook, no default. The drivers always supply `backend::AbstractBackend` and
+# `mode::LoopMode` among the keywords (plus the state/grid payload documented above); a calculator
+# that needs neither just splats them. `mode`, not `backend`, is the per-point-vs-batched
+# discriminator — see the `AbstractCalculator` docstring.
 function setup_calculator!(::AbstractCalculator, kpts, qpts, el_states; kwargs...)
     error("setup_calculator! has to be implemented")
 end
@@ -163,15 +172,15 @@ end
 # Scope singletons name the iteration level being bracketed, so the call reads as a sentence:
 # `calculator_begin!(calc, OuterIteration(), ctx)` = "at the beginning of one outer iteration".
 struct OuterIteration end        # one iteration of the outer loop (one ik / one iq)
-struct OuterIterationBatch end   # one batch of consecutive outer iterations (GPU loops)
+struct OuterIterationBatch end   # one batch of consecutive outer iterations (batched loops)
 
 # Begin/end brackets. There is NO no-op default: a calculator MUST define the brackets for every
 # (scope, loop-mode) combination the drivers fire on it, even when it wants a no-op — a missing
 # method is a loud error, never a silent skip (a silently-skipped bracket is a hard-to-find bug). The
-# combinations follow what the calculator `supports`: OuterIteration/SingleMode (CPU loops),
-# OuterIteration/BatchedMode (GPU outer-q per-q accumulator), and OuterIterationBatch/BatchedMode
-# (GPU outer-k per-batch). OuterIterationBatch/SingleMode is never fired, and neither is
-# OuterIteration/BatchedMode in the GPU OUTER-K loop: there the q-tile loop runs outside the k loop,
+# combinations follow what the calculator `supports`: OuterIteration/SingleMode (per-point loops),
+# OuterIteration/BatchedMode (batched outer-q per-q accumulator), and OuterIterationBatch/BatchedMode
+# (batched outer-k per-batch). OuterIterationBatch/SingleMode is never fired, and neither is
+# OuterIteration/BatchedMode in the BATCHED OUTER-K loop: there the q-tile loop runs outside the k loop,
 # so a single k's work is spread over the whole batch and has no per-k begin/end point — a
 # calculator needing a per-k device reduction there must do it at OuterIterationBatch scope.
 # A calculator that does nothing at a scope defines an explicit no-op (`= nothing`).
@@ -203,7 +212,7 @@ function run_calculator! end
     eph_batched_bytes_per_point(calc, ::Type{<:AbstractElPhPayload}; nw, nmodes) -> Int
 
 Device bytes of per-point scratch the calculator's batched `run_calculator!` path holds (its
-workspace arrays sized `(…, batch)`, divided by the batch width). The GPU loops sum this over the
+workspace arrays sized `(…, batch)`, divided by the batch width). The batched loops sum this over the
 calculators and combine it with their own per-point staging cost to derive a memory-adaptive batch
 width from `free_bytes`. Default `0` (no per-point device scratch).
 """

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -223,8 +223,10 @@ if VERSION >= v"1.11.0-DEV.469"
         "postprocess_calculator!, calculator_begin!, calculator_end!, " *
         "OuterKLoop, OuterQLoop, OuterIteration, OuterIterationBatch, " *
         "AbstractElPhPayload, EPData, EPDataQBatched, EPDataKBatched, " *
-        "LoopContext, SingleMode, BatchedMode, CPUBackend, GPUBackend, alloc, free_bytes, synchronize, " *
-        "eph_window_scatter!, eph_batched_bytes_per_point, allowed_eph_phonon_basis, " *
+        "LoopContext, SingleMode, BatchedMode, LoopMode, " *
+        "AbstractBackend, CPUBackend, GPUBackend, gpu_backend, alloc, free_bytes, synchronize, " *
+        "batched_gemm!, eph_window_scatter!, bte_window_accumulate!, " *
+        "eph_batched_bytes_per_point, allowed_eph_phonon_basis, " *
         "required_el_k_quantities, _indmap_to_device, " *
         "TiledDeviceOutput, tile_begin!, tile_download!, tile_free!, device_array, host_array, " *
         "tile_offset, tile_length, tile_stride, is_block, is_allocated, residency_use_block, " *

--- a/src/calculator/AbstractCalculator.jl
+++ b/src/calculator/AbstractCalculator.jl
@@ -7,12 +7,19 @@ phonon states and the e-ph matrix elements are formed, the driver hands them to 
 **payload** (a subtype of [`AbstractElPhPayload`]) together with a [`LoopContext`].
 
 Users subtype `AbstractCalculator` and implement:
-* `setup_calculator!(calc, kpts, qpts, el_states; kwargs...)` — run once, before the loop. Among its
-  keywords, two describe the run itself: `backend::AbstractBackend` (where arrays live) and
-  `mode::LoopMode` (`SingleMode()` / `BatchedMode()`, which loop shape will run). **Gate device-buffer
-  construction on `mode`, never on `backend isa GPUBackend`** — the two are independent, and the
-  batched loop also runs on a `CPUBackend` (a validation configuration), where a backend test builds
-  the wrong buffers while still compiling and running. Splat everything else with `kwargs...`.
+* `setup_calculator!(calc, backend::AbstractBackend, mode::LoopMode, kpts, qpts, el_states; kwargs...)`
+  — run once, before the loop. The two arguments describing the run come first and are POSITIONAL:
+  `backend` (where arrays live) and `mode` (`SingleMode()` / `BatchedMode()`, which loop shape will
+  run). Splat everything else with `kwargs...`.
+
+  **Dispatch device-buffer construction on `mode`, never on `backend isa GPUBackend`.** The two axes
+  are independent: the batched loop also runs on a `CPUBackend` (a validation configuration), where a
+  backend test silently builds the per-point buffers and skips the batched readback. That was a real
+  bug in `BoltzmannCalculator` (its `on_gpu` flag), which is why these are positional rather than
+  keywords — a required keyword is absorbed by any `kwargs...` signature, so an out-of-date calculator
+  keeps compiling and computes the wrong thing; a positional argument breaks loudly at load time, and
+  it lets a calculator write `setup_calculator!(c, ::CPUBackend, ::BatchedMode, …)` instead of
+  branching inside one method.
 * `run_calculator!(calc, payload::AbstractElPhPayload, ctx::LoopContext)` — one method per payload
   type the calculator consumes (host per-(k,q), or one of the device-batched payloads).
 * `postprocess_calculator!(calc; kwargs...)` — run once, after the loop.
@@ -157,11 +164,18 @@ conservative full list.
 """
 required_el_k_quantities(::AbstractCalculator) = ["eigenvalue", "eigenvector", "velocity", "position"]
 
-# Mandatory hook, no default. The drivers always supply `backend::AbstractBackend` and
-# `mode::LoopMode` among the keywords (plus the state/grid payload documented above); a calculator
-# that needs neither just splats them. `mode`, not `backend`, is the per-point-vs-batched
-# discriminator — see the `AbstractCalculator` docstring.
-function setup_calculator!(::AbstractCalculator, kpts, qpts, el_states; kwargs...)
+# Mandatory hook, no working default. `backend` and `mode` are POSITIONAL and come before the
+# state/grid arguments, so a calculator can dispatch on them (`::CPUBackend`, `::BatchedMode`) instead
+# of branching, and so a calculator still on the old signature fails loudly here instead of silently
+# absorbing them into `kwargs...`. `mode`, not `backend`, is the per-point-vs-batched discriminator —
+# see the `AbstractCalculator` docstring.
+#
+# Arguments 2 and 3 are deliberately UNANNOTATED. Annotating them `::AbstractBackend, ::LoopMode`
+# makes this method ambiguous with any calculator method that leaves them untyped (the natural
+# spelling: `setup_calculator!(c::MyCalc, backend, mode, kpts, qpts, el_states; kwargs...)`), because
+# neither candidate is more specific — the subtype wins on argument 1, the abstract types win on 2-3.
+# A catch-all must not compete on the arguments it does not dispatch on.
+function setup_calculator!(::AbstractCalculator, backend, mode, kpts, qpts, el_states; kwargs...)
     error("setup_calculator! has to be implemented")
 end
 

--- a/src/calculator/eph_device_staging.jl
+++ b/src/calculator/eph_device_staging.jl
@@ -15,7 +15,7 @@
     plan_batch(backend, per_point, committed, cap; headroom_num = 7, headroom_den = 10, what = "",
                warn = true) -> nbatch
 
-Size a batched GPU e-ph loop's batch to free device memory:
+Size a batched e-ph loop's batch to free device memory:
 `nbatch = min(cap, (free - committed) · headroom ÷ per_point)`, clamped to at least 1, where
 `per_point` / `committed` are the per-(batched-inner index) and whole-run device-byte counts. On a
 CPU backend `free_bytes` is `typemax(Int)`, so `nbatch = cap`. Errors if the whole-run commitments
@@ -31,7 +31,7 @@ function plan_batch(backend::AbstractBackend, per_point::Integer, committed::Int
         warn::Bool = true)
     free = free_bytes(backend)
     if free != typemax(Int) && committed > free
-        error("GPU $(what): committed device memory ($(round(committed / 1e9, digits = 2)) GB, " *
+        error("batched $(what): committed device memory ($(round(committed / 1e9, digits = 2)) GB, " *
               "whole-run stacks) exceeds free device memory ($(round(free / 1e9, digits = 2)) GB). " *
               "Reduce the batch cap or the grid size.")
     end
@@ -39,8 +39,8 @@ function plan_batch(backend::AbstractBackend, per_point::Integer, committed::Int
         max(1, ((free - committed) ÷ headroom_den * headroom_num) ÷ per_point)
     nbatch = min(Int(cap), nb_mem)
     if warn && free != typemax(Int) && nb_mem < cap
-        @warn "WARNING : GPU batch width reduced from the requested cap $(Int(cap)) to $nbatch to fit " *
-            "free device memory in plan_batch$(isempty(what) ? "" : " ($what)"). GPU performance may " *
+        @warn "WARNING : batch width reduced from the requested cap $(Int(cap)) to $nbatch to fit " *
+            "free device memory in plan_batch$(isempty(what) ? "" : " ($what)"). Performance may " *
             "degrade compared to smaller calculations."
     end
     nbatch

--- a/src/calculator/eph_setup_common.jl
+++ b/src/calculator/eph_setup_common.jl
@@ -107,19 +107,20 @@ function _setup_electron_kq(model, kqpts_input;
 end
 
 
-# setup_calculator! fan-out shared by all three drivers. The common keyword payload (band range,
-# k+q states/grid, carrier counts, thread chunking) is passed explicitly; the rest (`backend`, the
-# loop-shape `mode`, `verbosity`) forwards through `kwargs`. Every driver supplies `backend` and
-# `mode`: a calculator that keys off the loop shape reads `mode` (`SingleMode()`/`BatchedMode()`),
-# the same vocabulary its `calculator_begin!/end!` brackets dispatch on, because the backend alone
-# cannot say (batched-on-CPUBackend is a valid configuration).
+# setup_calculator! fan-out shared by all three drivers. `backend` and the loop-shape `mode` are
+# POSITIONAL (mirroring `setup_calculator!` itself, so they cannot be silently absorbed by a
+# calculator's `kwargs...`); the common keyword payload (band range, k+q states/grid, carrier counts,
+# thread chunking) is passed explicitly and the rest (`verbosity`) forwards through `kwargs`. A
+# calculator that keys off the loop shape uses `mode` (`SingleMode()`/`BatchedMode()`), the same
+# vocabulary its `calculator_begin!/end!` brackets dispatch on, because the backend alone cannot say
+# (batched-on-CPUBackend is a valid configuration).
 function _setup_calculators!(
-        calculators, kpts, qpts, el_k_save;
+        calculators, backend::AbstractBackend, mode::LoopMode, kpts, qpts, el_k_save;
         nw, nmodes, rng_band, el_states_kq, kqpts, nchunks_threads,
         sel_k, sel_kq, kwargs...,
     )
     for calc in calculators
-        setup_calculator!(calc, kpts, qpts, el_k_save;
+        setup_calculator!(calc, backend, mode, kpts, qpts, el_k_save;
             nw, nmodes, rng_band, el_states_kq, kqpts, nchunks_threads,
             sel_k, sel_kq, kwargs...)
     end

--- a/src/calculator/eph_setup_common.jl
+++ b/src/calculator/eph_setup_common.jl
@@ -7,25 +7,26 @@
 
 # k-side setup shared by all three drivers: obtain the outer-k selection (a prebuilt `FilteredStates`
 # passed through verbatim, or filtered from a grid to the energy window) and compute the electron
-# states there. `verbosity` selects timing (@time when > 0, via `maybe_time`); `el_k_quantities` lets
-# the outer-q GPU-batched path skip velocity/position. The prebuilt pass-through is dead for the two
+# states there. `backend` says where the eigensolves run (a non-CPU backend takes the batched device
+# path). `verbosity` selects timing (@time when > 0, via `maybe_time`); `el_k_quantities` lets
+# the outer-q batched path skip velocity/position. The prebuilt pass-through is dead for the two
 # grid-only sibling callers (they always pass a grid), so their behavior is unchanged.
 function _setup_electron_k(
         model :: Model, kpts_input;
-        window_k, mpi_comm_k, symmetry, fourier_mode, use_gpu = false, verbosity = 1,
+        window_k, mpi_comm_k, symmetry, fourier_mode, backend = CPUBackend(), verbosity = 1,
         el_k_quantities = ["eigenvalue", "eigenvector", "velocity", "position"],
     )
     (; nw) = model
     sel_k = kpts_input isa FilteredStates ? kpts_input :
         maybe_time(verbosity) do
-            filter_electron_states(kpts_input, nw, model.el_ham, window_k; symmetry, fourier_mode, use_gpu, mpi_comm=mpi_comm_k)
+            filter_electron_states(kpts_input, nw, model.el_ham, window_k; symmetry, fourier_mode, backend, mpi_comm=mpi_comm_k)
         end
     kpts = sel_k.kpts
     br = band_range(sel_k)
     iband_min, iband_max = first(br), last(br)
 
     el_k_save = maybe_time(verbosity) do
-        compute_electron_states(model, sel_k, el_k_quantities; fourier_mode, use_gpu)
+        compute_electron_states(model, sel_k, el_k_quantities; fourier_mode, backend)
     end
     (; kpts, iband_min, iband_max, el_k_save, sel_k)
 end
@@ -37,17 +38,17 @@ end
 # directly on `kqpts`. `kqpts_irr` / `ik_to_ikirr_isym_kq` are only read on the unfolding path.
 function _compute_electron_states_kq(
         model, kqpts, kqpts_irr, ik_to_ikirr_isym_kq, symmetry, el_kq_from_unfolding, window_kq;
-        quantities, fourier_mode, use_gpu = false, verbosity = 1,
+        quantities, fourier_mode, backend = CPUBackend(), verbosity = 1,
     )
     maybe_time(verbosity) do
         if el_kq_from_unfolding
             symmetry !== nothing || throw(ArgumentError("el_kq_from_unfolding = true requires symmetry"))
-            el_kq_save_irr = compute_electron_states(model, kqpts_irr, quantities, window_kq; fourier_mode, use_gpu)
+            el_kq_save_irr = compute_electron_states(model, kqpts_irr, quantities, window_kq; fourier_mode, backend)
             el_kq_save = unfold_ElectronStates(model, el_kq_save_irr, kqpts_irr, kqpts, ik_to_ikirr_isym_kq, symmetry; fourier_mode)
             # el_kq_save_irr is not used anymore.
             el_kq_save_irr !== el_kq_save && empty!(el_kq_save_irr)
         else
-            el_kq_save = compute_electron_states(model, kqpts, quantities, window_kq; fourier_mode, use_gpu)
+            el_kq_save = compute_electron_states(model, kqpts, quantities, window_kq; fourier_mode, backend)
         end
         el_kq_save
     end
@@ -67,14 +68,14 @@ end
 # to compute at k+q) is supplied by the caller.
 function _setup_electron_kq(model, kqpts_input;
         window_kq, mpi_comm_q, symmetry, el_kq_from_unfolding, el_kq_quantities,
-        fourier_mode, use_gpu = false, verbosity = 1)
+        fourier_mode, backend = CPUBackend(), verbosity = 1)
     (; nw) = model
 
     # (1) prebuilt full-BZ selection: consume as-is
     if kqpts_input isa FilteredStates
         sel_kq = kqpts_input
         el_kq_save = maybe_time(verbosity) do
-            compute_electron_states(model, sel_kq, el_kq_quantities; fourier_mode, use_gpu)
+            compute_electron_states(model, sel_kq, el_kq_quantities; fourier_mode, backend)
         end
         return (; kqpts = sel_kq.kpts, el_kq_save, sel_kq)
     end
@@ -83,7 +84,7 @@ function _setup_electron_kq(model, kqpts_input;
     if symmetry !== nothing
         sel_irr = maybe_time(verbosity) do
             filter_electron_states(kqpts_input, nw, model.el_ham, window_kq;
-                mpi_comm=mpi_comm_q, symmetry, fourier_mode, use_gpu)
+                mpi_comm=mpi_comm_q, symmetry, fourier_mode, backend)
         end
         nelec_kq = sel_irr.nstates_base
         kqpts, ik_to_ikirr_isym_kq = unfold_kpoints(sel_irr.kpts, symmetry)
@@ -91,7 +92,7 @@ function _setup_electron_kq(model, kqpts_input;
     else
         sel_kqf = maybe_time(verbosity) do
             filter_electron_states(kqpts_input, nw, model.el_ham, window_kq;
-                mpi_comm=mpi_comm_q, fourier_mode, use_gpu)
+                mpi_comm=mpi_comm_q, fourier_mode, backend)
         end
         kqpts = sel_kqf.kpts; nelec_kq = sel_kqf.nstates_base
         kqpts_irr, ik_to_ikirr_isym_kq = nothing, nothing
@@ -100,15 +101,18 @@ function _setup_electron_kq(model, kqpts_input;
     # (3) states: direct, or gauge-consistent IBZ→full unfolding (the one genuinely special path)
     el_kq_save = _compute_electron_states_kq(model, kqpts, kqpts_irr, ik_to_ikirr_isym_kq,
         symmetry, el_kq_from_unfolding, window_kq;
-        quantities=el_kq_quantities, fourier_mode, use_gpu, verbosity)
+        quantities=el_kq_quantities, fourier_mode, backend, verbosity)
     sel_kq = electron_states_to_FilteredStates(kqpts, el_kq_save, nelec_kq; nw)
     return (; kqpts, el_kq_save, sel_kq)
 end
 
 
 # setup_calculator! fan-out shared by all three drivers. The common keyword payload (band range,
-# k+q states/grid, carrier counts, thread chunking) is passed explicitly; driver-specific extras
-# (backend / verbosity) forward through `kwargs`.
+# k+q states/grid, carrier counts, thread chunking) is passed explicitly; the rest (`backend`, the
+# loop-shape `mode`, `verbosity`) forwards through `kwargs`. Every driver supplies `backend` and
+# `mode`: a calculator that keys off the loop shape reads `mode` (`SingleMode()`/`BatchedMode()`),
+# the same vocabulary its `calculator_begin!/end!` brackets dispatch on, because the backend alone
+# cannot say (batched-on-CPUBackend is a valid configuration).
 function _setup_calculators!(
         calculators, kpts, qpts, el_k_save;
         nw, nmodes, rng_band, el_states_kq, kqpts, nchunks_threads,

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -272,13 +272,14 @@ function _setup_eph_over_k_and_kq(
 
     # Initialize calculators. `sel_k`/`sel_kq` carry the per-state weights, per-k band extent, and
     # `nstates_base`, so the calculator builds `el_i`/`el_f` (and the auto-μ carrier count) from the
-    # selection rather than from a below-window override. `mode` tells each calculator which loop
-    # shape it is being set up for, in the same vocabulary the `calculator_begin!/end!` brackets
-    # dispatch on — the backend alone cannot say (CPU+batched is a valid configuration).
-    _setup_calculators!(calculators, kpts, qpts, el_k_save;
+    # selection rather than from a below-window override. `backend` and `mode` are positional: `mode`
+    # tells each calculator which loop shape it is being set up for, in the same vocabulary the
+    # `calculator_begin!/end!` brackets dispatch on — the backend alone cannot say (CPU+batched is a
+    # valid configuration).
+    _setup_calculators!(calculators, backend, batched ? BatchedMode() : SingleMode(),
+        kpts, qpts, el_k_save;
         nw, nmodes, rng_band = iband_min:iband_max, el_states_kq = el_kq_save, kqpts,
-        sel_k, sel_kq, nchunks_threads, verbosity, backend,
-        mode = batched ? BatchedMode() : SingleMode(),
+        sel_k, sel_kq, nchunks_threads, verbosity,
     )
 
     if verbosity > 0 && mpi_isroot()

--- a/src/calculator/run_eph_over_k_and_kq.jl
+++ b/src/calculator/run_eph_over_k_and_kq.jl
@@ -1,3 +1,22 @@
+"""
+    run_eph_over_k_and_kq(model, kpts, kqpts; calculators, backend, batched, kwargs...)
+
+Sweep the outer k points and, for each, the inner k+q points, handing each calculator the e-ph
+coupling. Two keywords select where the arrays live and which payload the calculators receive:
+
+* `backend :: AbstractBackend = CPUBackend()` — array placement. Pass
+  `backend = ElectronPhonon.gpu_backend()` for a GPU run (requires a loaded GPU extension, e.g. CUDA).
+* `batched :: Union{Nothing, Bool} = nothing` — payload/loop shape: the per-(k,q) host
+  [`EPData`](@ref) (`false`) or the batched [`EPDataQBatched`](@ref) (`true`). `nothing` derives it
+  from `backend` (batched on any non-CPU backend), so a production GPU run passes `backend` alone and
+  a production CPU run passes neither. An explicit `batched = false` on a GPU backend is an
+  `ArgumentError`; `batched = true` on a `CPUBackend` is a validation configuration (the batched loop
+  on host arrays — serial and unoptimized, see the notice it prints at `verbosity > 0`).
+
+The batched path has a narrower scope than the per-point one (no polar/long-range, no screening,
+`energy_conservation = (:None, 0.0)`, commensurate grids, no `covariant_derivative_of_g`, no
+`skip_eph`, no `el_kq_from_unfolding` under symmetry); it asserts each of these.
+"""
 function run_eph_over_k_and_kq(
         model       :: Model{FT},
         kpts_input  :: Union{NTuple{3,Int}, Kpoints, GridKpoints, FilteredStates},
@@ -17,9 +36,10 @@ function run_eph_over_k_and_kq(
         progress_print_step = 20,
         nchunks_threads = nthreads(),  # Number of chunks for multithreading
         covariant_derivative_of_g = false,  # Compute cov. derivative of g
-        use_gpu = false,   # Run the e-ph Wannier->Bloch interpolation on the GPU
-        nq_batch_max = nothing,  # GPU: k+q points per batched kR->kq kernel (nothing = all k+q in one batch)
-        # GPU: number of outer k points per batched RR->kR kernel + D2H tile extent. Calculators still
+        backend :: AbstractBackend = CPUBackend(),   # Where arrays live (gpu_backend() for a GPU run)
+        batched :: Union{Nothing, Bool} = nothing,   # Payload/loop shape (nothing = derive from `backend`)
+        nq_batch_max = nothing,  # Batched: k+q points per batched kR->kq kernel (nothing = all k+q in one batch)
+        # Batched: number of outer k points per batched RR->kR kernel + D2H tile extent. Calculators still
         # see one payload per outer k, but a k's q-tiles are no longer contiguous (the q-tile loop is
         # outside the k loop) and only the `OuterIterationBatch` bracket is fired; this also sets how
         # many outer k reuse one kR->kq phase tile. No deprecated alias for the former `nk_batch_max`.
@@ -33,19 +53,32 @@ function run_eph_over_k_and_kq(
     screening_params === nothing || error(
         "screening_params is not supported: dielectric screening is currently disabled (ϵ ≡ 1). " *
         "Pass screening_params = nothing.")
+
+    # Resolve the loop shape once, here: `nothing` derives it from the backend (there is exactly one
+    # sensible shape per backend), so nothing below this entry ever sees anything but a `Bool`. An
+    # EXPLICIT `batched = false` on a GPU backend is an error rather than silently overridden.
+    batched_resolved = batched === nothing ? !(backend isa CPUBackend) : batched
+    (backend isa CPUBackend || batched_resolved) || throw(ArgumentError(
+        "batched = false is not supported on a GPU backend: the per-(k,q) host `EPData` payload " *
+        "cannot be built from device arrays. Pass backend = CPUBackend() for the per-point path."))
+    if batched_resolved && backend isa CPUBackend && verbosity > 0 && mpi_isroot()
+        @info "batched e-ph loop on CPUBackend: validation configuration (serial, unoptimized); " *
+              "omit `batched` for production CPU runs."
+    end
+
     for calc in calculators
         if !supports(calc, OuterKLoop)
             throw(ArgumentError("$calc does not support the outer-k loop. Use run_eph_over_q_and_k instead."))
         end
-        # CPU path hands each calculator the per-(k,q) host `EPData`; the GPU path hands the device
-        # `EPDataQBatched`. Fail fast up front (before the expensive device upload / state setup),
-        # symmetric with the CPU check, rather than only inside `_loop_eph_over_k_and_kq_gpu`.
-        if !use_gpu && !supports(calc, EPData)
+        # The per-point path hands each calculator the per-(k,q) host `EPData`; the batched path hands
+        # `EPDataQBatched`. Fail fast up front (before the expensive device upload / state setup)
+        # rather than only inside `_loop_eph_over_k_and_kq_batched`.
+        if !batched_resolved && !supports(calc, EPData)
             throw(ArgumentError("$calc does not declare support for the per-(k,q) host payload; " *
                 "define supports(::$(typeof(calc)), ::Type{EPData}) = true."))
         end
-        if use_gpu && !supports(calc, EPDataQBatched)
-            throw(ArgumentError("$calc does not declare support for the GPU outer-k batched payload; " *
+        if batched_resolved && !supports(calc, EPDataQBatched)
+            throw(ArgumentError("$calc does not declare support for the outer-k batched payload; " *
                 "define supports(::$(typeof(calc)), ::Type{EPDataQBatched}) = true."))
         end
     end
@@ -61,12 +94,14 @@ function run_eph_over_k_and_kq(
         "mpi_comm_k requires el_kq_from_unfolding = false (k+q stays full per rank; the unfolding " *
         "path is not split-aware)."))
 
-    # Symmetry (IBZ outer k) is supported on the GPU path, but only with directly-computed k+q
-    # (el_kq_from_unfolding = false): the IBZ reduction happens in the shared setup and the GPU loop
-    # is symmetry-agnostic (validated: filter/states/scatter match CPU). GPU unfolding of the k+q
-    # electron states is not implemented. Checked before setup so the unfolding branch is not entered.
-    (!use_gpu || symmetry === nothing || !el_kq_from_unfolding) || throw(ArgumentError(
-        "use_gpu supports symmetry only with el_kq_from_unfolding = false (GPU k+q unfolding not implemented)."))
+    # Symmetry (IBZ outer k) is supported on the batched path, but only with directly-computed k+q
+    # (el_kq_from_unfolding = false): the IBZ reduction happens in the shared setup and the batched
+    # loop is symmetry-agnostic (validated: filter/states/scatter match the per-point path). Unfolding
+    # of the k+q electron states is not implemented there. Checked before setup so the unfolding
+    # branch is not entered.
+    (!batched_resolved || symmetry === nothing || !el_kq_from_unfolding) || throw(ArgumentError(
+        "the batched path supports symmetry only with el_kq_from_unfolding = false " *
+        "(batched k+q unfolding not implemented)."))
 
     # A prebuilt k+q FilteredStates is consumed as-is (the caller already built the full-BZ selection,
     # e.g. via unfold_band_states), so the internal IBZ+unfold path does not run — el_kq_from_unfolding
@@ -78,15 +113,16 @@ function run_eph_over_k_and_kq(
     setup = _setup_eph_over_k_and_kq(model, kpts_input, kqpts_input;
         mpi_comm_k, mpi_comm_q, fourier_mode, window_k, window_kq,
         el_kq_from_unfolding, symmetry, calculators, nchunks_threads,
-        covariant_derivative_of_g, use_gpu, verbosity,
+        covariant_derivative_of_g, backend, batched = batched_resolved, verbosity,
     )
 
-    if use_gpu
-        # GPU path: minimal scope. Extra flags must be off; the loop asserts the
-        # rest (no polar, full bands, commensurate grids, no symmetry/screening/MPI).
-        covariant_derivative_of_g && throw(ArgumentError("use_gpu does not support covariant_derivative_of_g"))
-        skip_eph && throw(ArgumentError("use_gpu requires skip_eph = false"))
-        _loop_eph_over_k_and_kq_gpu(model,
+    if batched_resolved
+        # Batched path: minimal scope. Extra flags must be off; the loop asserts the
+        # rest (no polar, full bands, commensurate grids, no screening).
+        covariant_derivative_of_g && throw(ArgumentError(
+            "the batched path does not support covariant_derivative_of_g"))
+        skip_eph && throw(ArgumentError("the batched path requires skip_eph = false"))
+        _loop_eph_over_k_and_kq_batched(model,
             setup.kpts, setup.qpts, setup.kqpts,
             setup.el_k_save, setup.el_kq_save,
             setup.ph_save, setup.precompute_ph,
@@ -132,7 +168,8 @@ function _setup_eph_over_k_and_kq(
         calculators = [],
         nchunks_threads = nthreads(),
         covariant_derivative_of_g = false,
-        use_gpu = false,
+        backend :: AbstractBackend = CPUBackend(),
+        batched :: Bool = false,
         verbosity::Int = 1,
     ) where {FT}
 
@@ -143,13 +180,13 @@ function _setup_eph_over_k_and_kq(
     # IBZ-reduces + unfolds under symmetry) plus its `kpts` and computed electron states. Same calls,
     # same order as the prior inline block.
     (; kpts, iband_min, iband_max, el_k_save, sel_k) = _setup_electron_k(model, kpts_input;
-        window_k, mpi_comm_k, symmetry, fourier_mode, use_gpu, verbosity)
+        window_k, mpi_comm_k, symmetry, fourier_mode, backend, verbosity)
     nk = kpts.n
 
     el_kq_quantities = ["eigenvalue", "eigenvector", "velocity", "position"]
     (; kqpts, el_kq_save, sel_kq) = _setup_electron_kq(model, kqpts_input;
         window_kq, mpi_comm_q, symmetry, el_kq_from_unfolding, el_kq_quantities,
-        fourier_mode, use_gpu, verbosity)
+        fourier_mode, backend, verbosity)
 
 
     # Precompute qpts and phonon states if k and k+q meshes are commensurate
@@ -177,9 +214,9 @@ function _setup_eph_over_k_and_kq(
                     maximum(el.nband for el in el_kq_save))
 
 
-    # The CPU loop takes/puts one EPState buffer per thread; the GPU loop is device-batched and
-    # never touches epstate, so it does not allocate the (nw, nmodes, nband_max) thread buffers.
-    epstates = use_gpu ? nothing : get_epstates_channel(FT, nw, nmodes, nband_max)
+    # The per-point loop takes/puts one EPState buffer per thread; the batched loop never touches
+    # epstate, so it does not allocate the (nw, nmodes, nband_max) thread buffers.
+    epstates = batched ? nothing : get_epstates_channel(FT, nw, nmodes, nband_max)
 
     # E-ph matrix in electron Bloch, phonon Wannier representation
     ep_ekpR_obj = get_next_wannier_object(model.epmat)
@@ -217,7 +254,7 @@ function _setup_eph_over_k_and_kq(
     # Precompute phonon states if precompute_ph == true
     if precompute_ph
         ph_save = maybe_time(verbosity) do
-            compute_phonon_states(model, qpts, ["eigenvalue", "eigenvector", "velocity_diagonal", "eph_dipole_coeff"]; fourier_mode, use_gpu)
+            compute_phonon_states(model, qpts, ["eigenvalue", "eigenvector", "velocity_diagonal", "eph_dipole_coeff"]; fourier_mode, backend)
         end
         dyn_threads = nothing
     else
@@ -227,19 +264,21 @@ function _setup_eph_over_k_and_kq(
     end
 
 
-    # Backend: one resolution point (`gpu_backend()` carries an empty device-array allocation
-    # template used by `alloc(backend, …)` / `similar(backend.proto, …)`). `model.epmat` is uploaded
-    # ONCE here — a separate device object that `_loop_eph_over_k_and_kq_gpu` reuses rather than
-    # re-uploading. `backend` is carried in `LoopContext` and passed to `setup_calculator!`.
-    backend = use_gpu ? gpu_backend() : CPUBackend()
-    epmat_dev = use_gpu ? to_device(backend, model.epmat) : nothing
+    # `model.epmat` is uploaded to the backend ONCE here — a separate device object that
+    # `_loop_eph_over_k_and_kq_batched` reuses rather than re-uploading. On a `CPUBackend`
+    # `to_device` is the identity (`common/gpu_utils.jl`), so `epmat_dev === model.epmat`.
+    # `backend` is carried in `LoopContext` and passed to `setup_calculator!`.
+    epmat_dev = batched ? to_device(backend, model.epmat) : nothing
 
     # Initialize calculators. `sel_k`/`sel_kq` carry the per-state weights, per-k band extent, and
     # `nstates_base`, so the calculator builds `el_i`/`el_f` (and the auto-μ carrier count) from the
-    # selection rather than from a below-window override.
+    # selection rather than from a below-window override. `mode` tells each calculator which loop
+    # shape it is being set up for, in the same vocabulary the `calculator_begin!/end!` brackets
+    # dispatch on — the backend alone cannot say (CPU+batched is a valid configuration).
     _setup_calculators!(calculators, kpts, qpts, el_k_save;
         nw, nmodes, rng_band = iband_min:iband_max, el_states_kq = el_kq_save, kqpts,
         sel_k, sel_kq, nchunks_threads, verbosity, backend,
+        mode = batched ? BatchedMode() : SingleMode(),
     )
 
     if verbosity > 0 && mpi_isroot()
@@ -475,22 +514,29 @@ end
 
 
 # =============================================================================
-#  GPU calculator loop (see README_GPU.md).
+#  Batched calculator loop (see README_GPU.md).
 #
 #  This mirrors `_loop_eph_over_k_and_kq` but moves the e-ph Wannier->Bloch interpolation
-#  onto the device using the batched drivers from `wannier_to_bloch_batched.jl`. The code here is
+#  onto the backend using the batched drivers from `wannier_to_bloch_batched.jl`. The code here is
 #  backend-generic: it only calls `to_device` and the generic batched drivers, so no CUDA
 #  code lives in the base package (the device methods are provided by the CUDA extension). It
-#  is a separate function from the CPU `_loop_eph_over_k_and_kq` because its control flow —
-#  batched over k-batches and q-batches with device staging — differs from the per-(k,q) CPU loop,
+#  is a separate function from `_loop_eph_over_k_and_kq` because its control flow —
+#  batched over k-batches and q-batches with device staging — differs from the per-(k,q) loop,
 #  not because it holds any device-specific code.
+#
+#  Backend: `GPUBackend` is the production configuration. Because nothing here is device-specific,
+#  the loop also runs on `CPUBackend` (`batched = true`), which is a VALIDATION configuration only:
+#  the k-batch loop is serial, `batched_gemm!` degrades to a `mul!` loop, and `plan_batch` returns
+#  the requested cap verbatim (`free_bytes(::CPUBackend) == typemax(Int)`), so pass a small
+#  `nq_batch_max` there. Naming: the `_dev` suffix on the locals below means "on `backend`", which
+#  is the host under `CPUBackend()`.
 #
 #  Supported (all handled upstream in the shared `_setup`, so this loop itself is agnostic to them):
 #    * energy windows (window_k / window_kq): the k side carries only its in-window bands, the
 #      window is applied in the calculator scatter
 #    * IBZ outer-k symmetry
 #    * outer-k MPI decomposition (mpi_comm_k)
-#  Not supported — asserted off on the GPU path (see the scope-assert block below):
+#  Not supported — asserted off on the batched path (see the scope-assert block below):
 #    * polar / long-range terms
 #    * incommensurate k / k+q grids: requires precompute_ph (phonon states precomputed)
 #    * covariant derivative of g
@@ -534,7 +580,7 @@ function _fill_iqs!(iqs, qpts, xkqs_int, xks_int, ik, qstart, nq)
     iqs
 end
 
-function _loop_eph_over_k_and_kq_gpu(
+function _loop_eph_over_k_and_kq_batched(
         model       :: Model{FT},
         kpts, qpts, kqpts,
         el_k_save, el_kq_save,
@@ -554,14 +600,16 @@ function _loop_eph_over_k_and_kq_gpu(
     nk = kpts.n
     nkq = kqpts.n
 
-    # ----- scope asserts (minimal GPU step) -----
+    # ----- scope asserts (minimal batched step) -----
     precompute_ph || throw(ArgumentError(
-        "use_gpu requires commensurate k / k+q grids so phonon states are precomputed (precompute_ph)."))
+        "the batched path requires commensurate k / k+q grids so phonon states are precomputed (precompute_ph)."))
     (!model.polar_phonon.use && !model.polar_eph.use) || throw(ArgumentError(
-        "use_gpu does not support polar / long-range terms. Use the CPU path."))
+        "the batched path does not support polar / long-range terms. Use the per-point path " *
+        "(backend = CPUBackend(), batched = false)."))
     energy_conservation === (:None, 0.0) || throw(ArgumentError(
-        "use_gpu supports only energy_conservation = (:None, 0.0)."))
-    screening_params === nothing || throw(ArgumentError("use_gpu does not support screening_params."))
+        "the batched path supports only energy_conservation = (:None, 0.0)."))
+    screening_params === nothing || throw(ArgumentError(
+        "the batched path does not support screening_params."))
     # symmetry (IBZ outer k) is allowed: the reduction is done in the shared setup and this loop is
     # symmetry-agnostic — `symmetry` is only passed through to `postprocess_calculator!`. The
     # dispatcher gates the unsupported el_kq_from_unfolding = true case.
@@ -575,15 +623,15 @@ function _loop_eph_over_k_and_kq_gpu(
     nq_batch_user = nq_batch_max   # nothing = size to memory (capped at nkq); Int = hard upper cap
     nk_batch_max = min(nk_outer_batch_max, nk)
 
-    # The GPU path is always device-native/batched: the e-ph matrix for a whole (k, {k+q}) batch
-    # stays on the device and each calculator does its reduction/scatter there (no per-(k,q) host
-    # callback, no host g2, no complex-ep D2H). Every calculator must therefore implement the
-    # batched device hook; a non-batched calculator fails loudly rather than silently falling back
-    # to a slow host path — a hard-to-spot performance cliff (see README_GPU.md "Decisions").
-    isempty(calculators) && throw(ArgumentError("use_gpu requires at least one calculator."))
+    # The batched path keeps the e-ph matrix for a whole (k, {k+q}) batch on the backend and each
+    # calculator does its reduction/scatter there (no per-(k,q) host callback, no host g2, no
+    # complex-ep D2H). Every calculator must therefore implement the batched hook; a non-batched
+    # calculator fails loudly rather than silently falling back to a slow per-point path — a
+    # hard-to-spot performance cliff (see README_GPU.md "Decisions").
+    isempty(calculators) && throw(ArgumentError("the batched path requires at least one calculator."))
     all(c -> supports(c, EPDataQBatched), calculators) || throw(ArgumentError(
-        "use_gpu requires every calculator to support the EPDataQBatched payload " *
-        "(supports(calc, EPDataQBatched) = true); the GPU path does not fall back to the host loop."))
+        "the batched path requires every calculator to support the EPDataQBatched payload " *
+        "(supports(calc, EPDataQBatched) = true); it does not fall back to the per-point loop."))
 
     # The k+q side of the interpolation runs full-band (uniform nw×nw, using the full eigenvectors
     # `el.u_full`); the energy window is applied in the calculator scatter, where out-of-window
@@ -632,7 +680,7 @@ function _loop_eph_over_k_and_kq_gpu(
     nq_batch_cap = nq_batch_user === nothing ? nkq : min(nq_batch_user, nkq)
     nq_batch_max = plan_batch(backend, per_point, committed, nq_batch_cap; what = "outer-k")
     if verbosity > 0 && mpi_isroot()
-        @info "GPU outer-k device memory: committed = $(round(committed / 1e9, digits = 2)) GB, " *
+        @info "batched outer-k staging: committed = $(round(committed / 1e9, digits = 2)) GB, " *
               "$(round(per_point / 1e3, digits = 1)) kB/q; q-batch size = $nq_batch_max"
     end
 
@@ -671,8 +719,8 @@ function _loop_eph_over_k_and_kq_gpu(
     # collect the full q-grid stacks on the host and copy to the device once, then gather per
     # batch on the device by index (below).
     # TODO: these two are the only fields of `ph_save` this loop ever reads, and
-    # `_compute_phonon_states_gpu!` built them on the device before scattering them into per-q
-    # `PhononState`s — so this gather + H2D undoes a D2H. Have the setup hand `use_gpu` the device
+    # `_compute_phonon_states_device!` built them on the device before scattering them into per-q
+    # `PhononState`s — so this gather + H2D undoes a D2H. Have the setup hand this loop the device
     # stacks directly and drop this block; see the TODO at `_scatter_phonon_states!`.
     uph_all_dev = alloc(backend, Complex{FT}, nmodes, nmodes, qpts.n)
     ωq_all_dev  = alloc(backend, FT, nmodes, qpts.n)

--- a/src/calculator/run_eph_over_k_and_q.jl
+++ b/src/calculator/run_eph_over_k_and_q.jl
@@ -33,10 +33,12 @@ function run_eph_over_k_and_q(
         progress_print_step = 20,
         symmetry = model.symmetry,
         nchunks_threads = nthreads(),  # Number of chunks for multithreading
-        # This driver has no batched path, so the only backend it accepts is the CPU one. The kwarg
-        # exists (and is validated rather than ignored) so all three e-ph drivers take the same
-        # vocabulary and a caller sweeping over drivers cannot silently get a host run.
+        # This driver has no batched path, so it accepts only the CPU backend and only the per-point
+        # loop shape. Both kwargs exist, and are VALIDATED rather than ignored, so all three e-ph
+        # drivers take the same vocabulary and a caller sweeping over drivers cannot silently get a
+        # host / per-point run where it asked for something else.
         backend :: AbstractBackend = CPUBackend(),
+        batched :: Union{Nothing, Bool} = nothing,
         verbosity::Int = 1,
     ) where {FT}
 
@@ -46,6 +48,10 @@ function run_eph_over_k_and_q(
     backend isa CPUBackend || throw(ArgumentError(
         "run_eph_over_k_and_q has no batched path and supports backend = CPUBackend() only. " *
         "Use run_eph_over_k_and_kq (outer-k) or run_eph_over_q_and_k (outer-q) for a GPU run."))
+    batched === true && throw(ArgumentError(
+        "run_eph_over_k_and_q has no batched loop; it only hands calculators the per-(k,q) host " *
+        "`EPData`. Pass batched = nothing (or false), or use run_eph_over_k_and_kq / " *
+        "run_eph_over_q_and_k, which do have one."))
     screening_params === nothing || error(
         "screening_params is not supported: dielectric screening is currently disabled (ϵ ≡ 1). " *
         "Pass screening_params = nothing.")

--- a/src/calculator/run_eph_over_k_and_q.jl
+++ b/src/calculator/run_eph_over_k_and_q.jl
@@ -33,12 +33,19 @@ function run_eph_over_k_and_q(
         progress_print_step = 20,
         symmetry = model.symmetry,
         nchunks_threads = nthreads(),  # Number of chunks for multithreading
+        # This driver has no batched path, so the only backend it accepts is the CPU one. The kwarg
+        # exists (and is validated rather than ignored) so all three e-ph drivers take the same
+        # vocabulary and a caller sweeping over drivers cannot silently get a host run.
+        backend :: AbstractBackend = CPUBackend(),
         verbosity::Int = 1,
     ) where {FT}
 
     if model.epmat_outer_momentum != "el"
         throw(ArgumentError("model.epmat_outer_momentum must be el to use run_eph_over_k_and_q"))
     end
+    backend isa CPUBackend || throw(ArgumentError(
+        "run_eph_over_k_and_q has no batched path and supports backend = CPUBackend() only. " *
+        "Use run_eph_over_k_and_kq (outer-k) or run_eph_over_q_and_k (outer-q) for a GPU run."))
     screening_params === nothing || error(
         "screening_params is not supported: dielectric screening is currently disabled (ϵ ≡ 1). " *
         "Pass screening_params = nothing.")
@@ -193,13 +200,14 @@ function _setup_eph_over_k_and_q(
         @info "Number of q points = $nq"
     end
 
-    # Backend: one resolution point. This driver has no GPU loop, so it is always the CPU backend;
-    # it is carried in `LoopContext` and passed to `setup_calculator!` for interface uniformity.
+    # This driver has no batched loop, so the backend is always the CPU one (the entry rejects any
+    # other) and the loop shape is always per-point; both are carried in `LoopContext` and passed to
+    # `setup_calculator!` for interface uniformity across the three drivers.
     backend = CPUBackend()
 
     _setup_calculators!(calculators, kpts, qpts, el_k_save;
         nw, nmodes, rng_band = iband_min:iband_max, el_states_kq = el_kq_save, kqpts,
-        sel_k, sel_kq, nchunks_threads, verbosity, backend,
+        sel_k, sel_kq, nchunks_threads, verbosity, backend, mode = SingleMode(),
     )
 
     return (;

--- a/src/calculator/run_eph_over_k_and_q.jl
+++ b/src/calculator/run_eph_over_k_and_q.jl
@@ -211,9 +211,9 @@ function _setup_eph_over_k_and_q(
     # `setup_calculator!` for interface uniformity across the three drivers.
     backend = CPUBackend()
 
-    _setup_calculators!(calculators, kpts, qpts, el_k_save;
+    _setup_calculators!(calculators, backend, SingleMode(), kpts, qpts, el_k_save;
         nw, nmodes, rng_band = iband_min:iband_max, el_states_kq = el_kq_save, kqpts,
-        sel_k, sel_kq, nchunks_threads, verbosity, backend, mode = SingleMode(),
+        sel_k, sel_kq, nchunks_threads, verbosity,
     )
 
     return (;

--- a/src/calculator/run_eph_over_q_and_k.jl
+++ b/src/calculator/run_eph_over_q_and_k.jl
@@ -261,10 +261,10 @@ function _setup_eph_over_q_and_k(
     # the device via `backend.proto` (the bisection sweeps all in-window states many times and
     # dominates the setup at dense grids); the generic `compute_ncarrier` broadcast+sum works for
     # every occ_type on the device, so no occ_type is special-cased.
-    _setup_calculators!(calculators, kpts, qpts, el_k_save;
+    _setup_calculators!(calculators, backend, batched ? BatchedMode() : SingleMode(),
+        kpts, qpts, el_k_save;
         nw, nmodes, rng_band = iband_min:iband_max, el_states_kq = el_kq_save, kqpts,
-        sel_k, sel_kq, nchunks_threads, verbosity, backend,
-        mode = batched ? BatchedMode() : SingleMode(),
+        sel_k, sel_kq, nchunks_threads, verbosity,
     )
 
     return (;

--- a/src/calculator/run_eph_over_q_and_k.jl
+++ b/src/calculator/run_eph_over_q_and_k.jl
@@ -8,7 +8,17 @@ using OffsetArrays: no_offset_view
 
 
 """
-    run_eph_over_q_and_k(model, kpts, qpts; calculators, kwargs...)
+    run_eph_over_q_and_k(model, kpts, qpts; calculators, backend, batched, kwargs...)
+
+Sweep the outer q points and, for each, the inner k points. `backend` and `batched` mean exactly what
+they do in [`run_eph_over_k_and_kq`](@ref):
+
+* `backend :: AbstractBackend = CPUBackend()` — array placement
+  (`backend = ElectronPhonon.gpu_backend()` for a GPU run).
+* `batched :: Union{Nothing, Bool} = nothing` — payload/loop shape: the per-(k,q) host
+  [`EPData`](@ref) (`false`) or the batched [`EPDataKBatched`](@ref) (`true`). `nothing` derives it
+  from `backend`. An explicit `batched = false` on a GPU backend is an `ArgumentError`;
+  `batched = true` on a `CPUBackend` is a validation configuration.
 
 * `el_kq_from_unfolding`: If true, compute the electron states at k+q by computing the
     states at k+q in the irreducible BZ and unfolding them to the full BZ. This is useful to
@@ -38,8 +48,9 @@ function run_eph_over_q_and_k(
         eph_phonon_basis::Symbol = :eigenmode,  # :eigenmode or :cartesian
         verbosity::Int = 1,
         eph_buffers::Union{Nothing, EphOuterQLoopBuffers} = nothing,
-        use_gpu = false,          # Run the inner-k e-ph interpolation + calculator on the GPU
-        nk_batch_max = 2^15,      # GPU: max number of outer k points processed per batch
+        backend :: AbstractBackend = CPUBackend(),   # Where arrays live (gpu_backend() for a GPU run)
+        batched :: Union{Nothing, Bool} = nothing,   # Payload/loop shape (nothing = derive from `backend`)
+        nk_batch_max = 2^15,      # Batched: max number of outer k points processed per batch
     ) where {FT}
 
     if model.epmat_outer_momentum != "ph"
@@ -48,13 +59,25 @@ function run_eph_over_q_and_k(
     screening_params === nothing || error(
         "screening_params is not supported: dielectric screening is currently disabled (ϵ ≡ 1). " *
         "Pass screening_params = nothing.")
+    # Resolve the loop shape once, here (see `run_eph_over_k_and_kq` for the full rationale):
+    # `nothing` derives it from the backend, and an EXPLICIT `batched = false` on a GPU backend is an
+    # error rather than silently overridden. Nothing below this entry sees anything but a `Bool`.
+    batched_resolved = batched === nothing ? !(backend isa CPUBackend) : batched
+    (backend isa CPUBackend || batched_resolved) || throw(ArgumentError(
+        "batched = false is not supported on a GPU backend: the per-(k,q) host `EPData` payload " *
+        "cannot be built from device arrays. Pass backend = CPUBackend() for the per-point path."))
+    if batched_resolved && backend isa CPUBackend && verbosity > 0 && mpi_isroot()
+        @info "batched e-ph loop on CPUBackend: validation configuration (serial, unoptimized); " *
+              "omit `batched` for production CPU runs."
+    end
+
     for calc in calculators
         if !supports(calc, OuterQLoop)
             throw(ArgumentError("$calc does not support the outer-q loop. Use run_eph_over_k_and_q instead."))
         end
-        # CPU path hands each calculator the per-(k,q) host `EPData`; it must declare support.
-        # The GPU path uses `EPDataKBatched` (checked in `_loop_eph_over_q_and_k_gpu`).
-        if !use_gpu && !supports(calc, EPData)
+        # The per-point path hands each calculator the per-(k,q) host `EPData`; it must declare
+        # support. The batched path uses `EPDataKBatched` (checked in `_loop_eph_over_q_and_k_batched`).
+        if !batched_resolved && !supports(calc, EPData)
             throw(ArgumentError("$calc does not declare support for the per-(k,q) host payload; " *
                 "define supports(::$(typeof(calc)), ::Type{EPData}) = true."))
         end
@@ -81,17 +104,17 @@ function run_eph_over_q_and_k(
         mpi_comm_k, mpi_comm_q, fourier_mode, window_k, window_kq,
         el_kq_from_unfolding, precompute_el_kq, use_symmetry,
         keep_all_qpts, eph_phonon_basis, calculators, nchunks_threads,
-        verbosity, eph_buffers, use_gpu,
+        verbosity, eph_buffers, backend, batched = batched_resolved,
     )
 
-    if use_gpu
-        # GPU path: setup stays on the host (filter/states/setup_calculator!); the inner-k e-ph
-        # interpolation, k+q eigensolve, and calculator reduction run on the device. Extra flags
-        # must be off; `_loop_eph_over_q_and_k_gpu` asserts the rest (no polar/screening, full-band via
-        # window masking, directly-computed k+q, energy_conservation = (:None, 0.0)).
+    if batched_resolved
+        # Batched path: setup stays on the host (filter/states/setup_calculator!); the inner-k e-ph
+        # interpolation, k+q eigensolve, and calculator reduction run on the backend. Extra flags
+        # must be off; `_loop_eph_over_q_and_k_batched` asserts the rest (no polar/screening, full-band
+        # via window masking, directly-computed k+q, energy_conservation = (:None, 0.0)).
         precompute_el_kq && throw(ArgumentError(
-            "use_gpu does not support precompute_el_kq (k+q states are eigensolved on the device)."))
-        _loop_eph_over_q_and_k_gpu(model,
+            "the batched path does not support precompute_el_kq (k+q states are eigensolved in the loop)."))
+        _loop_eph_over_q_and_k_batched(model,
             setup.kpts, setup.qpts,
             setup.el_k_save, setup.ph_save, setup.eph_buffers,
             setup.el_ham_dev, setup.backend;
@@ -137,22 +160,24 @@ function _setup_eph_over_q_and_k(
         nchunks_threads = nthreads(),
         verbosity::Int = 1,
         eph_buffers::Union{Nothing, EphOuterQLoopBuffers} = nothing,
-        use_gpu = false,
+        backend :: AbstractBackend = CPUBackend(),
+        batched :: Bool = false,
     ) where {FT}
 
     (; nw, nmodes) = model
 
     symmetry = use_symmetry ? model.symmetry : nothing
 
-    # Generate k points and electron states at k (shared setup core; use_gpu: batched device
-    # eigensolve for the window test). Each calculator declares the k-side quantities it needs via
+    # Generate k points and electron states at k (shared setup core; a non-CPU backend takes the
+    # batched device eigensolve for the window test). Each calculator declares the k-side quantities
+    # it needs via
     # `required_el_k_quantities`; the driver computes the union, so a calculator that only reads
     # eigenvalues/eigenvectors skips the velocity/position interpolation+rotation (the dominant
     # setup cost after the eigensolve). Default is the conservative full list.
     el_k_quantities = isempty(calculators) ? ["eigenvalue", "eigenvector", "velocity", "position"] :
         unique(reduce(vcat, required_el_k_quantities(c) for c in calculators))
     (; kpts, iband_min, iband_max, el_k_save, sel_k) = _setup_electron_k(
-        model, kpts_input; window_k, mpi_comm_k, symmetry, fourier_mode, use_gpu, verbosity, el_k_quantities)
+        model, kpts_input; window_k, mpi_comm_k, symmetry, fourier_mode, backend, verbosity, el_k_quantities)
     nk = kpts.n
 
     # Generate q points
@@ -225,21 +250,21 @@ function _setup_eph_over_q_and_k(
     end
 
 
-    # Backend: one resolution point (`gpu_backend()` carries an empty device-array allocation
-    # template; `alloc(backend, …)` / `similar(backend.proto, …)` use it). `model.el_ham` is uploaded
-    # ONCE here (for the k+q eigensolve in the loop), reused rather than re-uploaded — a separate
-    # device object from the backend. `backend` is carried in `LoopContext` and passed to `setup_calculator!`.
-    backend = use_gpu ? gpu_backend() : CPUBackend()
-    el_ham_dev = use_gpu ? to_device(backend, model.el_ham) : nothing
+    # `model.el_ham` is uploaded to the backend ONCE here (for the k+q eigensolve in the loop),
+    # reused rather than re-uploaded. On a `CPUBackend` `to_device` is the identity
+    # (`common/gpu_utils.jl`), so `el_ham_dev === model.el_ham`. `backend` is carried in
+    # `LoopContext` and passed to `setup_calculator!`.
+    el_ham_dev = batched ? to_device(backend, model.el_ham) : nothing
 
     # Chemical potential is solved inside each calculator's `setup_calculator!` (via
-    # `set_chemical_potential!`), not here. On the GPU path a calculator can run its ncarrier sums on
+    # `set_chemical_potential!`), not here. On a GPU backend a calculator can run its ncarrier sums on
     # the device via `backend.proto` (the bisection sweeps all in-window states many times and
     # dominates the setup at dense grids); the generic `compute_ncarrier` broadcast+sum works for
     # every occ_type on the device, so no occ_type is special-cased.
     _setup_calculators!(calculators, kpts, qpts, el_k_save;
         nw, nmodes, rng_band = iband_min:iband_max, el_states_kq = el_kq_save, kqpts,
         sel_k, sel_kq, nchunks_threads, verbosity, backend,
+        mode = batched ? BatchedMode() : SingleMode(),
     )
 
     return (;
@@ -375,11 +400,11 @@ end
 
 
 # =============================================================================
-#  GPU calculator loop for the outer-q e-ph sweep.
+#  Batched calculator loop for the outer-q e-ph sweep.
 #
-#  Mirrors `_loop_eph_over_k_and_kq_gpu` (run_eph_over_k_and_kq.jl): the shared `_setup_eph_over_q_and_k`
+#  Mirrors `_loop_eph_over_k_and_kq_batched` (run_eph_over_k_and_kq.jl): the shared `_setup_eph_over_q_and_k`
 #  runs on the host, and this loop moves the inner-k work — the e-ph Rq→kq interpolation, the k+q
-#  eigensolve, and the calculator reduction — onto the device via the generic batched drivers
+#  eigensolve, and the calculator reduction — onto the backend via the generic batched drivers
 #  (`get_eph_Rq_to_kq_batched!`, `eigen_batched`, `get_fourier_batched!`) and the outer-q batched
 #  calculator hook. The code is backend-generic: it calls only `to_device` and the batched drivers,
 #  so no CUDA code lives here (the device methods live in the CUDA extension).
@@ -390,12 +415,17 @@ end
 #  `run_calculator!(calc, ::EPDataKBatched, ctx)`. The per-q device accumulator is bracketed
 #  by the `calculator_begin!/end!(…, OuterIteration(), ctx)` brackets, the same ones the CPU loop uses.
 #
-#  Scope (asserted below; the CPU path handles the rest): no screening,
+#  Backend: `GPUBackend` is the production configuration; nothing here is device-specific, so the
+#  loop also runs on `CPUBackend` (`batched = true`) as a validation configuration (serial k-batches,
+#  `mul!`-loop `batched_gemm!`, and `plan_batch` returns the `nk_batch_max` cap verbatim). The `_dev`
+#  suffix means "on `backend`", which is the host there.
+#
+#  Scope (asserted below; the per-point path handles the rest): no screening,
 #  energy_conservation = (:None, 0.0), skip_eph = false, and every calculator supports the
 #  `EPDataKBatched` payload. Windows are supported via eigenvector-column masking (out-of-window
 #  states contribute exactly 0), so the batched full-band nw×nw shapes stay uniform. Polar models are
 #  supported: the `polar_eph` dipole term is added on the device per batch (`add_eph_dipole_batched!`).
-function _loop_eph_over_q_and_k_gpu(
+function _loop_eph_over_q_and_k_batched(
         model       :: Model{FT},
         kpts, qpts,
         el_k_save, ph_save,
@@ -417,14 +447,15 @@ function _loop_eph_over_q_and_k_gpu(
     nq = qpts.n
 
     # ----- scope asserts -----
-    skip_eph && throw(ArgumentError("use_gpu requires skip_eph = false."))
+    skip_eph && throw(ArgumentError("the batched path requires skip_eph = false."))
     energy_conservation === (:None, 0.0) || throw(ArgumentError(
-        "use_gpu supports only energy_conservation = (:None, 0.0)."))
+        "the batched path supports only energy_conservation = (:None, 0.0)."))
     # screening_params === nothing also guarantees ϵ ≡ 1 in the polar dipole term below.
-    screening_params === nothing || throw(ArgumentError("use_gpu does not support screening_params."))
+    screening_params === nothing || throw(ArgumentError(
+        "the batched path does not support screening_params."))
     (!isempty(calculators) && all(c -> supports(c, EPDataKBatched), calculators)) || throw(ArgumentError(
-        "use_gpu (outer-q) requires every calculator to support the EPDataKBatched payload. " *
-        "Use the CPU path otherwise."))
+        "the batched outer-q path requires every calculator to support the EPDataKBatched payload. " *
+        "Use the per-point path otherwise."))
 
     # `el_ham_dev` (device Hamiltonian for the k+q eigensolve) was uploaded ONCE in the shared setup
     # and threaded here through `backend`; the loop reuses it rather than re-uploading.
@@ -458,7 +489,7 @@ function _loop_eph_over_q_and_k_gpu(
     nk_batch_cap = min(Int(nk_batch_max), nk)
     nk_batch_max = plan_batch(backend, per_point, committed, nk_batch_cap; what = "outer-q")
     if verbosity > 0 && mpi_isroot()
-        @info "GPU outer-q device memory: committed = $(round(committed / 1e9, digits = 2)) GB, " *
+        @info "batched outer-q staging: committed = $(round(committed / 1e9, digits = 2)) GB, " *
               "$(round(per_point / 1e3, digits = 1)) kB/k; k-batch size = $nk_batch_max"
     end
 
@@ -584,15 +615,20 @@ end
 
 """
     estimate_device_memory(model; nk, nkq, nk_outer_batch_max = 256, nq_batch_max = nothing,
-                           nk_batch_max = 2^15, calculators = [], use_gpu = true) -> NamedTuple
+                           nk_batch_max = 2^15, calculators = [], backend = CPUBackend()) -> NamedTuple
 
-Estimate the GPU device memory a batched e-ph run would use, WITHOUT running it, so a batch width can
+Estimate the device memory a batched e-ph run would use, WITHOUT running it, so a batch width can
 be sized ahead of time. Uses the same byte functions as the drivers (`_outer_{k,q}_staging_bytes`,
 full-band: `nbandk_max = nw`, so windowed runs use less), and reports both the whole-run `committed`
 bytes and the `per_point` (per batched-inner index) bytes, plus the memory-adaptive batch width
-`plan_batch` would pick against the current backend. Which loop is estimated follows
+`plan_batch` would pick against `backend`. Which loop is estimated follows
 `model.epmat_outer_momentum` (`el` → outer-k, `ph` → outer-q). Returns a `NamedTuple`; the
 committed / per-point fields are also printed by the drivers at `verbosity > 0`.
+
+The byte counts themselves are backend-independent, so no GPU is needed for them and the default
+`backend = CPUBackend()` reports them fine. Only the `batch` and `free` fields depend on the backend:
+on a `CPUBackend` `free_bytes` is unbounded, so `batch` is the requested cap verbatim. Pass
+`backend = ElectronPhonon.gpu_backend()` to see the memory-adaptive width an actual GPU run would pick.
 
 Note: these counts cover the driver's own device buffers only. Actual device usage starts ~100-150 MB
 HIGHER than reported here because of a fixed CUDA library context/workspace floor (cuBLAS etc.),
@@ -604,9 +640,8 @@ it is sized by the calculator, not by this estimate.)
 """
 function estimate_device_memory(model::Model{FT}; nk::Integer, nkq::Integer,
         nk_outer_batch_max::Integer = 256, nq_batch_max = nothing, nk_batch_max::Integer = 2^15,
-        calculators = [], use_gpu::Bool = true) where {FT}
+        calculators = [], backend::AbstractBackend = CPUBackend()) where {FT}
     (; nw, nmodes) = model
-    backend = use_gpu ? gpu_backend() : CPUBackend()
     if model.epmat_outer_momentum == "el"
         nr_ep = length(get_next_wannier_object(model.epmat).irvec)
         nk_batch = min(Int(nk_outer_batch_max), Int(nk))

--- a/src/common/gpu_utils.jl
+++ b/src/common/gpu_utils.jl
@@ -4,13 +4,15 @@
 # (`ext/ElectronPhononCUDAExt.jl`); the base package defines only the CPU methods, so it loads and
 # runs on CPU-only machines. Nothing here is exported (use `ElectronPhonon.<name>`).
 
-# Backend objects: one resolution point per driver entry (`backend = use_gpu ? gpu_backend() :
-# CPUBackend()`), then carried in `LoopContext` (see calculator/AbstractCalculator.jl). Below the
-# driver entry, code allocates buffers via `alloc(backend, T, dims...)`, moves data with
-# `to_device(backend, x)`, and queries `free_bytes(backend)` / `synchronize(backend)`, so `use_gpu`
-# never threads through the interfaces. `GPUBackend` carries a device-array prototype that `alloc`
-# uses as a `similar` template; `gpu_backend()` (extension) builds one with an empty prototype so a
-# backend can be constructed before any array is moved.
+# Backend objects: the user passes one to a driver entry (`backend = CPUBackend()` or
+# `backend = gpu_backend()`), which carries it in `LoopContext` (see calculator/AbstractCalculator.jl).
+# Everywhere below, code allocates buffers via `alloc(backend, T, dims...)`, moves data with
+# `to_device(backend, x)`, and queries `free_bytes(backend)` / `synchronize(backend)`, so the backend
+# object is the only thing that says where "device" is. `GPUBackend` carries a device-array prototype
+# that `alloc` uses as a `similar` template; `gpu_backend()` (extension) builds one with an empty
+# prototype so a backend can be constructed before any array is moved. Note the backend does NOT say
+# which loop SHAPE runs — that is the drivers' separate `batched` keyword, which defaults from the
+# backend but can be set independently (batched-on-`CPUBackend` is a validation configuration).
 abstract type AbstractBackend end
 struct CPUBackend <: AbstractBackend end
 struct GPUBackend{AT <: AbstractArray} <: AbstractBackend

--- a/src/compute_states.jl
+++ b/src/compute_states.jl
@@ -9,7 +9,7 @@ export compute_phonon_states
 Compute the quantities listed in `quantities` and return a vector of ElectronState.
 `quantities` can containing the following: "eigenvalue", "eigenvector", "velocity_diagonal", "velocity"
 """
-function compute_electron_states(model::Model{FT}, kpts, quantities, window=(-Inf, Inf); fourier_mode="normal", use_gpu=false) where FT
+function compute_electron_states(model::Model{FT}, kpts, quantities, window=(-Inf, Inf); fourier_mode="normal", backend=CPUBackend()) where FT
     # TODO: MPI, threading
     allowed_quantities = ["eigenvalue", "eigenvector", "velocity_diagonal", "velocity", "position"]
     for quantity in quantities
@@ -22,16 +22,16 @@ function compute_electron_states(model::Model{FT}, kpts, quantities, window=(-In
         return states
     end
 
-    if use_gpu
-        _compute_electron_states_gpu!(states, model, kpts, quantities, window)
-    else
+    if backend isa CPUBackend
         _compute_electron_states_cpu!(states, model, kpts, quantities, window; fourier_mode)
+    else
+        _compute_electron_states_device!(states, model, kpts, quantities, window, backend)
     end
     states
 end
 
 """
-    compute_electron_states(model, sel::FilteredStates, quantities; fourier_mode="normal", use_gpu=false)
+    compute_electron_states(model, sel::FilteredStates, quantities; fourier_mode="normal", backend=CPUBackend())
 
 Compute electron states for exactly the per-k bands selected by `sel`: each state's band range is
 `sel.band_extent[ik]` (from the selection) rather than a single energy window, so a multigrid (whose
@@ -39,7 +39,7 @@ per-k band extent is narrow at fine-only nodes and wide at coincident nodes) get
 k. Returns a vector of `ElectronState` over `sel.kpts`.
 """
 function compute_electron_states(model::Model{FT}, sel::FilteredStates, quantities;
-        fourier_mode="normal", use_gpu=false) where FT
+        fourier_mode="normal", backend=CPUBackend()) where FT
     allowed_quantities = ["eigenvalue", "eigenvector", "velocity_diagonal", "velocity", "position"]
     for quantity in quantities
         quantity ∉ allowed_quantities && error("$quantity is not an allowed quantity.")
@@ -47,10 +47,10 @@ function compute_electron_states(model::Model{FT}, sel::FilteredStates, quantiti
     kpts = sel.kpts
     states = [ElectronState{FT}(model.nw) for _ in 1:kpts.n]
     isempty(quantities) && return states
-    if use_gpu
-        _compute_electron_states_gpu!(states, model, kpts, quantities, sel.band_extent)
-    else
+    if backend isa CPUBackend
         _compute_electron_states_cpu!(states, model, kpts, quantities, sel.band_extent; fourier_mode)
+    else
+        _compute_electron_states_device!(states, model, kpts, quantities, sel.band_extent, backend)
     end
     states
 end
@@ -121,7 +121,7 @@ function _compute_electron_states_cpu!(states, model::Model{FT}, kpts, quantitie
     end # ik
 end
 
-# GPU: one batched eigensolve on the device replaces the per-k solve, then a host loop copies the
+# Device: one batched eigensolve on the backend replaces the per-k solve, then a host loop copies the
 # results into the states. The energy window is applied by set_window! after the full-band
 # eigenpair is copied in (e_full/u_full); windowed quantities (rbar/velocity) then read the
 # in-window block of the full-band device result.
@@ -132,11 +132,11 @@ end
 # get_el_eigen!, so for degenerate bands the eigenvectors (and per-band-pair e-ph matrix elements /
 # g2) can differ from the CPU path by a unitary rotation within the degenerate subspace. Gauge-
 # independent quantities (eigenvalues, ωq, BZ-summed observables) are unaffected.
-function _compute_electron_states_gpu!(states, model::Model{FT}, kpts, quantities, window) where FT
+function _compute_electron_states_device!(states, model::Model{FT}, kpts, quantities, window,
+                                          backend) where FT
     (; nw, el_velocity_mode) = model
     (; need_vfull, need_vdiag, need_position) = _electron_state_needs(model, quantities)
 
-    backend = gpu_backend()
     itp_elham = get_interpolator(to_device(backend, model.el_ham); fourier_mode="batched", batch_size=kpts.n)
 
     if quantities == ["eigenvalue"]
@@ -220,7 +220,7 @@ Compute the quantities listed in `quantities` and return a vector of PhononState
 `quantities` can containing the following: "eigenvalue", "eigenvector", "velocity_diagonal", "eph_dipole_coeff"
 TODO: Implement quantities "velocity"
 """
-function compute_phonon_states(model::Model{FT}, kpts, quantities; fourier_mode="normal", eph_phonon_basis::Symbol = :eigenmode, use_gpu=false) where FT
+function compute_phonon_states(model::Model{FT}, kpts, quantities; fourier_mode="normal", eph_phonon_basis::Symbol = :eigenmode, backend=CPUBackend()) where FT
     # TODO: MPI, threading
     allowed_quantities = ["eigenvalue", "eigenvector", "velocity_diagonal", "eph_dipole_coeff"]
     for quantity in quantities
@@ -234,10 +234,10 @@ function compute_phonon_states(model::Model{FT}, kpts, quantities; fourier_mode=
         return states
     end
 
-    if use_gpu
-        _compute_phonon_states_gpu!(states, model, kpts, quantities, eph_phonon_basis)
-    else
+    if backend isa CPUBackend
         _compute_phonon_states_cpu!(states, model, kpts, quantities, eph_phonon_basis; fourier_mode)
+    else
+        _compute_phonon_states_device!(states, model, kpts, quantities, eph_phonon_basis, backend)
     end
     states
 end
@@ -278,19 +278,18 @@ function _compute_phonon_states_cpu!(states, model::Model{FT}, kpts, quantities,
     end  # iks
 end
 
-# GPU: batch the phonon eigensolve on the device (same idea as _compute_electron_states_gpu!),
+# Device: batch the phonon eigensolve on the backend (same idea as _compute_electron_states_device!),
 # then a host loop copies the results into the states. velocity_diagonal is rotated on the device
-# too. polar is unsupported (the GPU e-ph loop asserts no polar). Same degeneracy-gauge caveat as
+# too. polar is unsupported (the batched e-ph loop asserts no polar). Same degeneracy-gauge caveat as
 # the electrons — small g2 differences for degenerate modes, most visible on COARSE q grids.
-function _compute_phonon_states_gpu!(states, model::Model{FT}, kpts, quantities,
-                                     eph_phonon_basis) where FT
+function _compute_phonon_states_device!(states, model::Model{FT}, kpts, quantities,
+                                        eph_phonon_basis, backend) where FT
     (; nmodes, mass) = model
     need_velocity = "velocity_diagonal" ∈ quantities
     polar = model.polar_phonon
-    polar.use && error("compute_phonon_states use_gpu does not support polar phonons")
+    polar.use && error("compute_phonon_states on a non-CPU backend does not support polar phonons")
     "velocity" ∈ quantities && error("full velocity for phonons not implemented")
 
-    backend = gpu_backend()
     itp_dyn = get_interpolator(to_device(backend, model.ph_dyn); fourier_mode="batched", batch_size=kpts.n)
     D = _fourier_hk_batched(itp_dyn, kpts.vectors)  # (nmodes,nmodes,nq)
     msqrt_d = similar(D, FT, nmodes); copyto!(msqrt_d, sqrt.(mass))
@@ -320,7 +319,7 @@ end
 # backends and the GPU path never leaves the device. A `Vector` of per-q mutable structs costs ~13
 # allocations and ~1.5 kB per q point, which at the q-grids the outer-k driver builds (nq = 6.9 M for
 # Cu at nk = 200) is ~90 M allocations and ~10 GiB of churn, most of the setup's GC time.
-# `_loop_eph_over_k_and_kq_gpu` shows how little of it is wanted: it reads only `.u` and `.e`, and
+# `_loop_eph_over_k_and_kq_batched` shows how little of it is wanted: it reads only `.u` and `.e`, and
 # gathers them straight back into dense stacks to re-upload — data `E_dev`/`U_dev` above already hold
 # on the device — while `velocity_diagonal` and `eph_dipole_coeff`, which that driver requests, are
 # never read. Measured on Cu at nq = 436 k: 1.62 s / 5.67 M allocations / 669 MiB for the per-q

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -37,20 +37,19 @@ end
 filter_kpoints(kpts_input, nw, el_ham, window, mpi_comm; kwargs...) =
     filter_kpoints(kpts_input, nw, el_ham, window; mpi_comm, kwargs...)
 
-function _filter_kpoints(nw, kpoints, el_ham, window; fourier_mode="normal", use_gpu=false)
+function _filter_kpoints(nw, kpoints, el_ham, window; fourier_mode="normal", backend=CPUBackend())
     ik_keep = zeros(Bool, kpoints.n)
     nelec_below_window_ = zeros(eltype(window), kpoints.n)
     band_min_ = zeros(Int, kpoints.n)
     band_max_ = zeros(Int, kpoints.n)
 
-    if use_gpu
-        # GPU: batched valueonly eigensolve (the band-eigenvalues are the expensive part of
+    if !(backend isa CPUBackend)
+        # Device: batched valueonly eigensolve (the band-eigenvalues are the expensive part of
         # filtering); the cheap window test stays on the host. `to_device` /
         # `get_el_eigen_valueonly_batched` come from the base + CUDA extension. Chunk over k so the
         # per-chunk device H(k) stack (nw*nw*kchunk complex) stays bounded — a single all-nk solve
         # can exhaust GPU memory on large grids. kchunk caps that stack at ~1 GiB (nk if smaller).
         kchunk = clamp(fld(2^30, nw * nw * 16), 1, kpoints.n)
-        backend = gpu_backend()
         itp_elham = get_interpolator(to_device(backend, el_ham); fourier_mode="batched", batch_size=kchunk)
         kstart = 1
         while kstart <= kpoints.n
@@ -158,7 +157,7 @@ end
 # min/max. Non-MPI (the selection generators are single-node); a trivial window keeps the whole grid
 # with all bands `1:nw`.
 function _filter_with_band_ranges(kpts_input, nw, el_ham, window;
-                                  symmetry=nothing, fourier_mode="gridopt", use_gpu=false, shift=(0, 0, 0))
+                                  symmetry=nothing, fourier_mode="gridopt", backend=CPUBackend(), shift=(0, 0, 0))
     if kpts_input isa NTuple{3,Integer}
         (symmetry === nothing || all(shift .== 0)) ||
             error("nonzero shift and symmetry incompatible (not implemented)")
@@ -170,13 +169,13 @@ function _filter_with_band_ranges(kpts_input, nw, el_ham, window;
         gkpts = kpoints isa GridKpoints ? kpoints : GridKpoints(kpoints)
         return gkpts, fill(1, gkpts.n), fill(nw, gkpts.n), zero(eltype(window))
     end
-    r = _filter_kpoints(nw, kpoints, el_ham, window; fourier_mode, use_gpu)
+    r = _filter_kpoints(nw, kpoints, el_ham, window; fourier_mode, backend)
     gkpts = GridKpoints(get_filtered_kpoints(kpoints, r.ik_keep))
     gkpts, r.band_min_per_k[r.ik_keep], r.band_max_per_k[r.ik_keep], r.nelec_below_window
 end
 
 """
-    filter_electron_states(kpts_input, nw, el_ham, window; symmetry, fourier_mode, use_gpu,
+    filter_electron_states(kpts_input, nw, el_ham, window; symmetry, fourier_mode, backend,
                            mpi_comm, shift) -> FilteredStates
     filter_electron_states(kpts_input, model::Model, window; kwargs...) -> FilteredStates
 
@@ -194,10 +193,10 @@ k-points and per-k band ranges are redistributed together through the same gathe
 stay aligned, and the local below-window counts are summed.
 """
 function filter_electron_states(kpts_input, nw::Integer, el_ham, window;
-        symmetry=nothing, fourier_mode="gridopt", use_gpu=false, mpi_comm=nothing, shift=(0, 0, 0))
+        symmetry=nothing, fourier_mode="gridopt", backend=CPUBackend(), mpi_comm=nothing, shift=(0, 0, 0))
     if mpi_comm === nothing
         gkpts, ibmin, ibmax, nelec = _filter_with_band_ranges(kpts_input, nw, el_ham, window;
-            symmetry, fourier_mode, use_gpu, shift)
+            symmetry, fourier_mode, backend, shift)
     else
         kpts_input isa NTuple{3,Integer} ||
             throw(ArgumentError("filter_electron_states with mpi_comm requires an NTuple grid spec"))
@@ -206,7 +205,7 @@ function filter_electron_states(kpts_input, nw::Integer, el_ham, window;
         # Build the grid distributed and filter each rank's slice once (single eigensolve pass).
         kpoints = kpoints_grid(kpts_input, mpi_comm; shift, symmetry)
         gkpts_l, ibmin_l, ibmax_l, nelec_l = _filter_with_band_ranges(kpoints, nw, el_ham, window;
-            fourier_mode, use_gpu)
+            fourier_mode, backend)
         # Redistribute the kept k-points via the shared GridKpoints wrapper (rank-concatenate +
         # even-split, no reorder; preserves the global ngrid). The per-k band ranges follow with the
         # SAME gather/scatter, so they stay aligned to `gkpts`. Sum the local below-window counts.
@@ -233,7 +232,7 @@ filter_electron_states(kpts_input, model::Model, window; kwargs...) =
 
 """
     filter_electron_states_multigrid(nks_f, nks_c, window_f, window_c, nw, el_ham;
-                                     fourier_mode="gridopt", symmetry=nothing, use_gpu=false)
+                                     fourier_mode="gridopt", symmetry=nothing, backend=CPUBackend())
         -> FilteredStates
 
 Generator 2 (double-grid): build a `FilteredStates` sampling a FINE grid `nks_f` in the narrow
@@ -256,14 +255,14 @@ grid for the q-lookup; its per-point `weights` are informational (the per-state 
 selection are the authoritative BZ weights).
 """
 function filter_electron_states_multigrid(nks_f, nks_c, window_f, window_c, nw, el_ham;
-                                  fourier_mode="gridopt", symmetry=nothing, use_gpu=false)
+                                  fourier_mode="gridopt", symmetry=nothing, backend=CPUBackend())
 
     all(mod.(nks_f, nks_c) .== 0) || throw(ArgumentError("nks_f must be a multiple of nks_c"))
     (window_f[1] >= window_c[1] && window_f[2] <= window_c[2]) ||
         throw(ArgumentError("the fine window_f must be contained in the coarse window_c"))
 
-    kpts_f, ibmin_f, ibmax_f, _            = _filter_with_band_ranges(nks_f, nw, el_ham, window_f; symmetry, fourier_mode, use_gpu)  # fine, narrow
-    kpts_c, ibmin_c, ibmax_c, nstates_base = _filter_with_band_ranges(nks_c, nw, el_ham, window_c; symmetry, fourier_mode, use_gpu)  # coarse, wide
+    kpts_f, ibmin_f, ibmax_f, _            = _filter_with_band_ranges(nks_f, nw, el_ham, window_f; symmetry, fourier_mode, backend)  # fine, narrow
+    kpts_c, ibmin_c, ibmax_c, nstates_base = _filter_with_band_ranges(nks_c, nw, el_ham, window_c; symmetry, fourier_mode, backend)  # coarse, wide
 
     T = eltype(kpts_f.weights)
 

--- a/test/boltzmann/test_gpu_boltzmann_calculator.jl
+++ b/test/boltzmann/test_gpu_boltzmann_calculator.jl
@@ -154,16 +154,44 @@ end
         occ = ElectronOccupationParams(; Tlist = [300.0 * K], nlist = 4.0, μlist = μ,
             volume = model.volume, nelec = 0, spin_degeneracy = 2, occ_type = :FermiDirac),
         smearing_list = [SmearingType(:Gaussian, 100.0 * meV)], occupation_method = 5)
-    runbte(use_gpu) = (c = mkcalc(); EP.run_eph_over_k_and_kq(model, (6, 6, 6), (6, 6, 6);
-        calculators = [c], symmetry = nothing, window_k = window, window_kq = window,
-        fourier_mode = "gridopt", use_gpu, progress_print_step = 10^9); c)
+    runbte(grid, backend, batched; nq_batch_max = nothing) =
+        (c = mkcalc(); EP.run_eph_over_k_and_kq(model, grid, grid;
+            calculators = [c], symmetry = nothing, window_k = window, window_kq = window,
+            fourier_mode = "gridopt", backend, batched, nq_batch_max,
+            progress_print_step = 10^9, verbosity = 0); c)
 
-    cc = runbte(false)
+    cc = runbte((6, 6, 6), EP.CPUBackend(), false)
     @test length(cc.Sₒ[1]) > 0
     @test all(isfinite, stack(cc.Sₒ)) && all(isfinite, stack(cc.Sᵢ))
+
+    # CPU + batched (no CUDA needed): the batched loop on host arrays must reproduce the per-point
+    # result on the SAME grid, to summation order. It is slow by construction (serial k-batches,
+    # `mul!`-loop `batched_gemm!`), so the grid is kept at 6³ — measured 0.04 s there, versus 0.06 s
+    # for the per-point arm, small enough not to need a separate smaller grid. (4³ is NOT usable: this
+    # ±0.5 eV window keeps zero k-points on that grid, and an empty selection cannot build a q-grid.)
+    # `nq_batch_max` is passed explicitly for two reasons: on a `CPUBackend` `plan_batch` returns the
+    # cap verbatim (`free_bytes` is unbounded), so without it the q-tile would be the whole k+q grid
+    # and every per-q buffer would be sized to it; and a cap below nkq is what forces ntiles > 1,
+    # exercising the `tile_begin!`/`tile_download!` bracket path on the host.
+    @testset "CPU+batched == CPU+per-point" begin
+        c_ba = runbte((6, 6, 6), EP.CPUBackend(), true; nq_batch_max = 7)
+        @test stack(c_ba.Sₒ) ≈ stack(cc.Sₒ) rtol = 1e-9
+        @test stack(c_ba.Sᵢ) ≈ stack(cc.Sᵢ) rtol = 1e-9
+        # Measured 2026-08-03 (Pb 6³): Sₒ 6.1e-16, Sᵢ 1.3e-15 — pure batched-GEMM reassociation.
+        @info "CPU+batched vs CPU+per-point (Pb 6³)" Sₒ_reldev =
+            maximum(abs, stack(c_ba.Sₒ) .- stack(cc.Sₒ)) / maximum(abs, stack(cc.Sₒ)) Sᵢ_reldev =
+            maximum(abs, stack(c_ba.Sᵢ) .- stack(cc.Sᵢ)) / maximum(abs, stack(cc.Sᵢ))
+    end
+
     if _CUDA_OK
-        cg = runbte(true)
+        # `batched` omitted: it derives from the backend, which is the production GPU spelling.
+        cg = runbte((6, 6, 6), EP.gpu_backend(), nothing)
+        # rtol, not ==: the setup eigensolve differs by a degeneracy gauge on the device, and Sₒ is an
+        # atomic fold there (not bitwise reproducible run-to-run; measured 5e-16 relative at 6³, while
+        # Sᵢ IS bitwise reproducible). Measured CPU-vs-GPU at 6³: Sₒ 1.8e-13, Sᵢ 2.5e-13.
         @test stack(cg.Sₒ) ≈ stack(cc.Sₒ) rtol = 1e-9
         @test stack(cg.Sᵢ) ≈ stack(cc.Sᵢ) rtol = 1e-9
+        # Explicit `batched = false` on a GPU backend: rejected at the driver entry.
+        @test_throws ArgumentError runbte((6, 6, 6), EP.gpu_backend(), false)
     end
 end

--- a/test/boltzmann/test_gpu_boltzmann_calculator.jl
+++ b/test/boltzmann/test_gpu_boltzmann_calculator.jl
@@ -26,11 +26,11 @@ using Random
     @test all(isfinite, s) && s == (0.0, 0.0)
 end
 
-# Device `bte_window_accumulate!` (CUDA kernel) vs an independent CPU reference. There is no generic
-# CPU `bte_window_accumulate!` method (the CPU BoltzmannCalculator never batches — it accumulates per
-# (k, q) via the `run_calculator!(::EPData)` host loop), so the reference here is a self-contained
-# per-(m, n, iq) loop over the same shared `bte_scattering_increments`. It independently pins the
-# device kernel to ~machine eps, block-tile `i0` and out-of-window `imap == 0` included.
+# Both `bte_window_accumulate!` methods — the generic host one (which serves the CPU+batched
+# validation configuration) and the CUDA kernel — against an independent CPU reference. The reference
+# is a self-contained per-(m, n, iq) loop over the same shared `bte_scattering_increments`; it is
+# deliberately NOT the implementation under test on either backend, so it independently pins both to
+# ~machine eps, block-tile `i0` and out-of-window `imap == 0` included.
 const _CUDA_OK = (get(ENV, "EP_TEST_CUDA", "1") == "1") && try
     @eval import CUDA
     CUDA.functional()
@@ -38,7 +38,9 @@ catch
     false
 end
 
-# Non-batched CPU reference for the device kernel's Sₒ/Sᵢ accumulation (not a production method).
+# Independent CPU reference for the Sₒ/Sᵢ accumulation (NOT a production method, and deliberately not
+# shared with `src`: keeping it duplicated is what makes it an oracle for the generic host method that
+# now lives in src/boltzmann/boltzmann_calculator.jl as well as for the CUDA kernel).
 function _bte_accumulate_ref!(So, Si, g2vals, ωqmat, imap_i_at_k, imap_f, ikqs, e_i, e_f, wf,
         μs, Ts, ηs, method, ω_cutoff, nbandkq, nbandk, nmodes, nq_batch, i0)
     nT = length(μs)
@@ -61,72 +63,90 @@ function _bte_accumulate_ref!(So, Si, g2vals, ωqmat, imap_i_at_k, imap_f, ikqs,
     (So, Si)
 end
 
-let
-    if _CUDA_OK
-        @testset "bte_window_accumulate! CUDA kernel vs CPU reference" begin
-            Random.seed!(7)
-            FT=Float64; nw=4; nmodes=3; nq_batch=6; nT=2
-            ikqs = collect(1:nq_batch)
-            imap_i_at_k = collect(1:nw)
-            imap_f = reshape(collect(1:nw*nq_batch), nw, nq_batch)
-            n_i=nw; n_f=nw*nq_batch
-            e_i=0.01randn(n_i); e_f=0.01randn(n_f); wf=abs.(0.1randn(n_f)).+0.01  # per-final-state weight
-            g2vals=abs.(randn(nw,nw,nmodes,nq_batch)).*1e-3; ωqmat=(0.5 .+ abs.(randn(nmodes,nq_batch))).*1e-2
-            μs=FT[0.0,0.002]; Ts=FT[0.01,0.02]; ωcut=FT(1e-6)
-            ηs = [SmearingType(:Gaussian, FT(x)) for x in [0.005, 0.005]]
-            for method in 1:6
-                So=zeros(n_i,nT); Si=zeros(n_i,n_f,nT)
-                _bte_accumulate_ref!(So,Si,g2vals,ωqmat,imap_i_at_k,imap_f,ikqs,e_i,e_f,wf,
-                    μs,Ts,ηs,method,ωcut,nw,nw,nmodes,nq_batch,0)
-                Sog=CUDA.zeros(FT,n_i,nT); Sig=CUDA.zeros(FT,n_i,n_f,nT)
-                EP.bte_window_accumulate!(Sog,Sig,CUDA.CuArray(g2vals),CUDA.CuArray(ωqmat),
-                    CUDA.CuArray(imap_i_at_k),CUDA.CuArray(imap_f),CUDA.CuArray(ikqs),
-                    CUDA.CuArray(e_i),CUDA.CuArray(e_f),CUDA.CuArray(wf),
-                    CUDA.CuArray(μs),CUDA.CuArray(Ts),CUDA.CuArray(ηs),method,ωcut,nw,nw,nmodes,nq_batch,0)
-                @test Array(Sog) ≈ So rtol=1e-10
-                @test Array(Sig) ≈ Si rtol=1e-10
-            end
-        end
-
-        @testset "bte_window_accumulate! out-of-window (imap==0) + block-tile (i0≠0)" begin
-            Random.seed!(11)
-            FT=Float64; nw=4; nmodes=2; nq_batch=4; nT=1
-            ikqs = collect(1:nq_batch)
-            # Some bands out-of-window (imap==0); in-window outer states live in a tile i0+1:i0+ni.
-            i0=3; ni=4                          # global outer states 4..7 land in tile rows 1..4
-            imap_i_at_k = [0, 4, 6, 7]           # band 1 out-of-window; others in-tile (global i)
-            n_i_global = 10
-            imap_f = [ (m+ (kq-1)*nw) % 7 == 0 ? 0 : (m + (kq-1)*nw) for m in 1:nw, kq in 1:nq_batch ]  # scatter some 0s
-            n_f = nw*nq_batch
-            e_i=0.01randn(n_i_global); e_f=0.01randn(n_f); wf=abs.(0.1randn(n_f)).+0.01  # per-final-state weight
-            g2vals=abs.(randn(nw,nw,nmodes,nq_batch)).*1e-3; ωqmat=(0.5 .+ abs.(randn(nmodes,nq_batch))).*1e-2
-            μs=FT[0.0]; Ts=FT[0.01]; ωcut=FT(1e-6)
-            ηs = [SmearingType(:Gaussian, FT(x)) for x in [0.005]]
-            for method in (1,5,6)
-                So=zeros(n_i_global,nT); Si=zeros(ni,n_f,nT)
-                _bte_accumulate_ref!(So,Si,g2vals,ωqmat,imap_i_at_k,imap_f,ikqs,e_i,e_f,wf,
-                    μs,Ts,ηs,method,ωcut,nw,nw,nmodes,nq_batch,i0)
-                Sog=CUDA.zeros(FT,n_i_global,nT); Sig=CUDA.zeros(FT,ni,n_f,nT)
-                EP.bte_window_accumulate!(Sog,Sig,CUDA.CuArray(g2vals),CUDA.CuArray(ωqmat),
-                    CUDA.CuArray(imap_i_at_k),CUDA.CuArray(imap_f),CUDA.CuArray(ikqs),
-                    CUDA.CuArray(e_i),CUDA.CuArray(e_f),CUDA.CuArray(wf),
-                    CUDA.CuArray(μs),CUDA.CuArray(Ts),CUDA.CuArray(ηs),method,ωcut,nw,nw,nmodes,nq_batch,i0)
-                @test Array(Sog) ≈ So rtol=1e-10
-                @test Array(Sig) ≈ Si rtol=1e-10
-                # out-of-window outer band 1 contributes nowhere; global rows 1..3,8..10 stay zero
-                @test all(So[setdiff(1:n_i_global, 4:7), :] .== 0)
-            end
-        end
-    else
-        @info "CUDA not functional — skipping GPU bte_window_accumulate! test"
+# The two accumulate fixtures below run on either backend: `arr` moves an input array onto it
+# (`identity` for the host, `CUDA.CuArray` for the device) and `zdev(T, dims...)` allocates the zeroed
+# output buffers there. Both fixtures compare against `_bte_accumulate_ref!` above.
+function check_bte_accumulate_methods(arr, zdev)
+    Random.seed!(7)
+    FT=Float64; nw=4; nmodes=3; nq_batch=6; nT=2
+    ikqs = collect(1:nq_batch)
+    imap_i_at_k = collect(1:nw)
+    imap_f = reshape(collect(1:nw*nq_batch), nw, nq_batch)
+    n_i=nw; n_f=nw*nq_batch
+    e_i=0.01randn(n_i); e_f=0.01randn(n_f); wf=abs.(0.1randn(n_f)).+0.01  # per-final-state weight
+    g2vals=abs.(randn(nw,nw,nmodes,nq_batch)).*1e-3; ωqmat=(0.5 .+ abs.(randn(nmodes,nq_batch))).*1e-2
+    μs=FT[0.0,0.002]; Ts=FT[0.01,0.02]; ωcut=FT(1e-6)
+    ηs = [SmearingType(:Gaussian, FT(x)) for x in [0.005, 0.005]]
+    for method in 1:6
+        So=zeros(n_i,nT); Si=zeros(n_i,n_f,nT)
+        _bte_accumulate_ref!(So,Si,g2vals,ωqmat,imap_i_at_k,imap_f,ikqs,e_i,e_f,wf,
+            μs,Ts,ηs,method,ωcut,nw,nw,nmodes,nq_batch,0)
+        Sod=zdev(FT,n_i,nT); Sid=zdev(FT,n_i,n_f,nT)
+        EP.bte_window_accumulate!(Sod,Sid,arr(g2vals),arr(ωqmat),
+            arr(imap_i_at_k),arr(imap_f),arr(ikqs),
+            arr(e_i),arr(e_f),arr(wf),
+            arr(μs),arr(Ts),arr(ηs),method,ωcut,nw,nw,nmodes,nq_batch,0)
+        @test Array(Sod) ≈ So rtol=1e-10
+        @test Array(Sid) ≈ Si rtol=1e-10
     end
 end
 
-# End-to-end BoltzmannCalculator: the same calculator run on CPU (use_gpu=false) and GPU
-# (use_gpu=true) over a full pass of run_eph_over_k_and_kq must produce the same Sₒ/Sᵢ. Sₒ (the
-# SERTA lifetime) is gauge-invariant so it agrees to ~machine eps; this is the real cross-check that
-# the device path (batched loop + device scatter) matches the host path. Pb (metal) artifact model.
-@testset "end-to-end BTE: CPU vs GPU (Pb)" begin
+function check_bte_accumulate_tile(arr, zdev)
+    Random.seed!(11)
+    FT=Float64; nw=4; nmodes=2; nq_batch=4; nT=1
+    ikqs = collect(1:nq_batch)
+    # Some bands out-of-window (imap==0); in-window outer states live in a tile i0+1:i0+ni.
+    i0=3; ni=4                          # global outer states 4..7 land in tile rows 1..4
+    imap_i_at_k = [0, 4, 6, 7]           # band 1 out-of-window; others in-tile (global i)
+    n_i_global = 10
+    imap_f = [ (m+ (kq-1)*nw) % 7 == 0 ? 0 : (m + (kq-1)*nw) for m in 1:nw, kq in 1:nq_batch ]  # scatter some 0s
+    n_f = nw*nq_batch
+    e_i=0.01randn(n_i_global); e_f=0.01randn(n_f); wf=abs.(0.1randn(n_f)).+0.01  # per-final-state weight
+    g2vals=abs.(randn(nw,nw,nmodes,nq_batch)).*1e-3; ωqmat=(0.5 .+ abs.(randn(nmodes,nq_batch))).*1e-2
+    μs=FT[0.0]; Ts=FT[0.01]; ωcut=FT(1e-6)
+    ηs = [SmearingType(:Gaussian, FT(x)) for x in [0.005]]
+    for method in (1,5,6)
+        So=zeros(n_i_global,nT); Si=zeros(ni,n_f,nT)
+        _bte_accumulate_ref!(So,Si,g2vals,ωqmat,imap_i_at_k,imap_f,ikqs,e_i,e_f,wf,
+            μs,Ts,ηs,method,ωcut,nw,nw,nmodes,nq_batch,i0)
+        Sod=zdev(FT,n_i_global,nT); Sid=zdev(FT,ni,n_f,nT)
+        EP.bte_window_accumulate!(Sod,Sid,arr(g2vals),arr(ωqmat),
+            arr(imap_i_at_k),arr(imap_f),arr(ikqs),
+            arr(e_i),arr(e_f),arr(wf),
+            arr(μs),arr(Ts),arr(ηs),method,ωcut,nw,nw,nmodes,nq_batch,i0)
+        @test Array(Sod) ≈ So rtol=1e-10
+        @test Array(Sid) ≈ Si rtol=1e-10
+        # out-of-window outer band 1 contributes nowhere; global rows 1..3,8..10 stay zero
+        @test all(So[setdiff(1:n_i_global, 4:7), :] .== 0)
+    end
+end
+
+# Host method: no CUDA needed. This is the method the CPU+batched configuration runs.
+@testset "bte_window_accumulate! host method vs CPU reference" begin
+    check_bte_accumulate_methods(identity, (T, dims...) -> zeros(T, dims...))
+    check_bte_accumulate_tile(identity, (T, dims...) -> zeros(T, dims...))
+end
+
+if _CUDA_OK
+    @testset "bte_window_accumulate! CUDA kernel vs CPU reference" begin
+        check_bte_accumulate_methods(CUDA.CuArray, CUDA.zeros)
+        check_bte_accumulate_tile(CUDA.CuArray, CUDA.zeros)
+    end
+else
+    @info "CUDA not functional — skipping GPU bte_window_accumulate! test"
+end
+
+# End-to-end BoltzmannCalculator: the same calculator over a full pass of run_eph_over_k_and_kq must
+# produce the same Sₒ/Sᵢ in every (backend, batched) configuration. Sₒ (the SERTA lifetime) is
+# gauge-invariant so it agrees to ~machine eps; this is the real cross-check that the batched loop +
+# its scatter match the per-point host path. Pb (metal) artifact model.
+#
+# NOTE: a green CPU+batched arm is NOT GPU coverage. It exercises the batched control flow, the tiling
+# brackets, the payload construction and the calculator's batched `run_calculator!` on host arrays, but
+# none of the CUDA kernels (`_bte_window_accumulate_kernel!`, `_window_scatter_kernel!`, the fused
+# rotation kernel, `CUBLAS.gemm_strided_batched!`, the cuSOLVER batched eigensolve). Those are only
+# covered by the `_CUDA_OK` arms.
+@testset "end-to-end BTE: per-point vs batched (Pb)" begin
     model = _load_model_from_artifacts("pb")   # nw=4, nmodes=3; loads the e-ph matrix
     eV = EP.unit_to_aru(:eV); K = EP.unit_to_aru(:K); meV = EP.unit_to_aru(:meV)
     μ = 11.68eV; window = (μ - 0.5eV, μ + 0.5eV)

--- a/test/boltzmann/test_gpu_boltzmann_calculator.jl
+++ b/test/boltzmann/test_gpu_boltzmann_calculator.jl
@@ -154,10 +154,10 @@ end
         occ = ElectronOccupationParams(; Tlist = [300.0 * K], nlist = 4.0, μlist = μ,
             volume = model.volume, nelec = 0, spin_degeneracy = 2, occ_type = :FermiDirac),
         smearing_list = [SmearingType(:Gaussian, 100.0 * meV)], occupation_method = 5)
-    runbte(grid, backend, batched; nq_batch_max = nothing) =
+    runbte(grid, backend, batched; nq_batch_max = nothing, nk_outer_batch_max = 256) =
         (c = mkcalc(); EP.run_eph_over_k_and_kq(model, grid, grid;
             calculators = [c], symmetry = nothing, window_k = window, window_kq = window,
-            fourier_mode = "gridopt", backend, batched, nq_batch_max,
+            fourier_mode = "gridopt", backend, batched, nq_batch_max, nk_outer_batch_max,
             progress_print_step = 10^9, verbosity = 0); c)
 
     cc = runbte((6, 6, 6), EP.CPUBackend(), false)
@@ -169,12 +169,24 @@ end
     # `mul!`-loop `batched_gemm!`), so the grid is kept at 6³ — measured 0.04 s there, versus 0.06 s
     # for the per-point arm, small enough not to need a separate smaller grid. (4³ is NOT usable: this
     # ±0.5 eV window keeps zero k-points on that grid, and an empty selection cannot build a q-grid.)
-    # `nq_batch_max` is passed explicitly for two reasons: on a `CPUBackend` `plan_batch` returns the
-    # cap verbatim (`free_bytes` is unbounded), so without it the q-tile would be the whole k+q grid
-    # and every per-q buffer would be sized to it; and a cap below nkq is what forces ntiles > 1,
-    # exercising the `tile_begin!`/`tile_download!` bracket path on the host.
+    #
+    # The two batch caps tile DIFFERENT axes, and both must be set explicitly here because on a
+    # `CPUBackend` `plan_batch` returns the requested cap verbatim (`free_bytes` is unbounded):
+    #   * `nq_batch_max` tiles the per-q device STAGING inside one k-batch. Without it every per-q
+    #     buffer would be sized to the whole k+q grid.
+    #   * `nk_outer_batch_max` tiles the outer-k axis, which is what the calculator's Sᵢ
+    #     `TiledDeviceOutput` is tiled over — so it, not `nq_batch_max`, is what makes ntiles > 1 and
+    #     drives `tile_begin!`/`tile_download!` more than once with a NONZERO `tile_offset`. The
+    #     default 256 exceeds nk = 66 here, which would leave the whole run in a single tile at
+    #     `i0 == 0` and never exercise the `Sᵢ[iT][i0+1:i0+ni, :] .= host[1:ni, :, iT]` bookkeeping.
+    #     20 gives 4 tiles (20+20+20+6).
     @testset "CPU+batched == CPU+per-point" begin
-        c_ba = runbte((6, 6, 6), EP.CPUBackend(), true; nq_batch_max = 7)
+        c_ba = runbte((6, 6, 6), EP.CPUBackend(), true; nq_batch_max = 7, nk_outer_batch_max = 20)
+        # Guard the tiling itself: `tile_free!` resets `tile_i0` at postprocess, so the offset cannot be
+        # read back after the run — assert its precondition instead. More outer k than the cap ⇒ several
+        # k-batches ⇒ several Sᵢ tiles at nonzero `tile_offset`. If a future change to the grid or the
+        # default cap collapses this to one tile, this fails instead of silently losing the coverage.
+        @test c_ba.el_i.kpts.n > 20        # 66 outer k at cap 20 ⇒ 4 tiles
         @test stack(c_ba.Sₒ) ≈ stack(cc.Sₒ) rtol = 1e-9
         @test stack(c_ba.Sᵢ) ≈ stack(cc.Sᵢ) rtol = 1e-9
         # Measured 2026-08-03 (Pb 6³): Sₒ 6.1e-16, Sᵢ 1.3e-15 — pure batched-GEMM reassociation.

--- a/test/boltzmann/test_multigrid_transport.jl
+++ b/test/boltzmann/test_multigrid_transport.jl
@@ -10,7 +10,8 @@ using LinearAlgebra
 # weights; the k+q selection is its explicit symmetry unfold (`unfold_band_states`). Checks:
 #   1. multigrid vs uniform reference — the double-grid σ discrepancy (reported, not pre-toleranced);
 #   2. the fine refinement improves accuracy — multigrid beats the coarse grid alone;
-#   3. CPU-vs-GPU equality on the multigrid — the per-final-state weight is bit-identical on both;
+#   3. per-point-vs-batched equality on the multigrid — the per-final-state weight is bit-identical on
+#      both (run for CPU+batched always, and for GPU+batched when CUDA is available);
 #   4. over-selection regression — a wide-tail band at a fine-only node is absent from el_i/el_f;
 #   5. auto-μ succeeds on the windowed multigrid selection (no bracket failure).
 # All solved with interpolate=false (unfold-only δf feedback, exact on the shared multigrid spec).
@@ -40,24 +41,27 @@ end
         smearing_list = [SmearingType(:Gaussian, 100.0 * meV)], occupation_method = 5)
 
     # Grid/tuple input runs Generator 1 internally (sugar); a FilteredStates passes through as-is.
-    run_sel(kk, kq; use_gpu) = (c = mkcalc();
+    run_sel(kk, kq; backend, batched = nothing, nq_batch_max = nothing) = (c = mkcalc();
         EP.run_eph_over_k_and_kq(model, kk, kq; calculators = [c], symmetry = sym,
             el_kq_from_unfolding = false, window_k = w_wide, window_kq = w_wide,
-            fourier_mode = "gridopt", use_gpu, progress_print_step = 10^9); c)
+            fourier_mode = "gridopt", backend, batched, nq_batch_max,
+            progress_print_step = 10^9, verbosity = 0); c)
     solve(c) = EP.solve_electron_bte(c.el_i, c.el_f, c.Sᵢ, stack(c.Sₒ), occ(), sym; interpolate = false)
     reldiff(a, b) = norm(a - b) / norm(b)
 
-    on_gpu = _CUDA_OK
+    # The reference arms run on whichever backend is available (they only need to be self-consistent);
+    # `batched` derives from it.
+    bk = _CUDA_OK ? EP.gpu_backend() : EP.CPUBackend()
 
     # Reference uniform 12/±0.4; coarse-only uniform 6/±0.4; multigrid fine 12/±0.1 + coarse 6/±0.4.
-    c_ref = run_sel((12, 12, 12), (12, 12, 12); use_gpu = on_gpu)
-    c_coarse = run_sel((6, 6, 6), (6, 6, 6); use_gpu = on_gpu)
+    c_ref = run_sel((12, 12, 12), (12, 12, 12); backend = bk)
+    c_coarse = run_sel((6, 6, 6), (6, 6, 6); backend = bk)
     sel_k = EP.filter_electron_states_multigrid((12, 12, 12), (6, 6, 6), w_fine, w_wide,
-                                        model.nw, model.el_ham; symmetry = sym, use_gpu = on_gpu)
+                                        model.nw, model.el_ham; symmetry = sym, backend = bk)
     sel_kq = EP.unfold_band_states(sel_k, sym)     # explicit full-BZ k+q selection
     @test sel_k isa FilteredStates && sel_kq isa FilteredStates
     @test sel_k.kpts.ngrid == (12, 12, 12)
-    c_mg = run_sel(sel_k, sel_kq; use_gpu = on_gpu)
+    c_mg = run_sel(sel_k, sel_kq; backend = bk)
 
     r_ref = solve(c_ref); r_coarse = solve(c_coarse); r_mg = solve(c_mg)
     @test all(isfinite, r_mg.σ) && all(isfinite, r_mg.σ_serta)
@@ -89,17 +93,33 @@ end
         end
     end
 
-    # CPU-vs-GPU equality on the multigrid: same calculator, both backends fold the identical
-    # bte_scattering_increments with the per-final-state weight, so Sₒ/Sᵢ and σ agree to ~machine eps.
+    # Per-point-vs-batched equality on the multigrid: the same calculator, both loop shapes fold the
+    # identical bte_scattering_increments with the per-final-state weight, so Sₒ/Sᵢ and σ agree to
+    # ~machine eps. The CPU+per-point reference is the ground truth for both batched arms.
+    #
+    # The CPU+batched arm needs no CUDA, so this block does real work on a CPU-only machine — which is
+    # the point: it covers the multigrid's per-(k,band) weights through the batched payload and the
+    # tiled Sᵢ path. `nq_batch_max` is explicit because `plan_batch` returns the cap verbatim on a
+    # `CPUBackend`; it also forces ntiles > 1.
+    c_mg_pt = run_sel(sel_k, sel_kq; backend = EP.CPUBackend(), batched = false)
+    @testset "multigrid: CPU+batched == CPU+per-point" begin
+        c_mg_cb = run_sel(sel_k, sel_kq; backend = EP.CPUBackend(), batched = true,
+                          nq_batch_max = 64)
+        @test stack(c_mg_cb.Sₒ) ≈ stack(c_mg_pt.Sₒ) rtol = 1e-9
+        @test stack(c_mg_cb.Sᵢ) ≈ stack(c_mg_pt.Sᵢ) rtol = 1e-9
+        r_cb = solve(c_mg_cb); r_pt = solve(c_mg_pt)
+        @test r_cb.σ_serta ≈ r_pt.σ_serta rtol = 1e-9
+        @test r_cb.σ       ≈ r_pt.σ       rtol = 1e-9
+    end
+
     if _CUDA_OK
-        c_mg_cpu = run_sel(sel_k, sel_kq; use_gpu = false)
-        @test stack(c_mg_cpu.Sₒ) ≈ stack(c_mg.Sₒ) rtol = 1e-9
-        @test stack(c_mg_cpu.Sᵢ) ≈ stack(c_mg.Sᵢ) rtol = 1e-9
-        r_mg_cpu = solve(c_mg_cpu)
+        @test stack(c_mg_pt.Sₒ) ≈ stack(c_mg.Sₒ) rtol = 1e-9
+        @test stack(c_mg_pt.Sᵢ) ≈ stack(c_mg.Sᵢ) rtol = 1e-9
+        r_mg_cpu = solve(c_mg_pt)
         @test r_mg_cpu.σ_serta ≈ r_mg.σ_serta rtol = 1e-9
         @test r_mg_cpu.σ       ≈ r_mg.σ       rtol = 1e-9
     else
-        @info "CUDA not functional — skipping CPU-vs-GPU multigrid equality"
+        @info "CUDA not functional — skipping the GPU+batched multigrid arm"
     end
 end
 
@@ -114,7 +134,7 @@ end
     w_wide = (e_fermi - 0.4eV, e_fermi + 0.4eV)
     w_fine = (e_fermi - 0.1eV, e_fermi + 0.1eV)
     sym = model.symmetry
-    on_gpu = _CUDA_OK
+    bk = _CUDA_OK ? EP.gpu_backend() : EP.CPUBackend()
 
     # Auto-μ occupation: nlist set, μlist NOT set → the driver solves μ.
     occ_auto() = ElectronOccupationParams(; Tlist = [300.0 * K], nlist = 4.0,
@@ -123,8 +143,8 @@ end
         smearing_list = [SmearingType(:Gaussian, 100.0 * meV)], occupation_method = 5)
     run_grid(o, kk, kq) = EP.run_eph_over_k_and_kq(model, kk, kq;
         calculators = [mkcalc(o)], symmetry = sym, el_kq_from_unfolding = false,
-        window_k = w_wide, window_kq = w_wide, fourier_mode = "gridopt", use_gpu = on_gpu,
-        progress_print_step = 10^9)
+        window_k = w_wide, window_kq = w_wide, fourier_mode = "gridopt", backend = bk,
+        progress_print_step = 10^9, verbosity = 0)
 
     # Uniform reference: the full grid is filtered, so the μ solve brackets.
     o_ref = occ_auto()
@@ -134,7 +154,7 @@ end
 
     # Multigrid selection: `nstates_base` rides on the selection, so auto-μ SUCCEEDS (does not throw).
     sel_k = EP.filter_electron_states_multigrid((12, 12, 12), (6, 6, 6), w_fine, w_wide,
-                                        model.nw, model.el_ham; symmetry = sym, use_gpu = on_gpu)
+                                        model.nw, model.el_ham; symmetry = sym, backend = bk)
     sel_kq = EP.unfold_band_states(sel_k, sym)
     o_mg = occ_auto()
     run_grid(o_mg, sel_k, sel_kq)

--- a/test/boltzmann/test_multigrid_transport.jl
+++ b/test/boltzmann/test_multigrid_transport.jl
@@ -41,10 +41,11 @@ end
         smearing_list = [SmearingType(:Gaussian, 100.0 * meV)], occupation_method = 5)
 
     # Grid/tuple input runs Generator 1 internally (sugar); a FilteredStates passes through as-is.
-    run_sel(kk, kq; backend, batched = nothing, nq_batch_max = nothing) = (c = mkcalc();
+    run_sel(kk, kq; backend, batched = nothing, nq_batch_max = nothing,
+            nk_outer_batch_max = 256) = (c = mkcalc();
         EP.run_eph_over_k_and_kq(model, kk, kq; calculators = [c], symmetry = sym,
             el_kq_from_unfolding = false, window_k = w_wide, window_kq = w_wide,
-            fourier_mode = "gridopt", backend, batched, nq_batch_max,
+            fourier_mode = "gridopt", backend, batched, nq_batch_max, nk_outer_batch_max,
             progress_print_step = 10^9, verbosity = 0); c)
     solve(c) = EP.solve_electron_bte(c.el_i, c.el_f, c.Sᵢ, stack(c.Sₒ), occ(), sym; interpolate = false)
     reldiff(a, b) = norm(a - b) / norm(b)
@@ -99,12 +100,22 @@ end
     #
     # The CPU+batched arm needs no CUDA, so this block does real work on a CPU-only machine — which is
     # the point: it covers the multigrid's per-(k,band) weights through the batched payload and the
-    # tiled Sᵢ path. `nq_batch_max` is explicit because `plan_batch` returns the cap verbatim on a
-    # `CPUBackend`; it also forces ntiles > 1.
-    c_mg_pt = run_sel(sel_k, sel_kq; backend = EP.CPUBackend(), batched = false)
+    # tiled Sᵢ path. Both caps are explicit because `plan_batch` returns the requested cap verbatim on
+    # a `CPUBackend`, and they tile different axes: `nq_batch_max` the per-q staging within a k-batch,
+    # `nk_outer_batch_max` the outer-k axis that the Sᵢ `TiledDeviceOutput` is tiled over. Only the
+    # latter makes ntiles > 1, so 3 (against this selection's small nk) is what gives a nonzero
+    # `tile_offset` and exercises the per-tile Sᵢ writeback rather than a single whole-run tile.
+    #
+    # Under CUDA, `c_mg` is already the GPU+batched arm and this is a genuinely different run; without
+    # CUDA `c_mg` IS a CPU+per-point multigrid pass, so reuse it rather than paying for an identical
+    # second one on every CPU-only CI run.
+    c_mg_pt = _CUDA_OK ? run_sel(sel_k, sel_kq; backend = EP.CPUBackend(), batched = false) : c_mg
     @testset "multigrid: CPU+batched == CPU+per-point" begin
         c_mg_cb = run_sel(sel_k, sel_kq; backend = EP.CPUBackend(), batched = true,
-                          nq_batch_max = 64)
+                          nq_batch_max = 64, nk_outer_batch_max = 3)
+        # See the note above: assert the precondition for ntiles > 1, since `tile_offset` is reset at
+        # postprocess. Here the tiled axis is the multigrid selection's outer k.
+        @test c_mg_cb.el_i.kpts.n > 3
         @test stack(c_mg_cb.Sₒ) ≈ stack(c_mg_pt.Sₒ) rtol = 1e-9
         @test stack(c_mg_cb.Sᵢ) ≈ stack(c_mg_pt.Sᵢ) rtol = 1e-9
         r_cb = solve(c_mg_cb); r_pt = solve(c_mg_pt)

--- a/test/test_calculator_contract.jl
+++ b/test/test_calculator_contract.jl
@@ -23,7 +23,7 @@ mutable struct _CountCalc <: AbstractCalculator
 end
 ElectronPhonon.supports(::_CountCalc, ::Type{OuterKLoop}) = true
 ElectronPhonon.supports(::_CountCalc, ::Type{EPData}) = true
-ElectronPhonon.setup_calculator!(c::_CountCalc, kpts, qpts, el_states; kwargs...) = c
+ElectronPhonon.setup_calculator!(c::_CountCalc, backend, mode, kpts, qpts, el_states; kwargs...) = c
 ElectronPhonon.postprocess_calculator!(c::_CountCalc; kwargs...) = c
 ElectronPhonon.run_calculator!(c::_CountCalc, ::EPData, ctx) = (c.n += 1; c)
 # CPU-only (SingleMode): nothing per outer iteration, but there is no default bracket, so the no-op

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -211,7 +211,7 @@ end
 end
 
 # Plumbing of the outer-q batched calculator payload (supports(_, EPDataKBatched) /
-# run_calculator!(_, ::EPDataKBatched, ctx)) used by `run_eph_over_q_and_k(...; use_gpu=true)`.
+# run_calculator!(_, ::EPDataKBatched, ctx)) used by `run_eph_over_q_and_k(...; batched=true)`.
 # The per-q device lifecycle reuses the OuterIteration begin/end brackets (same as the CPU outer-q
 # loop). Backend-agnostic, so no GPU is needed — checks the opt-in default and the MethodError path.
 struct _PlainQCalc <: ElectronPhonon.AbstractCalculator end
@@ -402,7 +402,7 @@ end
 # A minimal AbstractCalculator that records the mode-resolved g2 and phonon frequency for
 # every (ik, ikq). It mirrors what MigdalEliashberg's EliashbergCalculator reads
 # (epstate.g2[m,n,imode], epstate.ph.e[imode]) but has no external dependency, so it can verify
-# the GPU calculator loop (run_eph_over_k_and_kq use_gpu) against the CPU loop here.
+# the batched calculator loop (run_eph_over_k_and_kq batched) against the per-point loop here.
 mutable struct _RecordCalc <: ElectronPhonon.AbstractCalculator
     g2::Array{Float64,5}    # (nw, nw, nmodes, nk, nkq)
     ωq::Array{Float64,5}
@@ -430,10 +430,10 @@ function ElectronPhonon.run_calculator!(c::_RecordCalc, p::ElectronPhonon.EPData
     c
 end
 
-# Device-native counterpart of `_RecordCalc`: opts into the batched payload so the GPU loop keeps
-# the e-ph matrix on the device and calls `run_calculator!(::EPDataQBatched, ctx)` once per
+# Batched counterpart of `_RecordCalc`: opts into the batched payload so the loop keeps
+# the e-ph matrix on the backend and calls `run_calculator!(::EPDataQBatched, ctx)` once per
 # (k, batch). It records the same `g2 = |ep|²/2ω` and ωq as `_RecordCalc`, exercising the loop's
-# device-native branch (supports(EPDataQBatched), ωq/ikqs staging, on-device g2) without MigdalEliashberg.
+# batched branch (supports(EPDataQBatched), ωq/ikqs staging, backend-resident g2) without MigdalEliashberg.
 mutable struct _RecordCalcBatched <: ElectronPhonon.AbstractCalculator
     g2::Array{Float64,5}
     ωq::Array{Float64,5}
@@ -441,9 +441,9 @@ mutable struct _RecordCalcBatched <: ElectronPhonon.AbstractCalculator
 end
 ElectronPhonon.supports(::_RecordCalcBatched, ::Type{ElectronPhonon.OuterKLoop}) = true
 ElectronPhonon.supports(::_RecordCalcBatched, ::Type{ElectronPhonon.EPDataQBatched}) = true
-# Device-native (GPU outer-k): that loop fires only the per-batch OuterIterationBatch bracket
+# Batched (outer-k): that loop fires only the per-batch OuterIterationBatch bracket
 # (BatchedMode); this calculator needs nothing there, so define an explicit no-op. The
-# `OuterIteration` no-ops keep it usable under the CPU outer-k loop too, which does fire them.
+# `OuterIteration` no-ops keep it usable under the per-point outer-k loop too, which does fire them.
 ElectronPhonon.calculator_begin!(::_RecordCalcBatched, ::ElectronPhonon.OuterIteration, ctx) = nothing
 ElectronPhonon.calculator_end!(::_RecordCalcBatched, ::ElectronPhonon.OuterIteration, ctx) = nothing
 ElectronPhonon.calculator_begin!(::_RecordCalcBatched, ::ElectronPhonon.OuterIterationBatch, ctx) = nothing
@@ -455,7 +455,7 @@ function ElectronPhonon.setup_calculator!(c::_RecordCalcBatched, kpts, qpts, el_
     c
 end
 ElectronPhonon.postprocess_calculator!(c::_RecordCalcBatched; kwargs...) = c
-# Computes g2 from `eps` itself (independent check of the fused-kernel matrix output). The GPU
+# Computes g2 from `eps` itself (independent check of the fused-kernel matrix output). The batched
 # loop also folds g2 into the kRkq kernel and carries it in the payload; assert it matches the
 # abs2/(2ω) recomputation — this guards the production g2 output in-package.
 function ElectronPhonon.run_calculator!(c::_RecordCalcBatched, p::ElectronPhonon.EPDataQBatched, ctx)
@@ -474,14 +474,14 @@ function ElectronPhonon.run_calculator!(c::_RecordCalcBatched, p::ElectronPhonon
     c
 end
 
-@testset "GPU calculator loop (run_eph_over_k_and_kq use_gpu)" begin
+@testset "batched calculator loop (run_eph_over_k_and_kq)" begin
     if !GPU_AVAILABLE
         @info "CUDA not available/functional — skipping GPU calculator-loop test"
     else
         model = _load_model_from_artifacts("pb"; epmat_outer_momentum="el")
         grid = (4, 4, 4)
 
-        # NOTE on CPU-vs-GPU comparison: with use_gpu=true the SETUP eigensolve also runs on the
+        # NOTE on CPU-vs-GPU comparison: on a GPU backend the SETUP eigensolve also runs on the
         # device (batched), which does NOT apply the EPW degeneracy gauge-fixing of the per-k CPU
         # path. So for degenerate bands/modes the GPU e-ph matrix / g2 differs from CPU by a gauge
         # (a unitary rotation within each degenerate subspace) — physically equivalent, but not
@@ -500,7 +500,8 @@ end
         # above validates ep_kq itself — so the device g2 output is covered without a host path.
         cg = _RecordCalcBatched()
         ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
-            calculators=[cg], symmetry=nothing, use_gpu=true, progress_print_step=10^9)
+            calculators=[cg], symmetry=nothing, backend=ElectronPhonon.gpu_backend(),
+            progress_print_step=10^9)
 
         scale = maximum(abs, cg.g2)
         # Phonon frequencies are gauge-independent → must match the CPU path (eigenvalue precision).
@@ -510,7 +511,8 @@ end
         # batch) must reproduce the single-batch GPU result exactly.
         cg7 = _RecordCalcBatched()
         ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
-            calculators=[cg7], symmetry=nothing, use_gpu=true, nq_batch_max=7, progress_print_step=10^9)
+            calculators=[cg7], symmetry=nothing, backend=ElectronPhonon.gpu_backend(),
+            nq_batch_max=7, progress_print_step=10^9)
         @test maximum(abs, cg.g2 .- cg7.g2) < 1e-9 * scale
         @test cg.ωq == cg7.ωq
 
@@ -518,7 +520,7 @@ end
         # together with a partial q-batch.
         cbk = _RecordCalcBatched()
         ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
-            calculators=[cbk], symmetry=nothing, use_gpu=true,
+            calculators=[cbk], symmetry=nothing, backend=ElectronPhonon.gpu_backend(),
             nk_outer_batch_max=5, nq_batch_max=7, progress_print_step=10^9)
         @test maximum(abs, cg.g2 .- cbk.g2) < 1e-9 * scale
 
@@ -527,24 +529,60 @@ end
         # factor the loop is built around drops to 1.
         cb1 = _RecordCalcBatched()
         ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
-            calculators=[cb1], symmetry=nothing, use_gpu=true,
+            calculators=[cb1], symmetry=nothing, backend=ElectronPhonon.gpu_backend(),
             nk_outer_batch_max=1, progress_print_step=10^9)
         @test maximum(abs, cg.g2 .- cb1.g2) < 1e-9 * scale
 
-        # Fully-GPU policy: a non-batched calculator (does not support EPDataQBatched) must be
-        # rejected, not silently run on the host path.
+        # Fully-batched policy: a non-batched calculator (does not support EPDataQBatched) must be
+        # rejected, not silently run on the per-point path.
         @test_throws Exception ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
-            calculators=[_RecordCalc()], symmetry=nothing, use_gpu=true, progress_print_step=10^9)
+            calculators=[_RecordCalc()], symmetry=nothing, backend=ElectronPhonon.gpu_backend(),
+            progress_print_step=10^9)
 
-        # Scope guards: the GPU path must reject out-of-scope options it does not implement (use a
-        # batched calculator so the rejection is the scope guard, not the fully-GPU policy above).
+        # Scope guards: the batched path must reject out-of-scope options it does not implement (use a
+        # batched calculator so the rejection is the scope guard, not the fully-batched policy above).
         @test_throws Exception ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
-            calculators=[_RecordCalcBatched()], symmetry=nothing, use_gpu=true,
+            calculators=[_RecordCalcBatched()], symmetry=nothing, backend=ElectronPhonon.gpu_backend(),
             covariant_derivative_of_g=true, progress_print_step=10^9)
         @test_throws Exception ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
-            calculators=[_RecordCalcBatched()], symmetry=nothing, use_gpu=true,
+            calculators=[_RecordCalcBatched()], symmetry=nothing, backend=ElectronPhonon.gpu_backend(),
             energy_conservation=(:Fixed, 0.1), progress_print_step=10^9)
+
+        # An EXPLICIT `batched = false` on a GPU backend is an ArgumentError, not a silent override:
+        # the per-(k,q) host payload cannot be built from device arrays.
+        @test_throws ArgumentError ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
+            calculators=[_RecordCalcBatched()], symmetry=nothing,
+            backend=ElectronPhonon.gpu_backend(), batched=false, progress_print_step=10^9)
     end
+end
+
+# The batched outer-k loop holds no device-specific code, so it also runs on a `CPUBackend`
+# (`batched = true`) — a validation configuration that needs no CUDA. Same mock as above: the
+# per-point and batched arms must record the same g2/ωq on the same grid. This is the CUDA-free
+# coverage of the batched payload construction, the k+q-convention phase build and the q-tiling.
+@testset "outer-k CPU+batched == CPU+per-point (_RecordCalc)" begin
+    model = _load_model_from_artifacts("pb"; epmat_outer_momentum="el")
+    grid = (4, 4, 4)
+
+    cpt = _RecordCalc()
+    ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
+        calculators=[cpt], symmetry=nothing, progress_print_step=10^9, verbosity=0)
+
+    # nq_batch_max below nkq forces multiple q-tiles (plan_batch returns the cap verbatim on CPU).
+    cba = _RecordCalcBatched()
+    ElectronPhonon.run_eph_over_k_and_kq(model, grid, grid;
+        calculators=[cba], symmetry=nothing, backend=ElectronPhonon.CPUBackend(), batched=true,
+        nq_batch_max=7, nk_outer_batch_max=5, progress_print_step=10^9, verbosity=0)
+
+    # Same backend and same eigensolve on both arms (the CPU per-k LAPACK path with EPW degeneracy
+    # gauge-fixing), so unlike the CPU-vs-GPU comparison above there is no gauge difference here and
+    # g2 itself can be compared — only batched-GEMM reassociation separates them.
+    scale = maximum(abs, cpt.g2)
+    @test scale > 0
+    @test maximum(abs, cpt.g2 .- cba.g2) < 1e-10 * scale
+    @test cpt.ωq == cba.ωq
+    @info "outer-k CPU+batched vs CPU+per-point (Pb 4³)" g2_reldev =
+        maximum(abs, cpt.g2 .- cba.g2) / scale
 end
 
 # Outer-q analogue of `_RecordCalc`/`_RecordCalcBatched` above: a calculator for
@@ -615,7 +653,7 @@ function ElectronPhonon.run_calculator!(c::_RecordCalcOuterQ, p::ElectronPhonon.
     c
 end
 
-@testset "run_eph_over_q_and_k CPU vs GPU equivalence" begin
+@testset "run_eph_over_q_and_k per-point vs GPU-batched equivalence" begin
     if !GPU_AVAILABLE
         @info "CUDA not available/functional — skipping run_eph_over_q_and_k CPU-vs-GPU test"
     else
@@ -625,17 +663,48 @@ end
         calc_cpu = _RecordCalcOuterQ()
         ElectronPhonon.run_eph_over_q_and_k(model, grid, grid;
             calculators=[calc_cpu], use_symmetry=false, keep_all_qpts=true,
-            use_gpu=false, progress_print_step=10^9)
+            progress_print_step=10^9)
 
         calc_gpu = _RecordCalcOuterQ()
         ElectronPhonon.run_eph_over_q_and_k(model, grid, grid;
             calculators=[calc_gpu], use_symmetry=false, keep_all_qpts=true,
-            use_gpu=true, progress_print_step=10^9)
+            backend=ElectronPhonon.gpu_backend(), progress_print_step=10^9)
 
         rdiff = maximum(abs, calc_cpu.A .- calc_gpu.A) / maximum(abs, calc_cpu.A)
         @info "run_eph_over_q_and_k CPU vs GPU" cpu_A=calc_cpu.A gpu_A=calc_gpu.A rdiff
         @test isapprox(calc_cpu.A, calc_gpu.A; rtol=1e-8)
+
+        # Explicit `batched = false` on a GPU backend: rejected at the driver entry (outer-q too).
+        @test_throws ArgumentError ElectronPhonon.run_eph_over_q_and_k(model, grid, grid;
+            calculators=[_RecordCalcOuterQ()], use_symmetry=false, keep_all_qpts=true,
+            backend=ElectronPhonon.gpu_backend(), batched=false, progress_print_step=10^9)
     end
+end
+
+# D8: the outer-q batched loop has no CUDA-only callee either, so it runs on a `CPUBackend` as well.
+# This is the ONLY in-repo coverage of the `EPDataKBatched` payload that does not need a GPU (it has no
+# in-repo production consumer at all). `_RecordCalcOuterQ` already declares both payloads and branches
+# its per-q bracket on `ctx.mode isa BatchedMode`, so the same mock serves both arms.
+@testset "run_eph_over_q_and_k CPU+batched == CPU+per-point (D8)" begin
+    model = _load_model_from_artifacts("pb"; epmat_outer_momentum = "ph")
+    grid = (4, 4, 4)
+
+    calc_pt = _RecordCalcOuterQ()
+    ElectronPhonon.run_eph_over_q_and_k(model, grid, grid;
+        calculators=[calc_pt], use_symmetry=false, keep_all_qpts=true,
+        progress_print_step=10^9, verbosity=0)
+
+    # nk_batch_max below nk forces a partial final k-batch, so the payload's width-nk trim is real.
+    calc_ba = _RecordCalcOuterQ()
+    ElectronPhonon.run_eph_over_q_and_k(model, grid, grid;
+        calculators=[calc_ba], use_symmetry=false, keep_all_qpts=true,
+        backend=ElectronPhonon.CPUBackend(), batched=true, nk_batch_max=10,
+        progress_print_step=10^9, verbosity=0)
+
+    @test maximum(abs, calc_pt.A) > 0
+    rdiff = maximum(abs, calc_pt.A .- calc_ba.A) / maximum(abs, calc_pt.A)
+    @info "run_eph_over_q_and_k CPU+batched vs CPU+per-point (Pb 4³)" rdiff
+    @test isapprox(calc_pt.A, calc_ba.A; rtol=1e-10)
 end
 
 # F4: force a PARTIAL outer-q k-batch (small nk_batch_max) so the DECISION-9 payload trim is a real
@@ -651,12 +720,12 @@ end
         calc_cpu = _RecordCalcOuterQ()
         ElectronPhonon.run_eph_over_q_and_k(model, grid, grid;
             calculators=[calc_cpu], use_symmetry=false, keep_all_qpts=true,
-            use_gpu=false, progress_print_step=10^9)
+            progress_print_step=10^9)
 
         calc_gpu = _RecordCalcOuterQ()
         ElectronPhonon.run_eph_over_q_and_k(model, grid, grid;
             calculators=[calc_gpu], use_symmetry=false, keep_all_qpts=true,
-            use_gpu=true, nk_batch_max=10, progress_print_step=10^9)
+            backend=ElectronPhonon.gpu_backend(), nk_batch_max=10, progress_print_step=10^9)
 
         rdiff = maximum(abs, calc_cpu.A .- calc_gpu.A) / maximum(abs, calc_cpu.A)
         @info "run_eph_over_q_and_k partial k-batch (nk_batch_max=10) CPU vs GPU" rdiff
@@ -664,7 +733,7 @@ end
     end
 end
 
-@testset "GPU filter_kpoints with symmetry (IBZ reduction × use_gpu)" begin
+@testset "GPU filter_kpoints with symmetry (IBZ reduction × backend)" begin
     if !GPU_AVAILABLE
         @info "CUDA not available/functional — skipping GPU filter_kpoints symmetry test"
     else
@@ -672,18 +741,18 @@ end
         # Fine-mesh Fermi level / 0.3 eV window, as in the anisotropic-ME (mp_mesh_k) pipeline.
         ef = 11.682221647 * ElectronPhonon.unit_to_aru(:eV)
         window = (ef - 0.3 * ElectronPhonon.unit_to_aru(:eV), ef + 0.3 * ElectronPhonon.unit_to_aru(:eV))
-        # In filter_kpoints, `symmetry` (IBZ reduction, in kpoints_grid) and `use_gpu` (batched
+        # In filter_kpoints, `symmetry` (IBZ reduction, in kpoints_grid) and `backend` (batched
         # eigensolve for the window test) are orthogonal: the IBZ k-set is built backend-independently,
-        # and use_gpu only changes how the band eigenvalues are computed. The window test is discrete
+        # and the backend only changes how the band eigenvalues are computed. The window test is discrete
         # (which bands fall inside), so it is robust to the ~1e-12 eigenvalue difference between the
         # cuSOLVER and CPU eigensolvers ⇒ identical ik_keep / band range / nelec_below, hence an
         # identical IBZ Kpoints object. (Eigenvectors / gauge are not involved here; cf. the g2
         # gauge caveat in the calculator-loop test above.)
         for nk in (12, 24)
             rsel = filter_electron_states((nk, nk, nk), model.nw, model.el_ham, window;
-                symmetry = model.symmetry, use_gpu = false)
+                symmetry = model.symmetry, backend = ElectronPhonon.CPUBackend())
             gsel = filter_electron_states((nk, nk, nk), model.nw, model.el_ham, window;
-                symmetry = model.symmetry, use_gpu = true)
+                symmetry = model.symmetry, backend = ElectronPhonon.gpu_backend())
             rk = rsel.kpts; gk = gsel.kpts
             @test gk.n == rk.n
             @test gk.ngrid == rk.ngrid
@@ -710,10 +779,11 @@ end
         # subspaces u_full differs by a (physically equivalent) unitary rotation — same caveat as the
         # velocity test below and the g2 gauge note in the calculator-loop test.
         kpts_ibz = filter_electron_states((24, 24, 24), model.nw, model.el_ham, window;
-            symmetry = model.symmetry, use_gpu = false).kpts
+            symmetry = model.symmetry).kpts
         qv = ["eigenvalue", "eigenvector", "velocity", "position"]
         els_c = ElectronPhonon.compute_electron_states(model, kpts_ibz, qv, window; fourier_mode="gridopt")
-        els_g = ElectronPhonon.compute_electron_states(model, kpts_ibz, qv, window; use_gpu=true)
+        els_g = ElectronPhonon.compute_electron_states(model, kpts_ibz, qv, window;
+            backend=ElectronPhonon.gpu_backend())
         @test length(els_g) == length(els_c) == kpts_ibz.n
         demax = maximum(maximum(abs, els_c[ik].e_full .- els_g[ik].e_full) for ik in 1:kpts_ibz.n)
         escale = maximum(maximum(abs, els_c[ik].e_full) for ik in 1:kpts_ibz.n)
@@ -722,7 +792,7 @@ end
     end
 end
 
-@testset "compute_electron_states velocity (use_gpu)" begin
+@testset "compute_electron_states velocity (GPU backend)" begin
     if !GPU_AVAILABLE
         @info "CUDA not available/functional — skipping GPU compute_electron_states velocity test"
     else
@@ -733,7 +803,8 @@ end
 
         qv = ["eigenvalue", "eigenvector", "velocity", "position"]
         els_c = ElectronPhonon.compute_electron_states(model, kpts, qv, (-Inf, Inf); fourier_mode="gridopt")
-        els_g = ElectronPhonon.compute_electron_states(model, kpts, qv, (-Inf, Inf); use_gpu=true)
+        els_g = ElectronPhonon.compute_electron_states(model, kpts, qv, (-Inf, Inf);
+            backend=ElectronPhonon.gpu_backend())
 
         # Eigenvalues are gauge-independent → must match the CPU path to eigenvalue precision.
         emax = maximum(maximum(abs, els_c[ik].e_full .- els_g[ik].e_full) for ik in 1:nk)
@@ -782,7 +853,8 @@ end
         # velocity_diagonal-only path: must equal the diagonal of the full-velocity result exactly,
         # and match CPU on non-degenerate bands.
         qd = ["eigenvalue", "eigenvector", "velocity_diagonal"]
-        els_gd = ElectronPhonon.compute_electron_states(model, kpts, qd, (-Inf, Inf); use_gpu=true)
+        els_gd = ElectronPhonon.compute_electron_states(model, kpts, qd, (-Inf, Inf);
+            backend=ElectronPhonon.gpu_backend())
         els_cd = ElectronPhonon.compute_electron_states(model, kpts, qd, (-Inf, Inf); fourier_mode="gridopt")
         ddiag = 0.0
         for ik in 1:nk, i in els_g[ik].rng
@@ -802,7 +874,7 @@ end
     end
 end
 
-@testset "compute_phonon_states velocity_diagonal (use_gpu)" begin
+@testset "compute_phonon_states velocity_diagonal (GPU backend)" begin
     if !GPU_AVAILABLE
         @info "CUDA not available/functional — skipping GPU compute_phonon_states velocity test"
     else
@@ -812,7 +884,8 @@ end
 
         qp = ["eigenvalue", "eigenvector", "velocity_diagonal"]
         pc = ElectronPhonon.compute_phonon_states(model, kpts, qp; fourier_mode="gridopt")
-        pg = ElectronPhonon.compute_phonon_states(model, kpts, qp; use_gpu=true)
+        pg = ElectronPhonon.compute_phonon_states(model, kpts, qp;
+            backend=ElectronPhonon.gpu_backend())
 
         # Phonon frequencies are gauge-independent → must match the CPU path.
         wm = maximum(maximum(abs, pc[ik].e .- pg[ik].e) for ik in 1:nk)

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -413,7 +413,7 @@ ElectronPhonon.supports(::_RecordCalc, ::Type{ElectronPhonon.EPData}) = true
 # Nothing per outer iteration; explicit no-op (there is no default bracket). CPU-only ⇒ SingleMode.
 ElectronPhonon.calculator_begin!(::_RecordCalc, ::ElectronPhonon.OuterIteration, ctx) = nothing
 ElectronPhonon.calculator_end!(::_RecordCalc, ::ElectronPhonon.OuterIteration, ctx) = nothing
-function ElectronPhonon.setup_calculator!(c::_RecordCalc, kpts, qpts, el_states;
+function ElectronPhonon.setup_calculator!(c::_RecordCalc, backend, mode, kpts, qpts, el_states;
         el_states_kq, kqpts, nw, nmodes, kwargs...)
     c.g2 = zeros(nw, nw, nmodes, kpts.n, kqpts.n)
     c.ωq = zeros(nw, nw, nmodes, kpts.n, kqpts.n)
@@ -448,7 +448,7 @@ ElectronPhonon.calculator_begin!(::_RecordCalcBatched, ::ElectronPhonon.OuterIte
 ElectronPhonon.calculator_end!(::_RecordCalcBatched, ::ElectronPhonon.OuterIteration, ctx) = nothing
 ElectronPhonon.calculator_begin!(::_RecordCalcBatched, ::ElectronPhonon.OuterIterationBatch, ctx) = nothing
 ElectronPhonon.calculator_end!(::_RecordCalcBatched, ::ElectronPhonon.OuterIterationBatch, ctx) = nothing
-function ElectronPhonon.setup_calculator!(c::_RecordCalcBatched, kpts, qpts, el_states;
+function ElectronPhonon.setup_calculator!(c::_RecordCalcBatched, backend, mode, kpts, qpts, el_states;
         el_states_kq, kqpts, nw, nmodes, kwargs...)
     c.g2 = zeros(nw, nw, nmodes, kpts.n, kqpts.n)
     c.ωq = zeros(nw, nw, nmodes, kpts.n, kqpts.n)
@@ -609,7 +609,7 @@ ElectronPhonon.supports(::_RecordCalcOuterQ, ::Type{ElectronPhonon.EPDataKBatche
 ElectronPhonon.allowed_eph_phonon_basis(::_RecordCalcOuterQ) = [:eigenmode]
 # Reads only the e-ph matrix (→ eigenvalues/eigenvectors); skips velocity/position.
 ElectronPhonon.required_el_k_quantities(::_RecordCalcOuterQ) = ["eigenvalue", "eigenvector"]
-function ElectronPhonon.setup_calculator!(c::_RecordCalcOuterQ, kpts, qpts, el_states;
+function ElectronPhonon.setup_calculator!(c::_RecordCalcOuterQ, backend, mode, kpts, qpts, el_states;
         nchunks_threads=nthreads(), kwargs...)
     c.A = zeros(qpts.n)
     c.Achunk = zeros(nchunks_threads)

--- a/test/test_iq_build.jl
+++ b/test/test_iq_build.jl
@@ -3,7 +3,7 @@ using ElectronPhonon
 using Random
 using ElectronPhonon: Vec3, _grid_coords_reduced, _wrap_reduced, _fill_iqs!
 
-# The per-(k, q-tile) `iq` index build of the GPU outer-k loop (`_loop_eph_over_k_and_kq_gpu`). The
+# The per-(k, q-tile) `iq` index build of the batched outer-k loop (`_loop_eph_over_k_and_kq_batched`). The
 # loop hashes integer grid coordinates instead of calling `xk_to_ik` per pair, so the whole
 # correctness story is "the fast hash agrees with `xk_to_ik`".
 # CPU-only: the build is host arithmetic and the loop it feeds is never reached on `CPUBackend`.

--- a/test/test_iq_build.jl
+++ b/test/test_iq_build.jl
@@ -6,7 +6,9 @@ using ElectronPhonon: Vec3, _grid_coords_reduced, _wrap_reduced, _fill_iqs!
 # The per-(k, q-tile) `iq` index build of the batched outer-k loop (`_loop_eph_over_k_and_kq_batched`). The
 # loop hashes integer grid coordinates instead of calling `xk_to_ik` per pair, so the whole
 # correctness story is "the fast hash agrees with `xk_to_ik`".
-# CPU-only: the build is host arithmetic and the loop it feeds is never reached on `CPUBackend`.
+# CPU-only because the build is pure host arithmetic — not because the loop it feeds is GPU-only: that
+# loop also runs on a `CPUBackend` (`batched = true`, the validation configuration), which is exercised
+# end-to-end elsewhere. This file tests the hash in isolation and needs no backend at all.
 
 # Everything the build needs, assembled the way the loop's prologue assembles it. The outer k mesh
 # is always unshifted — the loop's `xks_int` does not subtract a shift, so a shifted k would not


### PR DESCRIPTION
## Motivation

`use_gpu::Bool` conflated two independent things: **where arrays live** and **which payload
calculators receive**. The batched outer-k e-ph loop already described itself as backend-generic
("not because it holds any device-specific code"), but there was no route into it with a host
backend — so the `BoltzmannCalculator` batched path was only reachable with CUDA present.

Consequence: `test/boltzmann/test_gpu_boltzmann_calculator.jl` and
`test/boltzmann/test_multigrid_transport.jl` skipped their equivalence testsets without a GPU. In
MigdalEliashberg.jl's own environment (CUDA is only in its `[extras]`) they contributed ~28
meaningless passes. They now run anywhere, and a batched calculator can be validated against its own
per-point hook on a machine with no GPU.

This is a clarity/duplication change, **not** a performance change — nothing here is expected to get
faster.

## Change

Two kwargs at the driver entries, with `batched` derived from `backend` so production callers pass
one argument:

```julia
backend :: AbstractBackend      = CPUBackend()
batched :: Union{Nothing, Bool} = nothing   # nothing = derive from `backend`
```

| | `batched = nothing` (default) | `batched = true` | `batched = false` |
|---|---|---|---|
| `CPUBackend()` (default) | production CPU, per-(k,q) `EPData` | validation only: batched loop on host arrays | same as default |
| `GPUBackend(...)` | production GPU (was `use_gpu = true`) | same as default | `ArgumentError` |

An *explicit* `batched = false` on a GPU backend is an error rather than silently honoured or
silently overridden. CPU+batched is a **validation configuration** — serial, `mul!`-loop
`batched_gemm!` — and the per-point CPU path (`@threads`, gridopt Fourier, polar, screening,
energy conservation) remains the production CPU path.

**Exactly one new function.** An audit of both batched loops, both calculators, the state staging and
the tiling object found two names in `src/` with no host method: `gpu_backend` (the gate) and
`bte_window_accumulate!`. The latter gets a generic host method next to its declaration in
`src/boltzmann/boltzmann_calculator.jl`, folding the same `bte_scattering_increments` the CUDA kernel
folds — completing the generic + `CuArray` pairing that `eph_window_scatter!` already ships. No
physics changed anywhere in this PR.

Other notable edits:
- `BoltzmannCalculator.on_gpu` -> `.batched`; it no longer infers run shape from the backend.
- **`setup_calculator!` signature change:**
  `setup_calculator!(calc, backend::AbstractBackend, mode::LoopMode, kpts, qpts, el_states; kwargs...)`.
  `backend` was a kwarg and `mode` is new; both are positional so the break is loud at load time and
  both are dispatchable. A kwarg would have been absorbed silently by every `kwargs...`, letting a
  calculator keep gating device buffers on `backend isa GPUBackend` and build the wrong buffers under
  CPU+batched — the same bug this PR fixes in `BoltzmannCalculator`.
  Note for calculator authors: the erroring `AbstractCalculator` fallback leaves arguments 2-3
  *unannotated* on purpose. Annotating them `::AbstractBackend, ::LoopMode` makes it ambiguous with
  any calculator method that leaves them untyped (the subtype wins argument 1, the abstract types win
  2-3, neither is more specific) — a catch-all must not compete on arguments it does not dispatch on.
- `_loop_eph_over_k_and_kq_gpu` -> `_loop_eph_over_k_and_kq_batched` (+ outer-q), and the 7 error
  messages that said "GPU" where the constraint is about the batched path.
- Deleted the three out-of-band `gpu_backend()` constructions in `src/filter.jl` and
  `src/compute_states.jl`; the backend is now injectable there.
- `src/calculator/AbstractCalculator.jl`: the prose API enumeration is deleted in favour of the
  `public` declaration as the single list; `mode` documented with the rule *gate on `mode`, never on
  `backend isa GPUBackend`*.
- `TODO.md`: two factual errors corrected rather than implemented — `gpu_backend()` builds an
  **empty** prototype (it does not wrap `epmat_dev.op_r`), and the batched begin/end brackets were
  already mode-keyed, so the defect was the `on_gpu` flag.

**Breaking:** `use_gpu` is removed from the three e-ph drivers, `filter_electron_states`,
`filter_electron_states_multigrid`, `compute_electron_states`, `compute_phonon_states`. The
`estimate_device_memory` default meaning flips (was adaptive width, now the cap verbatim). Call sites
outside this repo — MigdalEliashberg.jl, `broadening/`, `superconductivity/`,
`downfolding/Sr2RuO4/gpu/` — are **not** updated here and are swept after merge.

## Test

Full suite **without** CUDA: **22508/22508** (3m05s, `CUDA.functional() = false`) at `f853ecf`.
Full suite **with** CUDA: **22618/22618** measured at `dcea433`; the three CUDA-guarded files re-run
green on an A100 at `74dcbb4` and again at `f853ecf`, with every deviation byte-identical.
The 112-test with/without delta is exactly the GPU-only arms (295 with CUDA vs 183 without across the
three guarded files) — they genuinely run rather than vanishing in both configurations.

Max relative deviation, Pb 6³, ±0.5 eV, in the shipped tiled configuration:

| pair | Sᵢ | Sₒ |
|---|---|---|
| CPU+per-point vs CPU+batched | **1.34e-15** | 6.11e-16 |
| CPU+per-point vs GPU+batched | 2.46e-13 | 1.84e-13 |

The number this PR is answerable for is the **1.34e-15** — pure summation order between the two host
paths. The 2.5e-13 CPU-vs-GPU gap is pre-existing (degeneracy gauge in the device setup eigensolve +
batched-GEMM reassociation), and is *not* the atomic fold: noise floor established separately, with
GPU Sᵢ **bitwise identical** across two runs and GPU Sₒ reproducible to 5.09e-16.

**What existing coverage missed.** The Sᵢ `TiledDeviceOutput` tile follows the **outer-k** axis
(`nk_outer_batch_max`, default 256), not the q axis (`nq_batch_max`). Every test grid is far below
256 — Pb 6³ keeps nk = 66, the multigrid selection nk = 6 — so `tile_begin!`/`tile_download!` always
fired once with `tile_offset == 0`, and no test in the repo exercised a nonzero tile offset. A bug
writing tiles at the wrong global offset would have passed everything. Both CPU+batched arms now cap
`nk_outer_batch_max` (4 tiles and 2 tiles) and assert their own precondition, so a future grid or
default change fails loudly instead of silently reverting to one tile. Sᵢ is bitwise identical at 1
tile vs 4 tiles.
